### PR TITLE
#2 Keyboard server

### DIFF
--- a/python/PiFinder/keyboard_local.py
+++ b/python/PiFinder/keyboard_local.py
@@ -1,11 +1,14 @@
 import time
 from PiFinder.keyboard_interface import KeyboardInterface
 import logging
-from PyHotKey import Key, keyboard_manager as manager
-
 
 class KeyboardLocal(KeyboardInterface):
     def __init__(self, q):
+        try:
+            from PyHotKey import Key, keyboard_manager as manager
+        except:
+            print("pyhotkey not supported on pi hardware")
+            return
         try:
             self.q = q
             manager.set_wetkey_on_release(Key.enter, self.callback, self.ENT)

--- a/python/PiFinder/keyboard_local.py
+++ b/python/PiFinder/keyboard_local.py
@@ -2,6 +2,7 @@ import time
 from PiFinder.keyboard_interface import KeyboardInterface
 import logging
 
+
 class KeyboardLocal(KeyboardInterface):
     def __init__(self, q):
         try:

--- a/python/PiFinder/keyboard_server.py
+++ b/python/PiFinder/keyboard_server.py
@@ -2,11 +2,12 @@ import time
 from PiFinder.keyboard_interface import KeyboardInterface
 import logging
 
-class KeyboardServer(KeyboardInterface):
 
+class KeyboardServer(KeyboardInterface):
     def __init__(self, q):
         from bottle import Bottle, run, request, template
-        self.q = q 
+
+        self.q = q
         button_dict = {
             "UP": self.UP,
             "DN": self.DN,
@@ -26,26 +27,25 @@ class KeyboardServer(KeyboardInterface):
             "LNG_B": self.LNG_B,
             "LNG_C": self.LNG_C,
             "LNG_D": self.LNG_D,
-            "LNG_ENT": self.LNG_ENT
+            "LNG_ENT": self.LNG_ENT,
         }
- 
+
         app = Bottle()
 
-        @app.route('/')
+        @app.route("/")
         def home():
-            return template('index')
+            return template("index")
 
-        @app.route('/callback', method='POST')
+        @app.route("/callback", method="POST")
         def callback():
-            button = request.json.get('button')
+            button = request.json.get("button")
             if button in button_dict:
                 self.callback(button_dict[button])
             else:
                 self.callback(int(button))
             return {"message": "success"}
 
-        run(app, host='0.0.0.0', port=8080)
-
+        run(app, host="0.0.0.0", port=8080)
 
     def callback(self, key):
         self.q.put(key)

--- a/python/PiFinder/keyboard_server.py
+++ b/python/PiFinder/keyboard_server.py
@@ -1,0 +1,55 @@
+import time
+from PiFinder.keyboard_interface import KeyboardInterface
+import logging
+
+class KeyboardServer(KeyboardInterface):
+
+    def __init__(self, q):
+        from bottle import Bottle, run, request, template
+        self.q = q 
+        button_dict = {
+            "UP": self.UP,
+            "DN": self.DN,
+            "ENT": self.ENT,
+            "A": self.A,
+            "B": self.B,
+            "C": self.C,
+            "D": self.D,
+            "ALT_UP": self.ALT_UP,
+            "ALT_DN": self.ALT_DN,
+            "ALT_A": self.ALT_A,
+            "ALT_B": self.ALT_B,
+            "ALT_C": self.ALT_C,
+            "ALT_D": self.ALT_D,
+            "ALT_0": self.ALT_0,
+            "LNG_A": self.LNG_A,
+            "LNG_B": self.LNG_B,
+            "LNG_C": self.LNG_C,
+            "LNG_D": self.LNG_D,
+            "LNG_ENT": self.LNG_ENT
+        }
+ 
+        app = Bottle()
+
+        @app.route('/')
+        def home():
+            return template('index')
+
+        @app.route('/callback', method='POST')
+        def callback():
+            button = request.json.get('button')
+            if button in button_dict:
+                self.callback(button_dict[button])
+            else:
+                self.callback(int(button))
+            return {"message": "success"}
+
+        run(app, host='0.0.0.0', port=8080)
+
+
+    def callback(self, key):
+        self.q.put(key)
+
+
+def run_keyboard(q, script_path=None):
+    keyboard = KeyboardServer(q)

--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -681,19 +681,19 @@ if __name__ == "__main__":
         from PiFinder import keyboard_pi as keyboard
         from PiFinder import gps_pi as gps_monitor
 
-    if args.camera.lower() == 'pi':
+    if args.camera.lower() == "pi":
         logging.debug("using pi camera")
         from PiFinder import camera_pi as camera
-    elif args.camera.lower() == 'debug':
+    elif args.camera.lower() == "debug":
         logging.debug("using debug camera")
         from PiFinder import camera_debug as camera
     else:
         logging.debug("using asi camera")
         from PiFinder import camera_asi as camera
 
-    if args.keyboard.lower() == 'pi':
+    if args.keyboard.lower() == "pi":
         from PiFinder import keyboard_pi as keyboard
-    elif args.keyboard.lower() == 'local':
+    elif args.keyboard.lower() == "local":
         from PiFinder import keyboard_local as keyboard
     else:
         from PiFinder import keyboard_server as keyboard

--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -618,6 +618,7 @@ if __name__ == "__main__":
     print("starting main")
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
+    logging.getLogger("PIL.PngImagePlugin").setLevel(logging.WARNING)
     logging.basicConfig(format="%(asctime)s %(name)s: %(levelname)s %(message)s")
     parser = argparse.ArgumentParser(description="eFinder")
     parser.add_argument(
@@ -632,6 +633,13 @@ if __name__ == "__main__":
         "-c",
         "--camera",
         help="Specify which camera to use: pi, asi or debug",
+        default="pi",
+        required=False,
+    )
+    parser.add_argument(
+        "-k",
+        "--keyboard",
+        help="Specify which keyboard to use: pi, local or server",
         default="pi",
         required=False,
     )
@@ -665,15 +673,30 @@ if __name__ == "__main__":
         hardware_platform = "Fake"
         from PiFinder import imu_fake as imu
         from PiFinder import keyboard_local as keyboard
-        from PiFinder import camera_debug as camera
         from PiFinder import gps_fake as gps_monitor
     else:
         hardware_platform = "Pi"
         from rpi_hardware_pwm import HardwarePWM
         from PiFinder import imu_pi as imu
         from PiFinder import keyboard_pi as keyboard
-        from PiFinder import camera_pi as camera
         from PiFinder import gps_pi as gps_monitor
+
+    if args.camera.lower() == 'pi':
+        logging.debug("using pi camera")
+        from PiFinder import camera_pi as camera
+    elif args.camera.lower() == 'debug':
+        logging.debug("using debug camera")
+        from PiFinder import camera_debug as camera
+    else:
+        logging.debug("using asi camera")
+        from PiFinder import camera_asi as camera
+
+    if args.keyboard.lower() == 'pi':
+        from PiFinder import keyboard_pi as keyboard
+    elif args.keyboard.lower() == 'local':
+        from PiFinder import keyboard_local as keyboard
+    else:
+        from PiFinder import keyboard_server as keyboard
 
     if args.log:
         datenow = datetime.now()

--- a/python/index.tpl
+++ b/python/index.tpl
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <div id="numpad" style="display: flex; justify-content: space-between;">
+        <div style="display: flex; flex-direction: column;">
+            <button onclick="buttonClicked(this, 'A')">A</button>
+            <button onclick="buttonClicked(this, 'B')">B</button>
+            <button onclick="buttonClicked(this, 'C')">C</button>
+            <button onclick="buttonClicked(this, 'D')">D</button>
+        </div>
+        <div style="display: grid; grid-template-columns: repeat(3, 1fr); margin: 0 20px;">
+            <button onclick="buttonClicked(this, '1')">1</button>
+            <button onclick="buttonClicked(this, '2')">2</button>
+            <button onclick="buttonClicked(this, '3')">3</button>
+            <button onclick="buttonClicked(this, '4')">4</button>
+            <button onclick="buttonClicked(this, '5')">5</button>
+            <button onclick="buttonClicked(this, '6')">6</button>
+            <button onclick="buttonClicked(this, '7')">7</button>
+            <button onclick="buttonClicked(this, '8')">8</button>
+            <button onclick="buttonClicked(this, '9')">9</button>
+            <button onclick="buttonClicked(this, '0')" style="grid-column: span 3;">0</button>
+        </div>
+        <div style="display: flex; flex-direction: column;">
+            <button onclick="buttonClicked(this, 'UP')">Up</button>
+            <button onclick="buttonClicked(this, 'ENT')">Enter</button>
+            <button onclick="buttonClicked(this, 'DN')">Down</button>
+        </div>
+    </div>
+    <div style="margin-top: 20px;">
+        <button id="altButton" onclick="buttonPressed(this)">Alt</button>
+        <button id="longButton" onclick="buttonPressed(this)">Long</button>
+    </div>
+<script>
+        function buttonPressed(btn) {
+            const altButton = document.getElementById("altButton");
+            const longButton = document.getElementById("longButton");
+
+            // If the other button is pressed, unpress it
+            if (btn === altButton && longButton.classList.contains('pressed')) {
+                longButton.classList.remove('pressed');
+            } else if (btn === longButton && altButton.classList.contains('pressed')) {
+                altButton.classList.remove('pressed');
+            }
+
+            // If this button is already pressed, unpress it; otherwise, press it
+            if (btn.classList.contains('pressed')) {
+                btn.classList.remove('pressed');
+            } else {
+                btn.classList.add('pressed');
+            }
+        }
+
+        function buttonClicked(btn, code) {
+            const button = btn.innerHTML;
+            const altButton = document.getElementById("altButton");
+            const longButton = document.getElementById("longButton");
+
+            if (altButton.classList.contains('pressed')) {
+                code = `ALT_${code}`;
+                altButton.classList.remove('pressed');
+            } else if (longButton.classList.contains('pressed')) {
+                code = `LNG_${code}`;
+                longButton.classList.remove('pressed');
+            }
+
+            fetch('/callback', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ button: code }),
+            })
+            .then(response => response.json())
+            .then(data => console.log(data))
+            .catch((error) => {
+                console.error('Error:', error);
+            });
+        }
+    </script>
+
+    <style>
+        .pressed {
+            background-color: #008CBA; /* Blue */
+            color: white;
+        }
+    </style>
+</body>
+</html>
+

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 # dev requirements
 luma.emulator==1.4.0
 PyHotKey
+bottle


### PR DESCRIPTION
* added a keyboard server, which serves a basic webpage representing the pifinders' button interface. Supports 'alt' and 'long' modifiers. This adds the simple 'bottle' dependency for serving the website, looked into socket but didn't seem the best fit, too much code.
* small fix to keyboard_local so that it warns the user that it doesn't work on the pi. I haven't removed it because it's great that this just works on mac (and probably win/linux but haven't tested)
* reduced PIL logging in debug mode, because it swamps the logs
* extracted camera and keyboard from the fake hardware switch, because ultimately for testing you can have a working keyboard but no camera, everything but the imu, etc.

See [example](https://discord.com/channels/1087556380724052059/1092219845954781274/1114651183018152116)

Long term I might try to include the screen into the webpage so it can be run completely headless