### PR TITLE
#1 make POSS/SDSS Fov prettier

### DIFF
--- a/python/PiFinder/cat_images.py
+++ b/python/PiFinder/cat_images.py
@@ -4,8 +4,6 @@
 This module is used at runtime
 to handle catalog image loading
 """
-from queue import Queue
-import requests
 import sqlite3
 import os
 from PIL import Image, ImageChops, ImageDraw
@@ -131,7 +129,7 @@ def get_display_image(catalog_object, source, fov, roll, colors):
 def shadow_outline_text(
     ri_draw, xy, text, align, font, fill, shadow_color, shadow=None, outline=None
 ):
-    """ draw shadowed and outlined text """
+    """draw shadowed and outlined text"""
     x, y = xy
     if shadow:
         ri_draw.text(
@@ -156,7 +154,7 @@ def shadow_outline_text(
 
 
 def outline_text(ri_draw, xy, text, align, font, fill, shadow_color, stroke=4):
-    """ draw outline text """
+    """draw outline text"""
     x, y = xy
     ri_draw.text(
         xy,

--- a/python/PiFinder/cat_images.py
+++ b/python/PiFinder/cat_images.py
@@ -4,6 +4,7 @@
 This module is used at runtime
 to handle catalog image loading
 """
+from queue import Queue
 import requests
 import sqlite3
 import os
@@ -101,14 +102,83 @@ def get_display_image(catalog_object, source, fov, roll, colors):
         ri_draw = ImageDraw.Draw(return_image)
         ri_draw.ellipse([2, 2, 126, 126], outline=colors.get(64), width=1)
 
-    # Burn In
-    ri_draw.rectangle([0, 108, 30, 128], fill=colors.get(0))
-    ri_draw.text((1, 110), source, font=fonts.base, fill=colors.get(128))
+        # Burn In
+        # ri_draw.rectangle([0, 108, 30, 128], fill=colors.get(0))
+        # ri_draw.text((1, 110), source, font=fonts.base, fill=colors.get(128))
+        shadow2(
+            ri_draw,
+            (1, 110),
+            source,
+            font=fonts.base,
+            align="left",
+            fill=colors.get(128),
+            shadow_color=colors.get(0),
+            shadow=(1, 1),
+        )
 
-    ri_draw.rectangle([98, 108, 128, 128], fill=colors.get(0))
-    ri_draw.text((100, 110), f"{fov:0.2f}", font=fonts.base, fill=colors.get(128))
+        # ri_draw.rectangle([98, 108, 128, 128], fill=colors.get(0))
+        # ri_draw.text((90, 110), f"{fov:0.2f}° ", align='left', font=fonts.base, fill=colors.get(128))
+        shadow2(
+            ri_draw,
+            (98, 110),
+            f"{fov:0.2f}°",
+            align="right",
+            font=fonts.base,
+            fill=colors.get(254),
+            shadow_color=colors.get(0),
+            outline=2,
+        )
 
     return return_image
+
+
+def shadow2(
+    ri_draw, xy, text, align, font, fill, shadow_color, shadow=None, outline=None
+):
+    x, y = xy
+    if shadow:
+        ri_draw.text(
+            (x + shadow[0], y + shadow[1]),
+            text,
+            align=align,
+            font=font,
+            fill=shadow_color,
+        )
+
+    if outline:
+        outline_text(
+            ri_draw,
+            xy,
+            text,
+            align=align,
+            font=font,
+            fill=fill,
+            shadow_color=shadow_color,
+            stroke=2,
+        )
+
+
+def outline_text(ri_draw, xy, text, align, font, fill, shadow_color, stroke=4):
+    x, y = xy
+    ri_draw.text(
+        xy,
+        text,
+        align=align,
+        font=font,
+        fill=fill,
+        stroke_width=stroke,
+        stroke_fill=shadow_color,
+    )
+
+
+def shadow(ri_draw, xy, text, align, font, fill, shadowcolor):
+    x, y = xy
+    # thin border
+    ri_draw.text((x - 1, y), text, align=align, font=font, fill=shadowcolor)
+    ri_draw.text((x + 1, y), text, align=align, font=font, fill=shadowcolor)
+    ri_draw.text((x, y - 1), text, align=align, font=font, fill=shadowcolor)
+    ri_draw.text((x, y + 1), text, align=align, font=font, fill=shadowcolor)
+    ri_draw.text((x, y), text, align=align, font=font, fill=fill)
 
 
 def resolve_image_name(catalog_object, source):

--- a/python/PiFinder/cat_images.py
+++ b/python/PiFinder/cat_images.py
@@ -102,10 +102,8 @@ def get_display_image(catalog_object, source, fov, roll, colors):
         ri_draw = ImageDraw.Draw(return_image)
         ri_draw.ellipse([2, 2, 126, 126], outline=colors.get(64), width=1)
 
-        # Burn In
-        # ri_draw.rectangle([0, 108, 30, 128], fill=colors.get(0))
-        # ri_draw.text((1, 110), source, font=fonts.base, fill=colors.get(128))
-        shadow2(
+        # Outlined text on image source and fov
+        shadow_outline_text(
             ri_draw,
             (1, 110),
             source,
@@ -116,9 +114,7 @@ def get_display_image(catalog_object, source, fov, roll, colors):
             shadow=(1, 1),
         )
 
-        # ri_draw.rectangle([98, 108, 128, 128], fill=colors.get(0))
-        # ri_draw.text((90, 110), f"{fov:0.2f}° ", align='left', font=fonts.base, fill=colors.get(128))
-        shadow2(
+        shadow_outline_text(
             ri_draw,
             (98, 110),
             f"{fov:0.2f}°",
@@ -132,9 +128,10 @@ def get_display_image(catalog_object, source, fov, roll, colors):
     return return_image
 
 
-def shadow2(
+def shadow_outline_text(
     ri_draw, xy, text, align, font, fill, shadow_color, shadow=None, outline=None
 ):
+    """ draw shadowed and outlined text """
     x, y = xy
     if shadow:
         ri_draw.text(
@@ -159,6 +156,7 @@ def shadow2(
 
 
 def outline_text(ri_draw, xy, text, align, font, fill, shadow_color, stroke=4):
+    """ draw outline text """
     x, y = xy
     ri_draw.text(
         xy,


### PR DESCRIPTION

This is my proposal to make the image viewer a bit nicer by removing the black rectangles which provide contrast for the POSS / 1.0 text showing image catalog and fov. They are now replaced with outlined text. The fov has an added degree symbol and is full red to make it clearer to see (more important than the image catalog). In the image below, POSS has a shadow, the fov has an outline. Please adjust to taste.

<img width="261" alt="Screenshot 2023-06-06 at 12 49 53" src="https://github.com/brickbots/PiFinder/assets/1465310/ca57baac-178f-4a47-b116-6f6f97cfaae1">

Would it be an idea to convert < 1 degree into minutes using the " symbol? Not sure what's most helpful at the eyepiece. Maybe ultimately the eyepiece fl.

NOTE: should probably be merged before the other PR