### PR TITLE
Allow arbitrary username

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -25,7 +25,7 @@ pip install -r requirements_dev.txt
 
 Download the hipparcos catalog, change the download location.
 
-```wget -O /home/pifinder/PiFinder/astro_data/hip_main.dat https://cdsarc.cds.unistra.fr/ftp/cats/I/239/hip_main.dat```
+```wget -O $HOME/PiFinder/astro_data/hip_main.dat https://cdsarc.cds.unistra.fr/ftp/cats/I/239/hip_main.dat```
 
 ### Tetra3 solver
 

--- a/pi_config_files/smb.conf
+++ b/pi_config_files/smb.conf
@@ -235,7 +235,7 @@ guest account = pifinder
 # to the drivers directory for these users to have write rights in it
 ;   write list = root, @lpadmin
 [shared]
-path=/home/pifinder/PiFinder_data
+path=$HOME/PiFinder_data
 writeable=Yes
 create mask=0777
 directory mask=0777

--- a/pifinder.service
+++ b/pifinder.service
@@ -5,7 +5,7 @@ After=multi-user.target
 [Service]
 Type=idle
 User=pifinder
-WorkingDirectory=/home/pifinder/PiFinder/python
+WorkingDirectory=$HOME/PiFinder/python
 ExecStart=/usr/bin/python -m PiFinder.main
 
 [Install]

--- a/pifinder.service.template
+++ b/pifinder.service.template
@@ -4,8 +4,8 @@ After=multi-user.target
 
 [Service]
 Type=idle
-User=pifinder
-WorkingDirectory=$HOME/PiFinder/python
+User=$USER
+WorkingDirectory=/home/$USER/PiFinder/python
 ExecStart=/usr/bin/python -m PiFinder.main
 
 [Install]

--- a/pifinder_setup.sh
+++ b/pifinder_setup.sh
@@ -35,6 +35,8 @@ echo "dtparam=i2c_arm_baudrate=10000" | sudo tee -a /boot/config.txt
 echo "dtoverlay=pwm,pin=13,func=4" | sudo tee -a /boot/config.txt
 
 # Enable service
+# The service will be run as the same user running this install script.
+sed s/\$USER/$USER/g $HOME/PiFinder/pifinder.service.template > $HOME/PiFinder/pifinder.service
 sudo cp $HOME/PiFinder/pifinder.service /etc/systemd/system/pifinder.service
 sudo systemctl daemon-reload
 sudo systemctl enable pifinder

--- a/pifinder_setup.sh
+++ b/pifinder_setup.sh
@@ -6,27 +6,27 @@ cd PiFinder
 sudo pip install -r requirements.txt
 
 # data dirs
-mkdir ~/PiFinder_data
-mkdir ~/PiFinder_data/captures
-mkdir ~/PiFinder_data/obslists
-mkdir ~/PiFinder_data/screenshots
-mkdir ~/PiFinder_data/solver_debug_dumps
-mkdir ~/PiFinder_data/logs
-chmod -R 777 ~/PiFinder_data
+mkdir $HOME/PiFinder_data
+mkdir $HOME/PiFinder_data/captures
+mkdir $HOME/PiFinder_data/obslists
+mkdir $HOME/PiFinder_data/screenshots
+mkdir $HOME/PiFinder_data/solver_debug_dumps
+mkdir $HOME/PiFinder_data/logs
+chmod -R 777 $HOME/PiFinder_data
 
 # Wifi config
-sudo cp ~/PiFinder/pi_config_files/dhcpcd.* /etc
-sudo cp ~/PiFinder/pi_config_files/dhcpcd.conf.sta /etc/dhcpcd.conf
-sudo cp ~/PiFinder/pi_config_files/dnsmasq.conf /etc/dnsmasq.conf
-sudo cp ~/PiFinder/pi_config_files/hostapd.conf /etc/hostapd/hostapd.conf
-echo -n "Cli" > ~/PiFinder/wifi_status.txt
+sudo cp $HOME/PiFinder/pi_config_files/dhcpcd.* /etc
+sudo cp $HOME/PiFinder/pi_config_files/dhcpcd.conf.sta /etc/dhcpcd.conf
+sudo cp $HOME/PiFinder/pi_config_files/dnsmasq.conf /etc/dnsmasq.conf
+sudo cp $HOME/PiFinder/pi_config_files/hostapd.conf /etc/hostapd/hostapd.conf
+echo -n "Cli" > $HOME/PiFinder/wifi_status.txt
 sudo systemctl unmask hostapd
 
 # Samba config
-sudo cp ~/PiFinder/pi_config_files/smb.conf /etc/samba/smb.conf
+sudo cp $HOME/PiFinder/pi_config_files/smb.conf /etc/samba/smb.conf
 
 # Hipparcos catalog
-wget -O /home/pifinder/PiFinder/astro_data/hip_main.dat https://cdsarc.cds.unistra.fr/ftp/cats/I/239/hip_main.dat
+wget -O $HOME/PiFinder/astro_data/hip_main.dat https://cdsarc.cds.unistra.fr/ftp/cats/I/239/hip_main.dat
 
 # Enable interfaces
 echo "dtparam=spi=on" | sudo tee -a /boot/config.txt
@@ -35,7 +35,7 @@ echo "dtparam=i2c_arm_baudrate=10000" | sudo tee -a /boot/config.txt
 echo "dtoverlay=pwm,pin=13,func=4" | sudo tee -a /boot/config.txt
 
 # Enable service
-sudo cp /home/pifinder/PiFinder/pifinder.service /etc/systemd/system/pifinder.service
+sudo cp $HOME/PiFinder/pifinder.service /etc/systemd/system/pifinder.service
 sudo systemctl daemon-reload
 sudo systemctl enable pifinder
 

--- a/pifinder_update.sh
+++ b/pifinder_update.sh
@@ -2,8 +2,8 @@
 git checkout release
 git pull
 git submodule update --init --recursive
-sudo pip install -r /home/pifinder/PiFinder/requirements.txt
-source /home/pifinder/PiFinder/pifinder_post_update.sh
+sudo pip install -r $HOME/PiFinder/requirements.txt
+source $HOME/PiFinder/pifinder_post_update.sh
 
 echo "PiFinder software update complete, please restart the Pi"
 

--- a/python/PiFinder/sys_utils.py
+++ b/python/PiFinder/sys_utils.py
@@ -16,7 +16,7 @@ def update_software():
     service
     """
     print("SYS: Running update")
-    sh.bash("/home/pifinder/PiFinder/pifinder_update.sh")
+    sh.bash("$HOME/PiFinder/pifinder_update.sh")
     return True
 
 
@@ -32,11 +32,11 @@ def restart_pifinder():
 
 def go_wifi_ap():
     print("SYS: Switching to AP")
-    sh.sudo("/home/pifinder/PiFinder/switch-ap.sh")
+    sh.sudo("$HOME/PiFinder/switch-ap.sh")
     return True
 
 
 def go_wifi_cli():
     print("SYS: Switching to Client")
-    sh.sudo("/home/pifinder/PiFinder/switch-cli.sh")
+    sh.sudo("$HOME/PiFinder/switch-cli.sh")
     return True

--- a/python/PiFinder/utils.py
+++ b/python/PiFinder/utils.py
@@ -12,7 +12,7 @@ def create_path(apath: Path):
 
 home_dir = Path.home()
 cwd_dir = Path.cwd()
-pifinder_dir = Path("..")
+pifinder_dir = Path.home() / "PiFinder"
 astro_data_dir = pifinder_dir / "astro_data"
 data_dir = Path(Path.home(), "PiFinder_data")
 pifinder_db = astro_data_dir / "pifinder_objects.db"

--- a/switch-ap.sh
+++ b/switch-ap.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/bash
 cp /etc/dhcpcd.conf.ap /etc/dhcpcd.conf
-echo -n "AP" > /home/pifinder/PiFinder/wifi_status.txt
+echo -n "AP" > $HOME/PiFinder/wifi_status.txt
 systemctl enable dnsmasq
 systemctl enable hostapd
 #systemctl start dnsmasq

--- a/switch-cli.sh
+++ b/switch-cli.sh
@@ -5,5 +5,5 @@ cp /etc/dhcpcd.conf.sta /etc/dhcpcd.conf
 systemctl disable dnsmasq
 systemctl disable hostapd
 #systemctl restart dhcpcd
-echo -n "Cli" > /home/pifinder/PiFinder/wifi_status.txt
+echo -n "Cli" > $HOME/PiFinder/wifi_status.txt
 shutdown -r now


### PR DESCRIPTION
This PR removes the requirement that the user select 'pifinder' as the username for their Raspberry pi.

Overview of changes:
 - updates hard-coded user dir paths with $HOME
 - moves pifinder.service to pifinder.service.template and updates the install script to interpolate that template back to pifinder.service with the current user's username
 - One incidental change updating `astro_data_dir` to a consistent reference to utils

I tested these changes by installing PiFinder on a new sd card with my own username.