### PR TITLE
Find the Planets again

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -17,31 +17,12 @@
     "screen_off_timeout": "Off",
     "hint_timeout": "2s",
     "solve_pixel": [256, 256],
-    "catalogs": [
-        "NGC",
-        "IC",
-        "M",
-        "C",
-        "Col",
-        "H",
-        "Ta2",
-        "Str",
-        "RDS",
-        "SaA",
-        "SaR",
-        "SaM",
-        "Abl",
-        "EGC",
-        "B",
-        "Sh2"
-    ],
     "active_catalogs": [
         "NGC",
         "M",
         "H",
         "Ta2",
         "Str",
-        "SaA",
-        "Sh2"
+        "PL"
     ]
 }

--- a/python/PiFinder/catalogs.py
+++ b/python/PiFinder/catalogs.py
@@ -2,6 +2,8 @@ import logging
 import time
 import datetime
 import pytz
+from pprint import pformat
+
 from typing import List, Dict, DefaultDict, Optional
 from collections import defaultdict
 import PiFinder.calc_utils as calc_utils
@@ -339,15 +341,20 @@ class Catalogs:
     def add(self, catalog: Catalog):
         if catalog.catalog_code not in self._code_to_pos:
             self.__catalogs.append(catalog)
-            self._select_all_catalogs()
+
+            # Add the newly added index to the selection list to make sure it's
+            # selected
+            self.__selected_catalogs_idx.append(len(self.__catalogs) - 1)
             self._refresh_code_to_pos()
         else:
             logging.warning(f"Catalog {catalog.catalog_code} already exists")
 
     def remove(self, catalog_code: str):
-        if catalog_code in self._code_to_pos_sel:
-            idx = self._code_to_pos_sel[catalog_code]
-            self.__selected_catalogs_idx.remove(idx)
+        if catalog_code in self._code_to_pos:
+            idx = self._code_to_pos[catalog_code]
+            self.__catalogs.pop(idx)
+            if idx in self.__selected_catalogs_idx:
+                self.__selected_catalogs_idx.remove(idx)
             self._refresh_code_to_pos()
         else:
             logging.warning(f"Catalog {catalog_code} does not exist")
@@ -402,10 +409,10 @@ class Catalogs:
         }
 
     def _select_all_catalogs(self):
-        self.__selected_catalogs_idx = [x for x in range(len(self.__catalogs))]
+        self.__selected_catalogs_idx = list(range(len(self.__catalogs)))
 
     def __repr__(self):
-        return f"Catalogs({self.get_catalogs()=}, selected {len(self.__selected_catalogs_idx)}/{len(self.__catalogs)})"
+        return f"Catalogs(\n{pformat(self.get_catalogs(only_selected=False))},\n selected {len(self.__selected_catalogs_idx)}/{len(self.__catalogs)},\n{self.__selected_catalogs_idx})"
 
     def __str__(self):
         return self.__repr__()

--- a/python/PiFinder/catalogs.py
+++ b/python/PiFinder/catalogs.py
@@ -338,13 +338,14 @@ class Catalogs:
         self._select_all_catalogs()
         self._refresh_code_to_pos()
 
-    def add(self, catalog: Catalog):
+    def add(self, catalog: Catalog, select: bool = False):
         if catalog.catalog_code not in self._code_to_pos:
             self.__catalogs.append(catalog)
 
             # Add the newly added index to the selection list to make sure it's
             # selected
-            self.__selected_catalogs_idx.append(len(self.__catalogs) - 1)
+            if select:
+                self.__selected_catalogs_idx.append(len(self.__catalogs) - 1)
             self._refresh_code_to_pos()
         else:
             logging.warning(f"Catalog {catalog.catalog_code} already exists")

--- a/python/PiFinder/ui/catalog.py
+++ b/python/PiFinder/ui/catalog.py
@@ -140,7 +140,6 @@ class UICatalog(UIModule):
         self.catalog_tracker.filter()
         self.closest_objects_finder = ClosestObjectsFinder()
         self.update_object_info()
-        self._planets_loaded = False
 
     def add_planets(self, dt):
         """
@@ -148,11 +147,14 @@ class UICatalog(UIModule):
         this is called once we have a GPS lock to add on the planets catalog
         """
         self.catalogs.remove("PL")
-        self.catalogs.add(PlanetCatalog(dt))
+
+        # We need to feed through the planet catalog selection status
+        # here so when it gets re-added we can re-select it if needed
+        _select = "PL" in self._config_options["Catalogs"]["value"]
+        self.catalogs.add(PlanetCatalog(dt), select=_select)
         self.catalog_tracker = CatalogTracker(
             self.catalogs, self.shared_state, self._config_options
         )
-        self._planets_loaded = True
 
     def _layout_designator(self):
         """
@@ -375,10 +377,9 @@ class UICatalog(UIModule):
         super().active()
 
         # check for planet add
-        if not self._planets_loaded:
-            dt = self.shared_state.datetime()
-            if dt:
-                self.add_planets(dt)
+        dt = self.shared_state.datetime()
+        if dt:
+            self.add_planets(dt)
 
         self.catalog_tracker.filter()
         target = self.ui_state.target()

--- a/python/PiFinder/ui/catalog.py
+++ b/python/PiFinder/ui/catalog.py
@@ -92,11 +92,13 @@ class UICatalog(UIModule):
 
     def __init__(self, *args):
         super().__init__(*args)
+
+        # Initialze Catalogs
+        self.catalogs: Catalogs = CatalogBuilder().build()
+
         self.catalog_names = self.config_object.get_option("active_catalogs")
         self._config_options["Catalogs"]["value"] = self.catalog_names.copy()
-        self._config_options["Catalogs"]["options"] = self.config_object.get_option(
-            "catalogs"
-        )
+        self._config_options["Catalogs"]["options"] = self.catalogs.get_codes()
 
         self.object_text = ["No Object Found"]
         self.simpleTextLayout = functools.partial(
@@ -118,7 +120,6 @@ class UICatalog(UIModule):
                 "No Object Found", font=self.font_bold, color=self.colors.get(255)
             ),
         }
-        self.catalogs: Catalogs = CatalogBuilder().build()
         logging.debug(f"Catalogs created: {self.catalogs}")
         logging.debug(
             f"Value:{self._config_options['Catalogs']['value']}, Options{self._config_options['Catalogs']['options']}"


### PR DESCRIPTION
There were a couple of things that ended up with the Planets catalog always being de-selected, and since it was not in the default_config.json it did not show up in the config selection list and it could not be enabled.   I've removed this config item all together now that we can handle more than 10 catalogs in the menu :+1:  

While I was digging into this, I figured out that the remove method of the Catalogs object did not actually remove catalogs, so the planets were not re-added when the GPS lock happens and probably would have had the wrong positions.  This is fixed now and since it's not particularly slow, I've made this remove/add happen each time the catalog screen is accessed.  This should make sure the planet positions are always updated and accurate.

