### PR TITLE
More legible IMU status

### DIFF
--- a/python/PiFinder/ui/base.py
+++ b/python/PiFinder/ui/base.py
@@ -217,17 +217,9 @@ class UIModule:
                     (102, -2), self._GPS_ICON, font=fonts.icon_bold_large, fill=fg
                 )
 
-            # when moving the unit, nothing else matters
             if moving:
-                # logging.debug("imu moving %s", imu["moving"])
                 self._unmoved = False
                 self.draw.rectangle([115, 2, 125, 14], fill=self.colors.get(bg))
-                self.draw.text(
-                    (117, -2),
-                    self._IMU_ICON,
-                    font=fonts.icon_bold_large,
-                    fill=fg,
-                )
             if self.shared_state:
                 if self.shared_state.solve_state():
                     solution = self.shared_state.solution()
@@ -238,13 +230,14 @@ class UIModule:
                         time_since_cam_solve = time.time() - solution["cam_solve_time"]
                         var_fg = min(64, int(time_since_cam_solve / 6 * 64))
                     self.draw.rectangle([115, 2, 125, 14], fill=bg)
-                    # draw the CAM or IMU icon
-                    self.draw.text(
-                        (117, -2),
-                        self._CAM_ICON if self._unmoved else self._IMU_ICON,
-                        font=fonts.icon_bold_large,
-                        fill=var_fg if self._unmoved else fg,
-                    )
+
+                    if self._unmoved:
+                        self.draw.text(
+                            (117, -2),
+                            self._CAM_ICON,
+                            font=fonts.icon_bold_large,
+                            fill=var_fg,
+                        )
                     # draw the constellation
                     constellation = solution["constellation"]
                     self.draw.text(

--- a/python/PiFinder/ui/locate.py
+++ b/python/PiFinder/ui/locate.py
@@ -267,6 +267,7 @@ class UILocate(UIModule):
         )
 
         # Pointing Instructions
+        indicator_color = 255 if self._unmoved else 128
         point_az, point_alt = self.aim_degrees()
         if not point_az:
             self.draw.text(
@@ -278,14 +279,14 @@ class UILocate(UIModule):
         else:
             if point_az >= 0:
                 self.draw.regular_polygon(
-                    (10, 75, 10), 3, 90, fill=self.colors.get(255)
+                    (10, 75, 10), 3, 90, fill=self.colors.get(indicator_color)
                 )
                 # self.draw.pieslice([-20,65,20,85],330, 30, fill=self.colors.get(255))
                 # self.draw.text((0, 50), "+", font=self.font_huge, fill=self.colors.get(255))
             else:
                 point_az *= -1
                 self.draw.regular_polygon(
-                    (10, 75, 10), 3, 270, fill=self.colors.get(255)
+                    (10, 75, 10), 3, 270, fill=self.colors.get(indicator_color)
                 )
                 # self.draw.pieslice([0,65,40,85],150,210, fill=self.colors.get(255))
                 # self.draw.text((0, 50), "-", font=self.font_huge, fill=self.colors.get(255))
@@ -293,19 +294,19 @@ class UILocate(UIModule):
                 (25, 50),
                 f"{point_az : >5.1f}",
                 font=self.font_huge,
-                fill=self.colors.get(255),
+                fill=self.colors.get(indicator_color),
             )
 
             if point_alt >= 0:
                 self.draw.regular_polygon(
-                    (10, 110, 10), 3, 0, fill=self.colors.get(255)
+                    (10, 110, 10), 3, 0, fill=self.colors.get(indicator_color)
                 )
                 # self.draw.pieslice([0,84,20,124],60, 120, fill=self.colors.get(255))
                 # self.draw.text((0, 84), "+", font=self.font_huge, fill=self.colors.get(255))
             else:
                 point_alt *= -1
                 self.draw.regular_polygon(
-                    (10, 105, 10), 3, 180, fill=self.colors.get(255)
+                    (10, 105, 10), 3, 180, fill=self.colors.get(indicator_color)
                 )
                 # self.draw.pieslice([0,104,20,144],270, 330, fill=self.colors.get(255))
                 # self.draw.text((0, 84), "-", font=self.font_huge, fill=self.colors.get(255))
@@ -313,7 +314,7 @@ class UILocate(UIModule):
                 (25, 84),
                 f"{point_alt : >5.1f}",
                 font=self.font_huge,
-                fill=self.colors.get(255),
+                fill=self.colors.get(indicator_color),
             )
 
         return self.screen_update()


### PR DESCRIPTION
With low brightness or distance from the screen the camera and IMU icons can look similar at a glance.  This set of changes makes it easier to tell if the current position is based on IMU or camera by removing the IMU indicator and changing the brightness of the push-to instructions to mirror the constellation name 'dimming' 