### PR TITLE
Workaround for bright star rejection during alignment

### DIFF
--- a/python/PiFinder/state.py
+++ b/python/PiFinder/state.py
@@ -147,6 +147,7 @@ class SharedStateObj:
         self.__screen = None
         self.__solve_pixel = config.Config().get_option("solve_pixel")
         self.__arch = None
+        self.__camera_align = False
 
     def serialize(self, output_file):
         with open(output_file, "wb") as f:
@@ -182,6 +183,12 @@ class SharedStateObj:
 
     def set_solve_state(self, v):
         self.__solve_state = v
+
+    def camera_align(self):
+        return self.__camera_align
+
+    def set_camera_align(self, v: bool):
+        self.__camera_align = v
 
     def sats(self):
         return self.__sats

--- a/python/PiFinder/ui/preview.py
+++ b/python/PiFinder/ui/preview.py
@@ -217,9 +217,11 @@ class UIPreview(UIModule):
             self.screen.paste(image_obj)
             self.last_update = last_image_time
 
-            self.draw_reticle()
             if self.align_mode:
                 self.draw_star_selectors()
+            else:
+                self.draw_reticle()
+
         return self.screen_update(
             title_bar=not self.align_mode, button_hints=not self.align_mode
         )
@@ -232,6 +234,8 @@ class UIPreview(UIModule):
             self.align_mode = False
         else:
             self.align_mode = True
+
+        self.shared_state.set_camera_align(self.align_mode)
 
         self.update(force=True)
 


### PR DESCRIPTION
Add camera_align boolean to shared_state
if true, use previous tetra3 centroider