### PR TITLE
Planets available on startup / Fix missing image crash

### DIFF
--- a/python/PiFinder/cat_images.py
+++ b/python/PiFinder/cat_images.py
@@ -92,6 +92,9 @@ def resolve_image_name(catalog_object, source):
     """
     returns the image path for this objects
     """
+    if catalog_object.image_name == "":
+        return ""
+
     return f"{BASE_IMAGE_PATH}/{str(catalog_object.image_name)[-1]}/{catalog_object.image_name}_{source}.jpg"
 
 

--- a/python/PiFinder/catalogs.py
+++ b/python/PiFinder/catalogs.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import datetime
+import pytz
 from typing import List, Dict, DefaultDict, Optional
 import numpy as np
 import pandas as pd
@@ -256,6 +257,14 @@ class Catalogs:
         else:
             logging.warning(f"Catalog {catalog.catalog_code} already exists")
 
+    def remove(self, catalog_code: str):
+        self.__refresh_code_to_pos()
+        if catalog_code in self._code_to_pos:
+            self.catalogs.pop(self._code_to_pos[catalog_code])
+            self._code_to_pos = {}
+        else:
+            logging.warning(f"Catalog {catalog.catalog_code} does not exist")
+
     def get_codes(self) -> List[str]:
         self.__refresh_code_to_pos()
         return list(self._code_to_pos.keys())
@@ -356,6 +365,13 @@ class CatalogBuilder:
         self.catalog_dicts = {}
         logging.debug(f"Loaded {len(composite_objects)} objects from database")
         all_catalogs: Catalogs = self._get_catalogs(composite_objects, catalogs_info)
+        # Initialize planet catalog with whatever date we have for now
+        # This will be re-initialized on activation of Catalog ui module
+        # if we have GPS lock
+        planet_catalog: Catalog = PlanetCatalog(
+            datetime.datetime.now().replace(tzinfo=pytz.timezone("UTC"))
+        )
+        all_catalogs.add(planet_catalog)
         return all_catalogs
 
     def _build_composite(

--- a/python/PiFinder/ui/catalog.py
+++ b/python/PiFinder/ui/catalog.py
@@ -137,6 +137,7 @@ class UICatalog(UIModule):
         Since we can't calc planet positions until we know the date/time
         this is called once we have a GPS lock to add on the planets catalog
         """
+        self.catalogs.remove("PL")
         self.catalogs.add(PlanetCatalog(dt))
         self.catalog_tracker = CatalogTracker(
             self.catalogs, self.shared_state, self._config_options


### PR DESCRIPTION
Planets catalog is not initialized on startup with whatever date is available
During first activation of catalog ui module after GPS lock, planet catalog is removed and re-added to get proper locations of planets for the observing date/time

Made object image resolver return no-image image if file path is blank 