### PR TITLE
Remove gain / restart options

### DIFF
--- a/python/PiFinder/ui/preview.py
+++ b/python/PiFinder/ui/preview.py
@@ -53,12 +53,6 @@ class UIPreview(UIModule):
             "options": [0.05, 0.2, 0.4, 0.75, 1, 1.25, 1.5, 2],
             "callback": "set_exp",
         },
-        "Gain": {
-            "type": "enum",
-            "value": "",
-            "options": [1, 4, 10, 14, 20],
-            "callback": "set_gain",
-        },
         "Save Exp": {
             "type": "enum",
             "value": "",

--- a/python/PiFinder/ui/status.py
+++ b/python/PiFinder/ui/status.py
@@ -60,12 +60,6 @@ class UIStatus(UIModule):
             "options": ["right", "left", "flat", "CANCEL"],
             "callback": "side_switch",
         },
-        "Restart": {
-            "type": "enum",
-            "value": "",
-            "options": ["PiFi", "CANCEL"],
-            "callback": "restart",
-        },
         "Shutdown": {
             "type": "enum",
             "value": "",


### PR DESCRIPTION
Removing some options that are not needed/cause issues.

* Restart... no real need for this, just taking up space
* Gain.. moar is always better!