### PR TITLE
Pushing the B button crashes when a log is present

### DIFF
--- a/python/PiFinder/ui/catalog.py
+++ b/python/PiFinder/ui/catalog.py
@@ -303,7 +303,7 @@ class UICatalog(UIModule):
                 if len(logs) == 0:
                     self.texts["obs"] = self.SimpleTextLayout("No Logs")
                 else:
-                    self.texts["obs"] = self.DescTextLayout(f"Logged {len(logs)} times")
+                    self.texts["obs"] = self.descTextLayout(f"Logged {len(logs)} times")
         else:
             # Image stuff...
             if self.object_display_mode == DM_SDSS:

--- a/python/PiFinder/ui/catalog.py
+++ b/python/PiFinder/ui/catalog.py
@@ -303,7 +303,9 @@ class UICatalog(UIModule):
                 if len(logs) == 0:
                     self.texts["obs"] = self.SimpleTextLayout("No Logs")
                 else:
-                    self.texts["obs"] = self.descTextLayout(f"Logged {len(logs)} times")
+                    self.texts["obs"] = self.descTextLayout.set_text(
+                        f"Logged {len(logs)} times"
+                    )
         else:
             # Image stuff...
             if self.object_display_mode == DM_SDSS:


### PR DESCRIPTION
There was an incorrect variable name in an unfrequently used code path which crashed during field usage.