### PR TITLE
Cleaned up and rationalized debug dumps

### DIFF
--- a/python/PiFinder/state.py
+++ b/python/PiFinder/state.py
@@ -6,6 +6,7 @@
 """
 import time
 import datetime
+import pickle
 import pytz
 from PiFinder import config
 
@@ -28,6 +29,10 @@ class SharedStateObj:
         self.__target = None
         self.__screen = None
         self.__solve_pixel = config.Config().get_option("solve_pixel")
+
+    def serialize(self, output_file):
+        with open(output_file, "wb") as f:
+            pickle.dump(self, f)
 
     def solve_pixel(self, screen_space=False):
         """

--- a/python/PiFinder/ui/base.py
+++ b/python/PiFinder/ui/base.py
@@ -82,9 +82,7 @@ class UIModule:
     def screengrab(self):
         self.ss_count += 1
         ss_imagepath = self.ss_path + f"_{self.ss_count :0>3}.png"
-        ss = self.screen.getchannel("B")
-        ss = ss.convert("RGB")
-        ss = ImageChops.multiply(ss, Image.new("RGB", (128, 128), (255, 0, 0)))
+        ss = self.screen.copy()
         ss.save(ss_imagepath)
 
     def active(self):

--- a/python/PiFinder/ui/preview.py
+++ b/python/PiFinder/ui/preview.py
@@ -228,15 +228,6 @@ class UIPreview(UIModule):
 
         self.update(force=True)
 
-    def key_up(self):
-        self.command_queues["camera"].put("exp_up")
-
-    def key_down(self):
-        self.command_queues["camera"].put("exp_dn")
-
-    def key_enter(self):
-        self.command_queues["camera"].put("exp_save")
-
     def key_number(self, number):
         if self.align_mode:
             if number == 0:
@@ -261,10 +252,3 @@ class UIPreview(UIModule):
                     )
                 self.align_mode = False
                 self.update(force=True)
-        else:
-            if number == 0:
-                self.capture_count += 1
-                capture_imagepath = (
-                    self.capture_prefix + f"_{self.capture_count :0>3}.png"
-                )
-                self.command_queues["camera"].put("save:" + capture_imagepath)

--- a/python/PiFinder/utils.py
+++ b/python/PiFinder/utils.py
@@ -17,3 +17,4 @@ astro_data_dir = pifinder_dir / "astro_data"
 data_dir = Path(Path.home(), "PiFinder_data")
 pifinder_db = astro_data_dir / "pifinder_objects.db"
 observations_db = data_dir / "observations.db"
+debug_dump_dir = data_dir / "solver_debug_dumps"


### PR DESCRIPTION
Ent-D is for debug dumps!  One key to rule them all......

* Add shared state, ui state, screenshot to debug dump
* Made sure raw and filtered camera output is saved
* Switch dump location to proper ~/PiFinder_data/solver_debug_dumps
* Fix screenshot code (Ent-0) as a side effect
* Remove camera image saving from other locations
* Remove exposure up/down/save from Preview (general cleanup)

Now, no matter what you are seeing/investigating Ent-D should save enough info really debug and to get the PiFinder back in that exact state if desired.
