### PR TITLE
Adding a screen saver

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -13,6 +13,7 @@
     "screen_direction": "right",
     "solver_debug": 0,
     "sleep_timeout": "30s",
+    "screen_off_timeout": "Off",
     "solve_pixel": [256, 256],
     "catalogs": [
         "NGC",

--- a/python/PiFinder/camera_interface.py
+++ b/python/PiFinder/camera_interface.py
@@ -57,7 +57,7 @@ class CameraInterface:
             # 60 half-second cycles
             sleep_delay = 60
             while True:
-                if shared_state.power_state() == 0:
+                if shared_state.power_state() <= 0:
                     time.sleep(0.5)
 
                     # Even in sleep mode, we want to take photos every

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -133,7 +133,7 @@ def integrator(shared_state, solver_queue, console_queue):
         last_solved = None
         last_solve_time = time.time()
         while True:
-            if shared_state.power_state() == 0:
+            if shared_state.power_state() <= 0:
                 time.sleep(0.5)
             else:
                 time.sleep(1 / 30)

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -27,7 +27,7 @@ def solver(shared_state, solver_queue, camera_image, console_queue):
     }
     try:
         while True:
-            if shared_state.power_state() == 0:
+            if shared_state.power_state() <= 0:
                 time.sleep(0.5)
             # use the time the exposure started here to
             # reject images startede before the last solve

--- a/python/PiFinder/ui/status.py
+++ b/python/PiFinder/ui/status.py
@@ -33,6 +33,12 @@ class UIStatus(UIModule):
             "options": ["Off", "10s", "30s", "1m"],
             "callback": "set_sleep_timeout",
         },
+        "Screen Off": {
+            "type": "enum",
+            "value": "",
+            "options": ["Off", "30s", "1m", "10m"],
+            "callback": "set_screen_off_timeout",
+        },
         "WiFi Mode": {
             "type": "enum",
             "value": "UNK",
@@ -97,6 +103,9 @@ class UIStatus(UIModule):
         self._config_options["Sleep Tim"]["value"] = self.config_object.get_option(
             "sleep_timeout"
         )
+        self._config_options["Screen Off"]["value"] = self.config_object.get_option(
+            "screen_off_timeout"
+        )
         self._config_options["Key Brit"]["value"] = self.config_object.get_option(
             "keypad_brightness"
         )
@@ -124,6 +133,10 @@ class UIStatus(UIModule):
 
     def set_sleep_timeout(self, option):
         self.config_object.set_option("sleep_timeout", option)
+        return False
+
+    def set_screen_off_timeout(self, option):
+        self.config_object.set_option("screen_off_timeout", option)
         return False
 
     def side_switch(self, option):


### PR DESCRIPTION
- added now config option 'Screen Off'
- When the unit is idle for this amount of time, the screen is turned off, preventing burn-in and lowering power consumption.
- when pressing a key to get out of screen off/lower brightness mode, the key is now properly ignored

See the .hide() method in the docs below:
https://luma-oled.readthedocs.io/en/latest/api-documentation.html#module-luma.oled.device