### PR TITLE
Bright Star Alignment fixes

### DIFF
--- a/python/PiFinder/ui/preview.py
+++ b/python/PiFinder/ui/preview.py
@@ -139,8 +139,8 @@ class UIPreview(UIModule):
 
             for _i in range(self.highlight_count):
                 raw_y, raw_x = self.star_list[_i]
-                star_x = int(raw_x / 4)
-                star_y = int(raw_y / 4)
+                star_x = int(raw_x / 2)
+                star_y = int(raw_y / 2)
 
                 x_direction = 1
                 x_text_offset = 6
@@ -189,10 +189,12 @@ class UIPreview(UIModule):
             # Do this at least once to get a numpy array in
             # star_list
             if self.align_mode:
+                cent_image_obj = image_obj.resize((256, 256))
+                _t = time.time()
                 self.star_list = tetra3.get_centroids_from_image(
-                    image_obj,
+                    cent_image_obj,
                     sigma_mode="local_median_abs",
-                    filtsize=13,
+                    filtsize=11,
                 )
 
             # Resize
@@ -215,9 +217,9 @@ class UIPreview(UIModule):
 
             self.title = "PREVIEW"
 
-        self.draw_reticle()
-        if self.align_mode:
-            self.draw_star_selectors()
+            self.draw_reticle()
+            if self.align_mode:
+                self.draw_star_selectors()
         return self.screen_update(title_bar=not self.align_mode)
 
     def key_b(self):
@@ -243,15 +245,12 @@ class UIPreview(UIModule):
                 # They picked a star to align....
                 star_index = number - 1
                 if self.star_list.shape[0] > star_index:
-                    self.shared_state.set_solve_pixel(
-                        (self.star_list[star_index][0], self.star_list[star_index][1])
-                    )
+                    star_cam_x = self.star_list[star_index][0] * 2
+                    star_cam_y = self.star_list[star_index][1] * 2
+                    self.shared_state.set_solve_pixel((star_cam_x, star_cam_y))
                     self.config_object.set_option(
                         "solve_pixel",
-                        (
-                            float(self.star_list[star_index][0]),
-                            float(self.star_list[star_index][1]),
-                        ),
+                        (star_cam_x, star_cam_y),
                     )
                 self.align_mode = False
                 self.update(force=True)

--- a/python/PiFinder/ui/preview.py
+++ b/python/PiFinder/ui/preview.py
@@ -189,7 +189,13 @@ class UIPreview(UIModule):
             # Do this at least once to get a numpy array in
             # star_list
             if self.align_mode:
-                self.star_list = tetra3.get_centroids_from_image(image_obj)
+                self.star_list = tetra3.get_centroids_from_image(
+                    image_obj,
+                    # bg_sub_mode='local_median',
+                    sigma_mode="local_median_abs",
+                    filtsize=13,
+                    # max_area=200,
+                )
 
             # Resize
             image_obj = image_obj.resize((128, 128))
@@ -211,11 +217,10 @@ class UIPreview(UIModule):
 
             self.title = "PREVIEW"
 
-            if self.align_mode:
-                self.draw_star_selectors()
-
         self.draw_reticle()
-        return self.screen_update()
+        if self.align_mode:
+            self.draw_star_selectors()
+        return self.screen_update(title_bar=not self.align_mode)
 
     def key_b(self):
         """

--- a/python/PiFinder/ui/preview.py
+++ b/python/PiFinder/ui/preview.py
@@ -191,10 +191,8 @@ class UIPreview(UIModule):
             if self.align_mode:
                 self.star_list = tetra3.get_centroids_from_image(
                     image_obj,
-                    # bg_sub_mode='local_median',
                     sigma_mode="local_median_abs",
                     filtsize=13,
-                    # max_area=200,
                 )
 
             # Resize


### PR DESCRIPTION
This version uses slower centroiding parameters, but reliably detects bright stars and is more temporally stable.  To counteract the slower centroiding, only a 1/2 resolution (256x256) version of the camera image is used.