### PR TITLE
Allow larger motion in cam frames for solve

### DIFF
--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -56,7 +56,7 @@ def solver(shared_state, solver_queue, camera_image, console_queue, is_debug=Fal
             last_image_metadata = shared_state.last_image_metadata()
             if (
                 last_image_metadata["exposure_end"] > (last_solve_time)
-                and last_image_metadata["imu_delta"] < 0.1
+                and last_image_metadata["imu_delta"] < 1
             ):
                 img = camera_image.copy()
                 img = img.convert(mode="L")


### PR DESCRIPTION
When testing the new Cedar solver, I noticed that the PiFinder would take longer than expected to achieve first solve after moving the scope.

Turns out this has nothing to do with the new solver, but seems to be an overly aggressive image rejection.  Due to slight bounce/vibration it's not uncommon for the scope/imu to take an extra exposure (or two!) to hit the very low motion-during-exposure threshold for resuming plate solving.  

I'm betting that some of these exposures are worth trying to solve.  Especially with the new Cedar system.  Worse comes to worse, the solve fails and the system is no worse off than it was as the solver failure is usually very graceful.

This change really needs to be tested under the stars more, along with overall Cedar changes.