### PR TITLE
Add optional configuration + facility for camera rotation

### DIFF
--- a/python/PiFinder/camera_interface.py
+++ b/python/PiFinder/camera_interface.py
@@ -44,6 +44,7 @@ class CameraInterface:
             debug = False
 
             screen_direction = cfg.get_option("screen_direction")
+            camera_rotation = cfg.get_option("camera_rotation")
 
             # Set path for test images
             root_dir = os.path.realpath(
@@ -73,10 +74,13 @@ class CameraInterface:
                 if not debug:
                     base_image = self.capture()
                     base_image = base_image.convert("L")
-                    if screen_direction == "right":
-                        base_image = base_image.rotate(90)
+                    if camera_rotation is None:
+                        if screen_direction == "right":
+                            base_image = base_image.rotate(90)
+                        else:
+                            base_image = base_image.rotate(270)
                     else:
-                        base_image = base_image.rotate(270)
+                        base_image = base_image.rotate(int(camera_rotation) * -1)
                 else:
                     # load image and wait
                     base_image = Image.open(test_image_path)

--- a/python/PiFinder/config.py
+++ b/python/PiFinder/config.py
@@ -33,7 +33,9 @@ class Config:
             json.dump(self._config_dict, config_file, indent=4)
 
     def get_option(self, option):
-        return self._config_dict.get(option, self._default_config_dict[option])
+        return self._config_dict.get(
+            option, self._default_config_dict.get(option, None)
+        )
 
     def __str__(self):
         return str(self._config_dict)


### PR DESCRIPTION
config changed to return None on missing key in both user config.json and default_options.json
Check for camera_rotation config item and use this negated to rotate camera image if present, ignoring handedness config