### PR TITLE
#3 Keyboard server images

### DIFF
--- a/python/PiFinder/keyboard_local.py
+++ b/python/PiFinder/keyboard_local.py
@@ -1,11 +1,14 @@
 import time
 from PiFinder.keyboard_interface import KeyboardInterface
 import logging
-from PyHotKey import Key, keyboard_manager as manager
-
 
 class KeyboardLocal(KeyboardInterface):
     def __init__(self, q):
+        try:
+            from PyHotKey import Key, keyboard_manager as manager
+        except:
+            print("pyhotkey not supported on pi hardware")
+            return
         try:
             self.q = q
             manager.set_wetkey_on_release(Key.enter, self.callback, self.ENT)

--- a/python/PiFinder/keyboard_local.py
+++ b/python/PiFinder/keyboard_local.py
@@ -2,6 +2,7 @@ import time
 from PiFinder.keyboard_interface import KeyboardInterface
 import logging
 
+
 class KeyboardLocal(KeyboardInterface):
     def __init__(self, q):
         try:
@@ -55,7 +56,7 @@ class KeyboardLocal(KeyboardInterface):
         self.q.put(key)
 
 
-def run_keyboard(q, script_path=None):
+def run_keyboard(q, shared_state, script_path=None):
     keyboard = KeyboardLocal(q)
     if script_path:
         keyboard.run_script(script_path)

--- a/python/PiFinder/keyboard_pi.py
+++ b/python/PiFinder/keyboard_pi.py
@@ -6,13 +6,13 @@ and adds keys to the provided queue
 
 """
 import sh
-import RPi.GPIO as GPIO
 from time import sleep
 from PiFinder.keyboard_interface import KeyboardInterface
 
 
 class KeyboardPi(KeyboardInterface):
     def __init__(self, q):
+        import RPi.GPIO as GPIO
         self.q = q
 
         self.cols = [16, 23, 26, 27]
@@ -90,7 +90,7 @@ class KeyboardPi(KeyboardInterface):
                 GPIO.setup(self.rows[i], GPIO.IN)
 
 
-def run_keyboard(q, script_path=None):
+def run_keyboard(q, shared_state, script_path=None):
     keyboard = KeyboardPi(q)
     if script_path:
         keyboard.run_script(script_path)

--- a/python/PiFinder/keyboard_server.py
+++ b/python/PiFinder/keyboard_server.py
@@ -1,0 +1,55 @@
+import time
+from PiFinder.keyboard_interface import KeyboardInterface
+import logging
+
+class KeyboardServer(KeyboardInterface):
+
+    def __init__(self, q):
+        from bottle import Bottle, run, request, template
+        self.q = q 
+        button_dict = {
+            "UP": self.UP,
+            "DN": self.DN,
+            "ENT": self.ENT,
+            "A": self.A,
+            "B": self.B,
+            "C": self.C,
+            "D": self.D,
+            "ALT_UP": self.ALT_UP,
+            "ALT_DN": self.ALT_DN,
+            "ALT_A": self.ALT_A,
+            "ALT_B": self.ALT_B,
+            "ALT_C": self.ALT_C,
+            "ALT_D": self.ALT_D,
+            "ALT_0": self.ALT_0,
+            "LNG_A": self.LNG_A,
+            "LNG_B": self.LNG_B,
+            "LNG_C": self.LNG_C,
+            "LNG_D": self.LNG_D,
+            "LNG_ENT": self.LNG_ENT
+        }
+ 
+        app = Bottle()
+
+        @app.route('/')
+        def home():
+            return template('index')
+
+        @app.route('/callback', method='POST')
+        def callback():
+            button = request.json.get('button')
+            if button in button_dict:
+                self.callback(button_dict[button])
+            else:
+                self.callback(int(button))
+            return {"message": "success"}
+
+        run(app, host='0.0.0.0', port=8080)
+
+
+    def callback(self, key):
+        self.q.put(key)
+
+
+def run_keyboard(q, script_path=None):
+    keyboard = KeyboardServer(q)

--- a/python/PiFinder/keyboard_server.py
+++ b/python/PiFinder/keyboard_server.py
@@ -8,7 +8,7 @@ class KeyboardServer(KeyboardInterface):
 
     def __init__(self, q, shared_state):
         from bottle import Bottle, run, request, template, response
-        self.q = q 
+        self.q = q
         self.shared_state = shared_state
         button_dict = {
             "UP": self.UP,
@@ -31,8 +31,8 @@ class KeyboardServer(KeyboardInterface):
             "LNG_D": self.LNG_D,
             "LNG_ENT": self.LNG_ENT
         }
- 
-        app = Bottle() 
+
+        app = Bottle()
 
         @app.route('/')
         def home():
@@ -51,7 +51,6 @@ class KeyboardServer(KeyboardInterface):
         def serve_pil_image():
             img = Image.new('RGB', (60, 30), color = (73, 109, 137))  # create an image using PIL
             img = self.shared_state.screen()
-            print(f"{img}, {type(img)}")
             response.content_type = 'image/png'  # adjust for your image format
 
             img_byte_arr = io.BytesIO()

--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -202,17 +202,6 @@ def main(script_name=None):
     console.update()
     time.sleep(2)
 
-    # multiprocessing.set_start_method('spawn')
-    # spawn keyboard service....
-    console.write("   Keyboard")
-    console.update()
-    script_path = None
-    if script_name:
-        script_path = os.path.join(root_dir, "scripts", script_name)
-    keyboard_process = Process(
-        target=keyboard.run_keyboard, args=(keyboard_queue, script_path)
-    )
-    keyboard_process.start()
 
     # spawn gps service....
     console.write("   GPS")
@@ -229,6 +218,18 @@ def main(script_name=None):
     with StateManager() as manager:
         shared_state = manager.SharedState()
         console.set_shared_state(shared_state)
+
+        # multiprocessing.set_start_method('spawn')
+        # spawn keyboard service....
+        console.write("   Keyboard")
+        console.update()
+        script_path = None
+        if script_name:
+            script_path = os.path.join(root_dir, "scripts", script_name)
+        keyboard_process = Process(
+            target=keyboard.run_keyboard, args=(keyboard_queue, shared_state, script_path)
+        )
+        keyboard_process.start()
 
         # Load last location, set lock to false
         tz_finder = TimezoneFinder()
@@ -381,7 +382,7 @@ def main(script_name=None):
                                     lat=location["lat"], lng=location["lon"]
                                 )
                                 cfg.set_option("last_location", location)
-                                console.write("GPS: Location")
+                                console.write(f'GPS: Location {location["lat"]} {location["lon"]} {location["altitude"]}')
                                 location["gps_lock"] = True
                             shared_state.set_location(location)
                     if gps_msg == "time":
@@ -673,7 +674,7 @@ if __name__ == "__main__":
         hardware_platform = "Fake"
         from PiFinder import imu_fake as imu
         from PiFinder import keyboard_local as keyboard
-        from PiFinder import gps_fake as gps_monitor
+        from PiFinder import gps_pi as gps_monitor
     else:
         hardware_platform = "Pi"
         from rpi_hardware_pwm import HardwarePWM

--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -618,6 +618,7 @@ if __name__ == "__main__":
     print("starting main")
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
+    logging.getLogger("PIL.PngImagePlugin").setLevel(logging.WARNING)
     logging.basicConfig(format="%(asctime)s %(name)s: %(levelname)s %(message)s")
     parser = argparse.ArgumentParser(description="eFinder")
     parser.add_argument(
@@ -632,6 +633,13 @@ if __name__ == "__main__":
         "-c",
         "--camera",
         help="Specify which camera to use: pi, asi or debug",
+        default="pi",
+        required=False,
+    )
+    parser.add_argument(
+        "-k",
+        "--keyboard",
+        help="Specify which keyboard to use: pi, local or server",
         default="pi",
         required=False,
     )
@@ -665,15 +673,30 @@ if __name__ == "__main__":
         hardware_platform = "Fake"
         from PiFinder import imu_fake as imu
         from PiFinder import keyboard_local as keyboard
-        from PiFinder import camera_debug as camera
         from PiFinder import gps_fake as gps_monitor
     else:
         hardware_platform = "Pi"
         from rpi_hardware_pwm import HardwarePWM
         from PiFinder import imu_pi as imu
         from PiFinder import keyboard_pi as keyboard
-        from PiFinder import camera_pi as camera
         from PiFinder import gps_pi as gps_monitor
+
+    if args.camera.lower() == 'pi':
+        logging.debug("using pi camera")
+        from PiFinder import camera_pi as camera
+    elif args.camera.lower() == 'debug':
+        logging.debug("using debug camera")
+        from PiFinder import camera_debug as camera
+    else:
+        logging.debug("using asi camera")
+        from PiFinder import camera_asi as camera
+
+    if args.keyboard.lower() == 'pi':
+        from PiFinder import keyboard_pi as keyboard
+    elif args.keyboard.lower() == 'local':
+        from PiFinder import keyboard_local as keyboard
+    else:
+        from PiFinder import keyboard_server as keyboard
 
     if args.log:
         datenow = datetime.now()

--- a/python/PiFinder/state.py
+++ b/python/PiFinder/state.py
@@ -20,6 +20,7 @@ class SharedStateObj:
         self.__datetime = None
         self.__datetime_time = None
         self.__target = None
+        self.__screen = None
 
     def power_state(self):
         return self.__power_state
@@ -96,3 +97,9 @@ class SharedStateObj:
             if diff > 60:
                 self.__datetime_time = time.time()
                 self.__datetime = dt
+    
+    def screen(self):
+        return self.__screen
+
+    def set_screen(self, v):
+        self.__screen = v

--- a/python/PiFinder/ui/base.py
+++ b/python/PiFinder/ui/base.py
@@ -184,7 +184,10 @@ class UIModule:
                 self.draw.rectangle([100, 2, 110, 14], fill=bg)
                 self.draw.text((102, 0), "G", font=self.font_bold, fill=fg)
 
-        self.display.display(self.screen.convert(self.display.mode))
+        screen_to_display = self.screen.convert(self.display.mode)
+        self.display.display(screen_to_display)
+        if self.shared_state:
+            self.shared_state.set_screen(screen_to_display)
 
         # We can return a UIModule class name to force a switch here
         tmp_return = self.switch_to

--- a/python/index.tpl
+++ b/python/index.tpl
@@ -3,15 +3,6 @@
 <body>
 <img id="image" src="/image" alt="Image served from Bottle server">
 
-<script>
-    setInterval(function() {
-        fetch('/image')
-            .then(response => response.json())
-            .then(data => {
-                document.getElementById('image').src = data.image;
-            });
-    }, 1000);
-</script>
 
     <div id="numpad" style="display: flex; justify-content: space-between;">
         <div style="display: flex; flex-direction: column;">
@@ -43,6 +34,11 @@
         <button id="longButton" onclick="buttonPressed(this)">Long</button>
     </div>
 <script>
+        setInterval(function() {
+               const imageElement = document.getElementById('image');
+               imageElement.src = "/image?t=" + new Date().getTime();
+        }, 1000);
+
         function buttonPressed(btn) {
             const altButton = document.getElementById("altButton");
             const longButton = document.getElementById("longButton");

--- a/python/index.tpl
+++ b/python/index.tpl
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <div id="numpad" style="display: flex; justify-content: space-between;">
+        <div style="display: flex; flex-direction: column;">
+            <button onclick="buttonClicked(this, 'A')">A</button>
+            <button onclick="buttonClicked(this, 'B')">B</button>
+            <button onclick="buttonClicked(this, 'C')">C</button>
+            <button onclick="buttonClicked(this, 'D')">D</button>
+        </div>
+        <div style="display: grid; grid-template-columns: repeat(3, 1fr); margin: 0 20px;">
+            <button onclick="buttonClicked(this, '1')">1</button>
+            <button onclick="buttonClicked(this, '2')">2</button>
+            <button onclick="buttonClicked(this, '3')">3</button>
+            <button onclick="buttonClicked(this, '4')">4</button>
+            <button onclick="buttonClicked(this, '5')">5</button>
+            <button onclick="buttonClicked(this, '6')">6</button>
+            <button onclick="buttonClicked(this, '7')">7</button>
+            <button onclick="buttonClicked(this, '8')">8</button>
+            <button onclick="buttonClicked(this, '9')">9</button>
+            <button onclick="buttonClicked(this, '0')" style="grid-column: span 3;">0</button>
+        </div>
+        <div style="display: flex; flex-direction: column;">
+            <button onclick="buttonClicked(this, 'UP')">Up</button>
+            <button onclick="buttonClicked(this, 'ENT')">Enter</button>
+            <button onclick="buttonClicked(this, 'DN')">Down</button>
+        </div>
+    </div>
+    <div style="margin-top: 20px;">
+        <button id="altButton" onclick="buttonPressed(this)">Alt</button>
+        <button id="longButton" onclick="buttonPressed(this)">Long</button>
+    </div>
+<script>
+        function buttonPressed(btn) {
+            const altButton = document.getElementById("altButton");
+            const longButton = document.getElementById("longButton");
+
+            // If the other button is pressed, unpress it
+            if (btn === altButton && longButton.classList.contains('pressed')) {
+                longButton.classList.remove('pressed');
+            } else if (btn === longButton && altButton.classList.contains('pressed')) {
+                altButton.classList.remove('pressed');
+            }
+
+            // If this button is already pressed, unpress it; otherwise, press it
+            if (btn.classList.contains('pressed')) {
+                btn.classList.remove('pressed');
+            } else {
+                btn.classList.add('pressed');
+            }
+        }
+
+        function buttonClicked(btn, code) {
+            const button = btn.innerHTML;
+            const altButton = document.getElementById("altButton");
+            const longButton = document.getElementById("longButton");
+
+            if (altButton.classList.contains('pressed')) {
+                code = `ALT_${code}`;
+                altButton.classList.remove('pressed');
+            } else if (longButton.classList.contains('pressed')) {
+                code = `LNG_${code}`;
+                longButton.classList.remove('pressed');
+            }
+
+            fetch('/callback', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ button: code }),
+            })
+            .then(response => response.json())
+            .then(data => console.log(data))
+            .catch((error) => {
+                console.error('Error:', error);
+            });
+        }
+    </script>
+
+    <style>
+        .pressed {
+            background-color: #008CBA; /* Blue */
+            color: white;
+        }
+    </style>
+</body>
+</html>
+

--- a/python/index.tpl
+++ b/python/index.tpl
@@ -25,8 +25,8 @@
         </div>
         <div style="display: flex; flex-direction: column;">
             <button onclick="buttonClicked(this, 'UP')">Up</button>
-            <button onclick="buttonClicked(this, 'ENT')">Enter</button>
             <button onclick="buttonClicked(this, 'DN')">Down</button>
+            <button onclick="buttonClicked(this, 'ENT')">Enter</button>
         </div>
     </div>
     <div style="margin-top: 20px;">

--- a/python/index.tpl
+++ b/python/index.tpl
@@ -1,6 +1,18 @@
 <!DOCTYPE html>
 <html>
 <body>
+<img id="image" src="/image" alt="Image served from Bottle server">
+
+<script>
+    setInterval(function() {
+        fetch('/image')
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById('image').src = data.image;
+            });
+    }, 1000);
+</script>
+
     <div id="numpad" style="display: flex; justify-content: space-between;">
         <div style="display: flex; flex-direction: column;">
             <button onclick="buttonClicked(this, 'A')">A</button>

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pandas==1.5.3
 pytz==2022.7.1
 requests==2.28.2
 rpi-hardware-pwm==0.1.4
-scipy==1.10.0
+scipy
 scikit-learn==1.2.2
 sh==1.14.3
 skyfield==1.45

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 # dev requirements
 luma.emulator==1.4.0
 PyHotKey
+bottle


### PR DESCRIPTION
updates screen image every second. Uses the same keyboard server as in #23  but extended with an /image endpoint. It passes the shared_state on creation of the keyboard, didn't see how to do it else besides running a second web server for the images.

This is handy to debug headless on the pi, but open to discuss other approaches.

<img width="722" alt="Screenshot 2023-06-07 at 00 59 53" src="https://github.com/brickbots/PiFinder/assets/1465310/a1ec6d1f-bf08-495e-8ee9-007d84610ba3">
