### PR TITLE
2 - Add advanced view in the web UI for development

### DIFF
--- a/python/PiFinder/server.py
+++ b/python/PiFinder/server.py
@@ -24,7 +24,7 @@ from PiFinder.keyboard_interface import KeyboardInterface
 try:
     from PiFinder import sys_utils
 except ImportError:
-    from PiFinder import sys_utils_fake as sys_util
+    from PiFinder import sys_utils_fake as sys_utils
 from PiFinder import utils, calc_utils
 from PiFinder.db.observations_db import (
     ObservationsDatabase,

--- a/python/PiFinder/server.py
+++ b/python/PiFinder/server.py
@@ -20,7 +20,12 @@ from bottle import (
 from PIL import Image
 
 from PiFinder.keyboard_interface import KeyboardInterface
-from PiFinder import sys_utils, utils, calc_utils
+
+try:
+    from PiFinder import sys_utils
+except ImportError:
+    from PiFinder import sys_utils_fake as sys_util
+from PiFinder import utils, calc_utils
 from PiFinder.db.observations_db import (
     ObservationsDatabase,
 )

--- a/python/PiFinder/server.py
+++ b/python/PiFinder/server.py
@@ -157,6 +157,13 @@ class Server:
                 "remote",
             )
 
+        @app.route("/advanced")
+        @auth_required
+        def advanced():
+            return template(
+                "advanced",
+            )
+
         @app.route("/network")
         @auth_required
         def network_page():
@@ -359,12 +366,14 @@ class Server:
                 },
             )
             self.gps_queue.put(msg)
+            logging.debug("Putting location msg on gps_queue")
 
         @app.route("/time-lock")
         @auth_required
         def time_lock():
             msg = ("time", datetime.datetime.now())
             self.gps_queue.put(msg)
+            logging.debug("Putting time msg on gps_queue")
 
         # If the PiFinder software is running as a service
         # it can grab port 80.  If not, it needs to use 8080

--- a/python/PiFinder/sys_utils_fake.py
+++ b/python/PiFinder/sys_utils_fake.py
@@ -1,0 +1,153 @@
+import glob
+import sh
+import socket
+from PiFinder import utils
+
+BACKUP_PATH = "/home/pifinder/PiFinder_data/PiFinder_backup.zip"
+
+
+class Network:
+    """
+    Provides wifi network info
+    """
+
+    def __init__(self):
+        pass
+
+    def populate_wifi_networks(self):
+        """
+        Parses wpa_supplicant.conf to get current config
+        """
+        pass
+
+    def get_wifi_networks(self):
+        return ""
+
+    def delete_wifi_network(self, network_id):
+        """
+        Immediately deletes a wifi network
+        """
+        pass
+
+    def add_wifi_network(self, ssid, key_mgmt, psk=None):
+        """
+        Add a wifi network
+        """
+        pass
+
+    def get_ap_name(self):
+        return "UNKN"
+
+    def set_ap_name(self, ap_name):
+        pass
+
+    def get_host_name(self):
+        return socket.gethostname()
+
+    def get_connected_ssid(self):
+        """
+        Returns the SSID of the connected wifi network or
+        None if not connected or in AP mode
+        """
+        return "UNKN"
+
+    def set_host_name(self, hostname):
+        if hostname == self.get_host_name():
+            return
+        result = "UNKN"
+
+    def wifi_mode(self):
+        return "UNKN"
+
+    def set_wifi_mode(self, mode):
+        pass
+
+    def local_ip(self):
+        return "NONE"
+
+
+def remove_backup():
+    """
+    Removes backup file
+    """
+    pass
+
+
+def backup_userdata():
+    """
+    Back up userdata to a single zip file for later
+    restore.  Returns the path to the zip file.
+
+    Backs up:
+        config.json
+        observations.db
+        obslist/*
+    """
+    return BACKUP_PATH
+
+
+def restore_userdata(zip_path):
+    """
+    Compliment to backup_userdata
+    restores userdata
+    OVERWRITES existing data!
+    """
+    pass
+
+
+def shutdown():
+    """
+    shuts down the Pi
+    """
+    print("SYS: Initiating Shutdown")
+    return True
+
+
+def update_software():
+    """
+    Uses systemctl to git pull and then restart
+    service
+    """
+    print("SYS: Running update")
+    return True
+
+
+def restart_pifinder():
+    """
+    Uses systemctl to restart the PiFinder
+    service
+    """
+    print("SYS: Restarting PiFinder")
+    return True
+
+
+def restart_system():
+    """
+    Restarts the system
+    """
+    print("SYS: Initiating System Restart")
+
+
+def go_wifi_ap():
+    print("SYS: Switching to AP")
+    return True
+
+
+def go_wifi_cli():
+    print("SYS: Switching to Client")
+    return True
+
+
+def verify_password(username, password):
+    """
+    Checks the provided password against the provided user
+    password
+    """
+    return True
+
+
+def change_password(username, current_password, new_password):
+    """
+    Changes the PiFinder User password
+    """
+    return False

--- a/python/PiFinder/ui/status.py
+++ b/python/PiFinder/ui/status.py
@@ -13,7 +13,7 @@ from PiFinder.ui.base import UIModule
 try:
     from PiFinder import sys_utils
 except ImportError:
-    from PiFinder import sys_utils_fake as sys_util
+    from PiFinder import sys_utils_fake as sys_utils
 from PiFinder import calc_utils
 from PiFinder import utils
 from PiFinder.ui.ui_utils import TextLayouter, SpaceCalculatorFixed

--- a/python/PiFinder/ui/status.py
+++ b/python/PiFinder/ui/status.py
@@ -9,7 +9,11 @@ import time
 import socket
 
 from PiFinder.ui.base import UIModule
-from PiFinder import sys_utils
+
+try:
+    from PiFinder import sys_utils
+except ImportError:
+    from PiFinder import sys_utils_fake as sys_util
 from PiFinder import calc_utils
 from PiFinder import utils
 from PiFinder.ui.ui_utils import TextLayouter, SpaceCalculatorFixed

--- a/python/views/advanced.tpl
+++ b/python/views/advanced.tpl
@@ -1,0 +1,31 @@
+% include("header.tpl", title="Advanced")
+
+<div id="error" class="error-message"></div>
+<center>
+    <div style="display: grid; grid-template-columns: repeat(4, 1fr); margin: 0.5rem; justify-content: center; gap: 0.5rem;">
+        <button class="btn remote-button" onclick="buttonClicked(this, 'LOC')">GPS location lock</button>
+        <button class="btn remote-button" onclick="buttonClicked(this, 'TIME')">GPS time lock</button>
+    </div>
+    <div style="display: flex; flex-direction: row; margin: 0px 5px 0px 5px; gap: 1rem; justify-content: center;">
+    </div>
+</center>
+<script>
+
+function buttonClicked(btn, code) {
+    if(code == 'LOC') {
+        fetch("/gps-lock")
+        .then(response => {
+            if (!response.ok) { throw Error(response.statusText); }
+        })
+    } else if(code == 'TIME') {
+        fetch("/time-lock")
+        .then(response => {
+            if (!response.ok) { throw Error(response.statusText); }
+        })
+    }
+
+}
+</script>
+
+% include("footer.tpl", title="PiFinder UI")
+


### PR DESCRIPTION
this is a quick fix to expose the gps-lock and time-lock endpoints via the UI. This is helpful for debugging when no GPS lock is present (both on desktop and in-house pifinder which can't find a lock)

Note:
The good solution is to add a little pencil next to the gps lock entry on the index, leading to a /gps page where you can enter lat/lon and time. Time could be gotten from the browser, lat/lon maybe also