### PR TITLE
Speed up boot + State Info on Splash

### DIFF
--- a/pi_config_files/pifinder.service
+++ b/pi_config_files/pifinder.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=PiFinder
-After=multi-user.target
+After=basic.target
 
 [Service]
 Type=idle
@@ -9,4 +9,4 @@ WorkingDirectory=/home/pifinder/PiFinder/python
 ExecStart=/usr/bin/python -m PiFinder.main
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=basic.target

--- a/pifinder_post_update.sh
+++ b/pifinder_post_update.sh
@@ -23,6 +23,18 @@ then
     mv /home/pifinder/PiFinder/config.json /home/pifinder/PiFinder_data/config.json
 fi
 
+# Adjust service definition / add PiFinder_splash
+if ! [ -f "/lib/systemd/system/pifinder_spash.service" ]
+then
+    sudo systemctl disable pifinder
+    sudo cp /home/pifinder/PiFinder/pi_config_files/pifinder.service /lib/systemd/system/pifinder.service
+    sudo cp /home/pifinder/PiFinder/pi_config_files/pifinder_splash.service /lib/systemd/system/pifinder_splash.service
+    sudo systemctl daemon-reload
+    sudo systemctl enable pifinder_splash
+    sudo systemctl enable pifinder
+fi
+
+
 # DONE
 echo "Post Update Complete"
 

--- a/pifinder_setup.sh
+++ b/pifinder_setup.sh
@@ -40,8 +40,8 @@ echo "dtoverlay=pwm,pin=13,func=4" | sudo tee -a /boot/config.txt
 echo "dtoverlay=uart3" | sudo tee -a /boot/config.txt
 
 # Enable service
-sudo cp /home/pifinder/PiFinder/pifinder.service /etc/systemd/system/pifinder.service
-sudo cp /home/pifinder/PiFinder/pi_config_files/pifinder_splash.service /etc/systemd/system/pifinder_splash.service
+sudo cp /home/pifinder/PiFinder/pi_config_files/pifinder.service /lib/systemd/system/pifinder.service
+sudo cp /home/pifinder/PiFinder/pi_config_files/pifinder_splash.service /lib/systemd/system/pifinder_splash.service
 sudo systemctl daemon-reload
 sudo systemctl enable pifinder
 sudo systemctl enable pifinder_splash

--- a/python/PiFinder/splash.py
+++ b/python/PiFinder/splash.py
@@ -11,9 +11,10 @@ This module is the main entry point for PiFinder it:
 """
 import os
 from time import sleep
-from PIL import Image
+from PIL import Image, ImageDraw
 from luma.core.interface.serial import spi
 import numpy as np
+from PiFinder.ui.fonts import Fonts as fonts
 
 
 def do_nothing():
@@ -40,6 +41,22 @@ def show_splash():
     welcome_image_path = os.path.join(root_dir, "images", "welcome.png")
     welcome_image = Image.open(welcome_image_path)
     welcome_image = Image.fromarray(np.array(welcome_image)[:, :, ::-1])
+    screen_draw = ImageDraw.Draw(welcome_image)
+
+    # Display version and Wifi mode
+    with open(os.path.join(root_dir, "version.txt"), "r") as ver_f:
+        version = "v" + ver_f.read()
+
+    with open(os.path.join(root_dir, "wifi_status.txt"), "r") as wifi_f:
+        wifi_mode = wifi_f.read()
+    screen_draw.rectangle([0, 0, 128, 16], fill=(0, 0, 0))
+    screen_draw.text(
+        (0, 1),
+        f"Wifi:{wifi_mode: <3}  {version: >11}",
+        font=fonts.base,
+        fill=(255, 0, 0),
+    )
+
     display.display(welcome_image.convert(display.mode))
 
 


### PR DESCRIPTION
* Adjust boot ordering for quicker PiFinder startup
* Add wifi config state and software version to splash screen
* Make sure splash screen gets installed on updates