### PR TITLE
Flat Mount

### DIFF
--- a/python/PiFinder/imu_pi.py
+++ b/python/PiFinder/imu_pi.py
@@ -11,6 +11,8 @@ import adafruit_bno055
 
 from scipy.spatial.transform import Rotation
 
+from PiFinder import config
+
 QUEUE_LEN = 10
 MOVE_CHECK_LEN = 2
 
@@ -21,14 +23,25 @@ class Imu:
         self.sensor = adafruit_bno055.BNO055_I2C(i2c)
         # self.sensor.mode = adafruit_bno055.IMUPLUS_MODE
         self.sensor.mode = adafruit_bno055.NDOF_MODE
-        self.sensor.axis_remap = (
-            adafruit_bno055.AXIS_REMAP_Z,
-            adafruit_bno055.AXIS_REMAP_Y,
-            adafruit_bno055.AXIS_REMAP_X,
-            adafruit_bno055.AXIS_REMAP_POSITIVE,
-            adafruit_bno055.AXIS_REMAP_POSITIVE,
-            adafruit_bno055.AXIS_REMAP_POSITIVE,
-        )
+        cfg = config.Config()
+        if cfg.get_option("screen_direction") == "flat":
+            self.sensor.axis_remap = (
+                adafruit_bno055.AXIS_REMAP_Y,
+                adafruit_bno055.AXIS_REMAP_X,
+                adafruit_bno055.AXIS_REMAP_Z,
+                adafruit_bno055.AXIS_REMAP_POSITIVE,
+                adafruit_bno055.AXIS_REMAP_POSITIVE,
+                adafruit_bno055.AXIS_REMAP_NEGATIVE,
+            )
+        else:
+            self.sensor.axis_remap = (
+                adafruit_bno055.AXIS_REMAP_Z,
+                adafruit_bno055.AXIS_REMAP_Y,
+                adafruit_bno055.AXIS_REMAP_X,
+                adafruit_bno055.AXIS_REMAP_POSITIVE,
+                adafruit_bno055.AXIS_REMAP_POSITIVE,
+                adafruit_bno055.AXIS_REMAP_POSITIVE,
+            )
         self.quat_history = [(0, 0, 0, 0)] * QUEUE_LEN
         self.__moving = False
         self.__moving_threshold = (0.005, 0.001)

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -118,10 +118,10 @@ def integrator(shared_state, solver_queue, console_queue):
             "constellation": None,
         }
         cfg = config.Config()
-        if cfg.get_option("screen_direction") == "left":
-            left_handed = True
+        if cfg.get_option("screen_direction") == "left" or cfg.get_option("screen_direction") == "flat":
+            flip_alt_offset = True
         else:
-            left_handed = False
+            flip_alt_offset = False
 
         # This holds the last image solve position info
         # so we can delta for IMU updates
@@ -185,7 +185,7 @@ def integrator(shared_state, solver_queue, console_queue):
                         imu_pos = imu["pos"]
                         if lis_imu != None and imu_pos != None:
                             alt_offset = imu_pos[IMU_ALT] - lis_imu[IMU_ALT]
-                            if left_handed:
+                            if flip_alt_offset:
                                 alt_offset = ((alt_offset + 180) % 360 - 180) * -1
                             else:
                                 alt_offset = (alt_offset + 180) % 360 - 180

--- a/python/PiFinder/ui/status.py
+++ b/python/PiFinder/ui/status.py
@@ -42,7 +42,7 @@ class UIStatus(UIModule):
         "Mnt Side": {
             "type": "enum",
             "value": "",
-            "options": ["right", "left", "CANCEL"],
+            "options": ["right", "left", "flat", "CANCEL"],
             "callback": "side_switch",
         },
         "Restart": {
@@ -133,7 +133,7 @@ class UIStatus(UIModule):
             )
             return False
 
-        self.message("Ok! Restaring", 10)
+        self.message("Ok! Restarting", 10)
         self.config_object.set_option("screen_direction", option)
         sys_utils.restart_pifinder()
 


### PR DESCRIPTION
Working on functionality to add flat mount as an option for use with SCTs and Refractors. This mount requires the PiFinder to be mounted parallel and perpendicular to the axis of rotation. 

Task List:

- [x] Add flat mount option in Options Menu
- [x] Flip IMU axis
- [ ] Invert azimuth from negative to positive degrees to resolve flipped arrow
- [x] Flip alt_offset to be that of left hand mount 
- [ ] Rotate chart