### PR TITLE
Remove scaling of selected pixel

### DIFF
--- a/python/PiFinder/ui/preview.py
+++ b/python/PiFinder/ui/preview.py
@@ -4,6 +4,14 @@
 This module contains all the UI Module classes
 
 """
+import sys
+import numpy as np
+import time
+
+from PIL import Image, ImageChops, ImageOps
+
+from PiFinder.ui.fonts import Fonts as fonts
+from PiFinder import utils
 from PiFinder.ui.base import UIModule
 from PiFinder.image_util import (
     gamma_correct_high,
@@ -11,12 +19,6 @@ from PiFinder.image_util import (
     gamma_correct_low,
     subtract_background,
 )
-import numpy as np
-import time
-from PIL import Image, ImageChops, ImageOps
-from PiFinder.ui.fonts import Fonts as fonts
-from PiFinder import utils
-import sys
 
 sys.path.append(str(utils.tetra3_dir))
 
@@ -191,9 +193,8 @@ class UIPreview(UIModule):
             # Do this at least once to get a numpy array in
             # star_list
             if self.align_mode and self.shared_state and self.shared_state.solution():
-                self.star_list = np.array(
-                    self.shared_state.solution()["matched_centroids"]
-                )
+                matched_centroids = self.shared_state.solution()["matched_centroids"]
+                self.star_list = np.array(matched_centroids)
 
             # Resize
             image_obj = image_obj.resize((128, 128))
@@ -246,8 +247,8 @@ class UIPreview(UIModule):
                 # They picked a star to align....
                 star_index = number - 1
                 if self.star_list.shape[0] > star_index:
-                    star_cam_x = self.star_list[star_index][0] * 2
-                    star_cam_y = self.star_list[star_index][1] * 2
+                    star_cam_x = self.star_list[star_index][0]
+                    star_cam_y = self.star_list[star_index][1]
                     self.shared_state.set_solve_pixel((star_cam_x, star_cam_y))
                     self.config_object.set_option(
                         "solve_pixel",


### PR DESCRIPTION
Previously the Bright Star Alignment pulled its own centroids using the standard Tetra3 system.  To make this very consistent and speed things up, a 1/2 resolution image was used.

Now that the BSA is using the matched_centroids info from the latest solve, this scaling is not needed and was causing the selected pixel position to be doubled.

TODO: Using the matched_centroids is *very* stable (no flicker between similarly bright stars) but means you can't align on a planet.... We might want to change this or update the docs.