### PR TITLE
Roll calculation

### DIFF
--- a/python/PiFinder/calc_utils.py
+++ b/python/PiFinder/calc_utils.py
@@ -192,6 +192,56 @@ def calc_object_altitude(shared_state, obj) -> Optional[float]:
     return None
 
 
+def hadec_to_pa(ha, dec, lat):
+    """ 
+    Returns the parallactic angle of an object at (ha, dec) for an observer
+    at latitude lat. 
+    
+    Note that all angles are in radians.
+
+    The parallactic angle is the angle between the great circles between the 
+    zenith (Z) to the source (S) and the North Pole (P) to the source. By 
+    convention, the parallactic angle is measured from PS to ZS, positive 
+    towards East. The parallactic angle is negative when H < 0 and positive 
+    when H > 0. When At the meridian (i.e. H=0), the parallactic angle is 0 
+    when dec < latitude and +/-180 degrees when dec > latitude.
+    """
+    pa = math.atan2(math.sin(ha), 
+              math.cos(dec) * math.tan(lat) - math.sin(dec) * math.cos(ha))
+
+    return pa  # Parallactic angle [rad]
+
+
+def hadec_to_roll(ha, dec, lat):
+    """
+    Returns the roll of a target at a given (HA, Dec) for and observer at 
+    latitude lat.
+
+    Note that all angles are in radians.
+
+    The roll or the field rotation angle describes how much the source (S) is
+    rotated on the sky as seen by and observer. The roll measures the same 
+    angle as the parallactic but measured with a different orientation. See
+    ha_dec2pa() for explanation on the parallactic angle. The roll is positive 
+    for anti-clockwise rotation of ZS to PS when looking out towards the sky.
+    """
+    pa = ha_dec2pa(ha, dec, lat)  # Calculate the parallactic angle
+    
+    if dec <= lat:
+        roll = -pa
+    else:
+        # Tedious but need to do this because math doesn't have a sign() func.
+        # Otherwise the eqn is: roll = -pa + np.sign(ha) * np.pi
+        if ha > 0:
+            roll = -pa + math.pi
+        elif ha < 0:
+            roll = -pa - math.pi
+        else:
+            roll = -pa
+
+    return roll
+
+
 def hash_dict(d):
     serialized_data = json.dumps(d, sort_keys=True).encode()
     return hashlib.sha256(serialized_data).hexdigest()

--- a/python/PiFinder/calc_utils.py
+++ b/python/PiFinder/calc_utils.py
@@ -225,7 +225,7 @@ def hadec_to_roll(ha, dec, lat):
     ha_dec2pa() for explanation on the parallactic angle. The roll is positive 
     for anti-clockwise rotation of ZS to PS when looking out towards the sky.
     """
-    pa = ha_dec2pa(ha, dec, lat)  # Calculate the parallactic angle
+    pa = hadec_to_pa(ha, dec, lat)  # Calculate the parallactic angle
     
     if dec <= lat:
         roll = -pa
@@ -326,6 +326,49 @@ class Skyfield_utils:
         else:
             alt, az, distance = apparent.altaz()
         return alt.degrees, az.degrees
+
+
+    def get_lst(self, dt):
+        """ 
+        Returns the local sidereal time.
+        
+        INPUTS:
+        dt: UTC date & time [SharedStateObj.datetime() object]
+
+        RETURNS:
+        lst: Local sidereal time
+        """
+        return lst
+
+
+    def ra_to_ha(self, ra, dt):
+        """
+        Converts RA (right ascension) to HA (hour angle)
+
+        INPUTS:
+        ra: Right asension
+        dt: UTC date & time [SharedStateObj.datetime() object]
+
+        RETURNS:
+        ha: Hour angle
+        """
+        lst = self.get_lst(dt)
+        ha = lst - ra
+        return ha
+
+
+    def radec_to_roll(self, ra, dec, dt):
+        """ 
+        Returns the roll (field rotation) of an object at (ra, dec) as 
+        seen from an observer at latitiude, lat and time, dt. See hadec_to_roll()
+        for details about roll.
+
+
+        """
+        ha = self.ra_to_ha(ra, dt)
+        roll = hadec_to_roll(ha, dec, lat)
+        return roll
+
 
     def radec_to_constellation(self, ra, dec):
         """

--- a/python/PiFinder/calc_utils.py
+++ b/python/PiFinder/calc_utils.py
@@ -1,6 +1,7 @@
 import datetime
 import pytz
 import math
+import numpy as np
 from typing import Tuple, Optional
 from skyfield.api import (
     wgs84,
@@ -211,14 +212,14 @@ def hadec_to_pa(ha_deg, dec_deg, lat_deg):
     RETURNS:
     pa_deg: Parallactic angle [deg]
     """
-    ha = math.radians(ha_deg)
-    dec = math.radians(dec_deg)
-    lat = math.radians(lat_deg)
+    ha = np.deg2rad(ha_deg)
+    dec = np.deg2rad(dec_deg)
+    lat = np.deg2rad(lat_deg)
 
-    pa = math.atan2(math.sin(ha), 
-              math.cos(dec) * math.tan(lat) - math.sin(dec) * math.cos(ha))
+    pa = np.arctan2(np.sin(ha), 
+              np.cos(dec) * np.tan(lat) - np.sin(dec) * np.cos(ha))  
 
-    return math.degrees(pa)  # Parallactic angle [deg]
+    return np.rad2deg(pa)  # Parallactic angle [deg]
 
 
 def hadec_to_roll(ha_deg, dec_deg, lat_deg):
@@ -234,7 +235,8 @@ def hadec_to_roll(ha_deg, dec_deg, lat_deg):
     ZS to PS when looking out towards the sky.
 
     INPUTS:
-    ha_deg, dec_deg: Hour Angle (HA) and declination of the target [deg]
+    ha_deg: Hour Angle (HA) of the target [deg]
+    dec_deg: Declination of the target [deg]
     lat_deg: Latitude of the observer [deg]
 
     RETURNS:
@@ -245,14 +247,7 @@ def hadec_to_roll(ha_deg, dec_deg, lat_deg):
     if dec_deg <= lat_deg:
         roll_deg = -pa_deg
     else:
-        # Tedious but need to do this because math doesn't have a sign() func.
-        # Otherwise the eqn is: roll_deg = -pa_deg + np.sign(ha_deg) * 180
-        if ha_deg > 0:
-            roll_deg = -pa_deg + 180
-        elif ha_deg < 0:
-            roll_deg = -pa_deg - 180
-        else:
-            roll_deg = -pa_deg
+        roll_deg = -pa_deg + np.sign(ha_deg) * 180
 
     return roll_deg
 

--- a/python/PiFinder/calc_utils.py
+++ b/python/PiFinder/calc_utils.py
@@ -1,7 +1,6 @@
 import datetime
 import pytz
 import math
-import unittest
 from typing import Tuple, Optional
 from skyfield.api import (
     wgs84,
@@ -446,46 +445,3 @@ class Skyfield_utils:
 
 # Create a single instance of the skyfield utils
 sf_utils = Skyfield_utils()
-
-
-class UnitTestCalcUtils(unittest.TestCase):
-    """
-    Unit tests for calc_utils.py which does coordinate transformations.
-    """
-
-    def test_hadec_to_pa0(self):
-        # Define the inputs:
-        ha_deg = 0.0
-        lat_deg = 51.0  # Approximately Greenwich Observatory
-        dec_degs = [90, 60, 51, 30, 0, -30]
-        
-        # At HA = 0, expect pa = 0
-        for dec in dec_degs:
-            pa_deg = hadec_to_pa(ha_deg, dec, lat_deg)
-            self.assertAlmostEqual(pa_deg, 0.0, places=3, 
-                                   message='HA = 0: PA should be 0')
-            
-    """
-    def test_hadec_to_pa(self):    
-        # Define the inputs:        
-        ha_deg = 60.0
-        lat_deg = 51.0  # Approximately Greenwich Observatory
-        dec_degs = [90, 60, 51, 30, 0, -30]
-        # Expected values
-        exp_pa_degs = []
-        
-        expected_pa_degs = []  # For HA=+60 deg
-        for dec, expected in zip(dec_degs, expected_pa_degs):
-            # +ve HA case:
-            pa_deg = hadec_to_pa(ha_deg, dec, lat_deg)
-            self.assertAlmostEqual(pa_deg, expected, places=3, 
-                                   message='HA = {:.2f}, dec = {:.2f}'.format(ha_deg, dec))
-            # -ve HA case (expect -ve values):
-            pa_deg = hadec_to_pa(-ha_deg, dec, lat_deg)
-            self.assertAlmostEqual(pa_deg, -expected, places=3, 
-                                   message='HA = {:.2f}, dec = {:.2f}'.format(-ha_deg, dec))
-    """
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/python/PiFinder/calc_utils.py
+++ b/python/PiFinder/calc_utils.py
@@ -329,46 +329,60 @@ class Skyfield_utils:
         return alt.degrees, az.degrees
 
 
-    def get_lst(self, dt):
+    def get_lst_hrs(self, dt):
         """ 
-        Returns the local sidereal time.
+        Returns the local sidereal time in hrs.
         
         INPUTS:
-        dt: UTC date & time [SharedStateObj.datetime() object]
+        dt: Python datetime object (must be timezone-aware)
 
         RETURNS:
-        lst: Local sidereal time
+        lst_hrs: Local sidereal time [hrs]
         """
-        return lst
+        t = self.ts.from_datetime(dt)
+        lst_hrs = self.observer_loc.lst_hours_at(t)  # LST in hrs
+
+        return lst_hrs  # LST [hrs]
 
 
-    def ra_to_ha(self, ra, dt):
+    def ra_to_ha(self, ra_deg, dt):
         """
-        Converts RA (right ascension) to HA (hour angle)
+        Converts RA (right ascension in deg) to HA (hour angle in deg) at time
+        dt. Note that HA is in deg.
 
         INPUTS:
-        ra: Right asension
-        dt: UTC date & time [SharedStateObj.datetime() object]
+        ra_deg: Right asension [deg]
+        dt: Python datetime object (must be timezone-aware)
 
         RETURNS:
-        ha: Hour angle
+        ha_hrs: Hour angle [deg]
         """
-        lst = self.get_lst(dt)
-        ha = lst - ra
-        return ha
+        lst_hrs = self.get_lst_hrs(dt)
+        ha_hrs = lst_hrs - (ra_deg * 12 / 180)  # ra converted to hrs
+        ha_hrs = (ha_hrs + 12) % 24 - 12  # Unwrap to -12 to +12hrs
+
+        return (ha_hrs * 180 / 12)  # Hour angle [deg]
 
 
-    def radec_to_roll(self, ra, dec, dt):
+    def radec_to_roll(self, ra_deg, dec_deg, dt):
         """ 
         Returns the roll (field rotation) of an object at (ra, dec) as 
         seen from an observer at latitiude, lat and time, dt. See hadec_to_roll()
         for details about roll.
 
+        INPUTS:
+        ra_deg:
+        dec: 
+        dt:
 
+        RETURNS:
+        roll_deg: Roll angle [deg]
         """
-        ha = self.ra_to_ha(ra, dt)
-        roll = hadec_to_roll(ha, dec, lat)
-        return roll
+        ha_deg = self.ra_to_ha(ra_deg, dt)  # Note that HA is in deg
+        lat = self.observer_loc.latitude
+        roll_deg = hadec_to_roll(ha_deg, dec_deg, lat._degrees)
+
+        return roll_deg  # roll angle [deg]
 
 
     def radec_to_constellation(self, ra, dec):

--- a/python/PiFinder/calc_utils.py
+++ b/python/PiFinder/calc_utils.py
@@ -226,7 +226,7 @@ def hadec_to_roll(ha_deg, dec_deg, lat_deg):
     Returns the roll of a target at a given (HA, Dec) for and observer at 
     latitude lat.
 
-    The roll or the field rotation angle, as used by the Tetra3 solver 
+    The roll or the field rotation angle, as returned by the Tetra3 solver, 
     describes how much the source (S) is rotated on the sky as seen by and 
     the observer. The roll measures the same angle as the parallactic but 
     measured with a different orientation. See ha_dec2pa() for explanation of 
@@ -382,7 +382,7 @@ class Skyfield_utils:
         """ 
         Returns the roll (field rotation) of an object at (ra, dec) as 
         seen from an observer at latitiude, lat and time, dt. See hadec_to_roll()
-        for details about roll.
+        for how 'roll' is defined.
 
         INPUTS:
         ra_deg:

--- a/python/PiFinder/calc_utils.py
+++ b/python/PiFinder/calc_utils.py
@@ -219,11 +219,12 @@ def hadec_to_roll(ha, dec, lat):
 
     Note that all angles are in radians.
 
-    The roll or the field rotation angle describes how much the source (S) is
-    rotated on the sky as seen by and observer. The roll measures the same 
-    angle as the parallactic but measured with a different orientation. See
-    ha_dec2pa() for explanation on the parallactic angle. The roll is positive 
-    for anti-clockwise rotation of ZS to PS when looking out towards the sky.
+    The roll or the field rotation angle, as used by the Tetra3 solver 
+    describes how much the source (S) is rotated on the sky as seen by and 
+    the observer. The roll measures the same angle as the parallactic but 
+    measured with a different orientation. See ha_dec2pa() for explanation of 
+    the parallactic angle. The roll is positive for anti-clockwise rotation of 
+    ZS to PS when looking out towards the sky.
     """
     pa = hadec_to_pa(ha, dec, lat)  # Calculate the parallactic angle
     

--- a/python/PiFinder/calc_utils.py
+++ b/python/PiFinder/calc_utils.py
@@ -192,32 +192,39 @@ def calc_object_altitude(shared_state, obj) -> Optional[float]:
     return None
 
 
-def hadec_to_pa(ha, dec, lat):
+def hadec_to_pa(ha_deg, dec_deg, lat_deg):
     """ 
     Returns the parallactic angle of an object at (ha, dec) for an observer
     at latitude lat. 
     
-    Note that all angles are in radians.
-
     The parallactic angle is the angle between the great circles between the 
     zenith (Z) to the source (S) and the North Pole (P) to the source. By 
     convention, the parallactic angle is measured from PS to ZS, positive 
     towards East. The parallactic angle is negative when H < 0 and positive 
     when H > 0. When At the meridian (i.e. H=0), the parallactic angle is 0 
     when dec < latitude and +/-180 degrees when dec > latitude.
+
+    INPUTS:
+    ha_deg, dec_deg: Hour Angle (HA) and declination of the target [deg]
+    lat_deg: Latitude of the observer [deg]
+
+    RETURNS:
+    pa_deg: Parallactic angle [deg]
     """
+    ha = math.radians(ha_deg)
+    dec = math.radians(dec_deg)
+    lat = math.radians(lat_deg)
+
     pa = math.atan2(math.sin(ha), 
               math.cos(dec) * math.tan(lat) - math.sin(dec) * math.cos(ha))
 
-    return pa  # Parallactic angle [rad]
+    return math.degrees(pa)  # Parallactic angle [deg]
 
 
-def hadec_to_roll(ha, dec, lat):
+def hadec_to_roll(ha_deg, dec_deg, lat_deg):
     """
     Returns the roll of a target at a given (HA, Dec) for and observer at 
     latitude lat.
-
-    Note that all angles are in radians.
 
     The roll or the field rotation angle, as used by the Tetra3 solver 
     describes how much the source (S) is rotated on the sky as seen by and 
@@ -225,22 +232,29 @@ def hadec_to_roll(ha, dec, lat):
     measured with a different orientation. See ha_dec2pa() for explanation of 
     the parallactic angle. The roll is positive for anti-clockwise rotation of 
     ZS to PS when looking out towards the sky.
+
+    INPUTS:
+    ha_deg, dec_deg: Hour Angle (HA) and declination of the target [deg]
+    lat_deg: Latitude of the observer [deg]
+
+    RETURNS:
+    roll: Roll [deg]
     """
-    pa = hadec_to_pa(ha, dec, lat)  # Calculate the parallactic angle
+    pa_deg = hadec_to_pa(ha_deg, dec_deg, lat_deg)  # Calculate the parallactic angle
     
-    if dec <= lat:
-        roll = -pa
+    if dec_deg <= lat_deg:
+        roll_deg = -pa_deg
     else:
         # Tedious but need to do this because math doesn't have a sign() func.
-        # Otherwise the eqn is: roll = -pa + np.sign(ha) * np.pi
-        if ha > 0:
-            roll = -pa + math.pi
-        elif ha < 0:
-            roll = -pa - math.pi
+        # Otherwise the eqn is: roll_deg = -pa_deg + np.sign(ha_deg) * 180
+        if ha_deg > 0:
+            roll_deg = -pa_deg + 180
+        elif ha_deg < 0:
+            roll_deg = -pa_deg - 180
         else:
-            roll = -pa
+            roll_deg = -pa_deg
 
-    return roll
+    return roll_deg
 
 
 def hash_dict(d):
@@ -355,7 +369,7 @@ class Skyfield_utils:
         dt: Python datetime object (must be timezone-aware)
 
         RETURNS:
-        ha_hrs: Hour angle [deg]
+        ha_deg: Hour angle [deg]
         """
         lst_hrs = self.get_lst_hrs(dt)
         ha_hrs = lst_hrs - (ra_deg * 12 / 180)  # ra converted to hrs

--- a/python/PiFinder/calc_utils.py
+++ b/python/PiFinder/calc_utils.py
@@ -1,6 +1,7 @@
 import datetime
 import pytz
 import math
+import unittest
 from typing import Tuple, Optional
 from skyfield.api import (
     wgs84,
@@ -445,3 +446,46 @@ class Skyfield_utils:
 
 # Create a single instance of the skyfield utils
 sf_utils = Skyfield_utils()
+
+
+class UnitTestCalcUtils(unittest.TestCase):
+    """
+    Unit tests for calc_utils.py which does coordinate transformations.
+    """
+
+    def test_hadec_to_pa0(self):
+        # Define the inputs:
+        ha_deg = 0.0
+        lat_deg = 51.0  # Approximately Greenwich Observatory
+        dec_degs = [90, 60, 51, 30, 0, -30]
+        
+        # At HA = 0, expect pa = 0
+        for dec in dec_degs:
+            pa_deg = hadec_to_pa(ha_deg, dec, lat_deg)
+            self.assertAlmostEqual(pa_deg, 0.0, places=3, 
+                                   message='HA = 0: PA should be 0')
+            
+    """
+    def test_hadec_to_pa(self):    
+        # Define the inputs:        
+        ha_deg = 60.0
+        lat_deg = 51.0  # Approximately Greenwich Observatory
+        dec_degs = [90, 60, 51, 30, 0, -30]
+        # Expected values
+        exp_pa_degs = []
+        
+        expected_pa_degs = []  # For HA=+60 deg
+        for dec, expected in zip(dec_degs, expected_pa_degs):
+            # +ve HA case:
+            pa_deg = hadec_to_pa(ha_deg, dec, lat_deg)
+            self.assertAlmostEqual(pa_deg, expected, places=3, 
+                                   message='HA = {:.2f}, dec = {:.2f}'.format(ha_deg, dec))
+            # -ve HA case (expect -ve values):
+            pa_deg = hadec_to_pa(-ha_deg, dec, lat_deg)
+            self.assertAlmostEqual(pa_deg, -expected, places=3, 
+                                   message='HA = {:.2f}, dec = {:.2f}'.format(-ha_deg, dec))
+    """
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -144,7 +144,7 @@ def integrator(shared_state, solver_queue, console_queue, is_debug=False):
                                 solved["Alt"], solved["Az"], dt
                             )
 
-                            # Find the roll from the RA/Dec
+                            # Find the roll from the RA/Dec and time
                             solved["Roll"] = calc_utils.sf_utils.radec_to_roll(
                                 solved["RA"], solved["Dec"], dt)
 

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -135,6 +135,7 @@ def integrator(shared_state, solver_queue, console_queue, is_debug=False):
                             solved["Alt"] = alt_upd
                             solved["Az"] = az_upd
 
+                            # N.B. Assumes that location hasn't changed since last solve
                             # Turn this into RA/DEC
                             (
                                 solved["RA"],
@@ -144,9 +145,8 @@ def integrator(shared_state, solver_queue, console_queue, is_debug=False):
                             )
 
                             # Find the roll from the RA/Dec
-                            solved["Roll"] = calc_utils.radec_to_roll(
-                                solved["RA"], solved["Dec"], degrees=True)
-                            #shared_state.location["lat"]
+                            solved["Roll"] = calc_utils.sf_utils.radec_to_roll(
+                                solved["RA"], solved["Dec"], dt)
 
 
                             solved["solve_time"] = time.time()

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -108,16 +108,14 @@ def integrator(shared_state, solver_queue, console_queue, is_debug=False):
                 last_image_solve = copy.copy(solved)
                 solved["solve_source"] = "CAM"
 
-            # generate new solution by offsetting last camera solve
-            # if we don't have an alt/az solve
-            # we can't use the IMU
+            # Use IMU dead-reckoning from the last camera solve: 
+            # Check we have an alt/az solve, otherwise we can't use the IMU
             elif solved["Alt"]:
                 imu = shared_state.imu()
                 if imu:
                     dt = shared_state.datetime()
                     if last_image_solve and last_image_solve["Alt"]:
-                        # If we have alt, then we have
-                        # a position/time
+                        # If we have alt, then we have a position/time
 
                         # calc new alt/az
                         lis_imu = last_image_solve["imu_pos"]

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -145,6 +145,12 @@ def integrator(shared_state, solver_queue, console_queue, is_debug=False):
                                 solved["Alt"], solved["Az"], dt
                             )
 
+                            # Find the roll from the RA/Dec
+                            solved["Roll"] = calc_utils.radec_to_roll(
+                                solved["RA"], solved["Dec"], degrees=True)
+                            #shared_state.location["lat"]
+
+
                             solved["solve_time"] = time.time()
                             solved["solve_source"] = "IMU"
 

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -148,7 +148,6 @@ def integrator(shared_state, solver_queue, console_queue, is_debug=False):
                             solved["Roll"] = calc_utils.sf_utils.radec_to_roll(
                                 solved["RA"], solved["Dec"], dt)
 
-
                             solved["solve_time"] = time.time()
                             solved["solve_source"] = "IMU"
 

--- a/python/tests/unit_test_calc_utils.py
+++ b/python/tests/unit_test_calc_utils.py
@@ -6,7 +6,7 @@ Run from PiFinder/python:
 """
 
 import unittest
-from PiFinder.calc_utils import hadec_to_pa
+from PiFinder.calc_utils import hadec_to_pa, hadec_to_roll
 
 class UnitTestCalcUtils(unittest.TestCase):
     """
@@ -14,7 +14,7 @@ class UnitTestCalcUtils(unittest.TestCase):
     """
 
     def test_hadec_to_pa0(self):
-        """ Unit test hadec_to_pa() for the special case when HA = 0 """
+        """ Unit Test: hadec_to_pa(): For the special case when HA = 0 """
         # Define the inputs:
         ha_deg = 0.0
         lat_deg = 51.0  # Approximately Greenwich Observatory
@@ -32,7 +32,7 @@ class UnitTestCalcUtils(unittest.TestCase):
     
 
     def test_hadec_to_pa(self):
-        """ Unit test haddec_to_pa() for when HA != 0 """
+        """ Unit Test: haddec_to_pa(): For when HA != 0 """
         # Define the inputs:        
         ha_deg = 60.0
         lat_deg = 51.0  # Approximately Greenwich Observatory
@@ -49,6 +49,24 @@ class UnitTestCalcUtils(unittest.TestCase):
             pa_deg = hadec_to_pa(-ha_deg, dec, lat_deg)
             self.assertAlmostEqual(pa_deg, -expected, places=3, 
                                    msg='HA = {:.2f}, dec = {:.2f}'.format(-ha_deg, dec))
+
+
+    def test_hadec_to_roll(self):
+            """ Unit Test: haddec_to_roll() """
+            # Define the inputs:        
+            lat_deg = 51.0  # Approximately Greenwich Observatory
+            ha_degs = [60.0, 60.0, 60.0, 60.0, 60.0, 60.0,
+                    -60.0, -60.0, -60.0, -60.0, -60.0, -60.0] 
+            dec_degs = [90, 60, 51, 30, 0, -30,
+                        90, 60, 51, 30, 0, -30]
+            # Expected values
+            expected_roll_degs = [124.0807, 74.1037, -79.9949, -98.92265, -60.2643, -131.5124, 
+                                -124.0807, -74.1037, 79.9949, 98.92265, 60.2643, 131.5124]
+
+            for ha, dec, expected in zip(ha_degs, dec_degs, expected_roll_degs):
+                roll = hadec_to_roll(ha, dec, lat_deg)
+                self.assertAlmostEqual(roll, expected, places=3, 
+                                    msg='HA = {:.2f}, dec = {:.2f}'.format(ha, dec))
 
 
 if __name__ == '__main__':

--- a/python/tests/unit_test_calc_utils.py
+++ b/python/tests/unit_test_calc_utils.py
@@ -7,6 +7,8 @@ Run from PiFinder/python:
 
 import unittest
 from PiFinder.calc_utils import hadec_to_pa, hadec_to_roll
+import numpy as np
+
 
 class UnitTestCalcUtils(unittest.TestCase):
     """
@@ -68,6 +70,23 @@ class UnitTestCalcUtils(unittest.TestCase):
                 self.assertAlmostEqual(roll, expected, places=3, 
                                     msg='HA = {:.2f}, dec = {:.2f}'.format(ha, dec))
 
+
+    def test_hadec_to_roll2(self):
+            """ Unit Test against observed roll data: haddec_to_roll() """
+            # Define the inputs:        
+            lat_deg = 35.819676052
+            ha_hrs = [4.1309, -3.6298, 0.3378] 
+            dec_degs = [74.0515, 22.2856, 30.3246]
+            # Observed values
+            observed_roll_degs = [72.0398, 62.6766, 328.6188]
+
+            for ha_hr, dec, observed in zip(ha_hrs, dec_degs, observed_roll_degs):
+                ha = ha_hr / 12 * 180  # Convert from hr to deg
+                roll = hadec_to_roll(ha, dec, lat_deg)
+                # Roll must be within 2 degrees
+                self.assertLess(np.abs(roll - observed), 2, 
+                                    msg='HA = {:.2f} hr, dec = {:.2f}, roll = {:.1f}, observed = {:.1f}'.format(ha_hr, dec, roll, observed))
+                
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/python/tests/unit_test_calc_utils.py
+++ b/python/tests/unit_test_calc_utils.py
@@ -62,8 +62,8 @@ class UnitTestCalcUtils(unittest.TestCase):
             dec_degs = [90, 60, 51, 30, 0, -30,
                         90, 60, 51, 30, 0, -30]
             # Expected values
-            expected_roll_degs = [124.0807, 74.1037, -79.9949, -98.92265, -60.2643, -131.5124, 
-                                -124.0807, -74.1037, 79.9949, 98.92265, 60.2643, 131.5124]
+            expected_roll_degs = [60.0, 102.0225, -65.8349, -46.5828, -35.0417, -33.2790, 
+                                  -60.0, -102.0226, 65.8349, 46.5828, 35.04173, 33.27898]
 
             for ha, dec, expected in zip(ha_degs, dec_degs, expected_roll_degs):
                 roll = hadec_to_roll(ha, dec, lat_deg)

--- a/python/tests/unit_test_calc_utils.py
+++ b/python/tests/unit_test_calc_utils.py
@@ -93,7 +93,7 @@ class UnitTestCalcUtils(unittest.TestCase):
 
     # Test Skyfield_utils:
 
-    def test_set_location(self):
+    def test_sf_set_location(self):
         """ 
         Unit test Skyfield_utils.set_location() and Skyfield_utils.get_latlon()
         setting and reading back latitude & logitude.
@@ -110,7 +110,7 @@ class UnitTestCalcUtils(unittest.TestCase):
         self.assertAlmostEqual(lon_deg, expected_lon_deg, places=3)
 
 
-    def test_get_lst_hrs(self):
+    def test_sf_get_lst_hrs(self):
         """ 
         Unit test Skyfield_utils.get_lst_hrs() against logged data 
         during observation.
@@ -130,7 +130,7 @@ class UnitTestCalcUtils(unittest.TestCase):
         self.assertAlmostEqual(lst_hrs, expected_lst_hrs, places=1)
 
 
-    def test_ra_to_ha(self):
+    def test_sf_ra_to_ha(self):
         """ 
         Unit test Skyfield_utils.ra_to_ha() against logged data during observation.
         """
@@ -151,7 +151,7 @@ class UnitTestCalcUtils(unittest.TestCase):
 
 
 
-    def test_radec_to_roll(self):
+    def test_sf_radec_to_roll(self):
         """ 
         Unit test Skyfield_utils.radec_to_roll() against logged data during 
         observation.

--- a/python/tests/unit_test_calc_utils.py
+++ b/python/tests/unit_test_calc_utils.py
@@ -78,13 +78,13 @@ class UnitTestCalcUtils(unittest.TestCase):
             ha_hrs = [4.1309, -3.6298, 0.3378] 
             dec_degs = [74.0515, 22.2856, 30.3246]
             # Observed values
-            observed_roll_degs = [72.0398, 62.6766, 328.6188]
+            observed_roll_degs = [72.0398, 62.6766, -31.3812]
 
             for ha_hr, dec, observed in zip(ha_hrs, dec_degs, observed_roll_degs):
                 ha = ha_hr / 12 * 180  # Convert from hr to deg
                 roll = hadec_to_roll(ha, dec, lat_deg)
-                # Roll must be within 2 degrees
-                self.assertLess(np.abs(roll - observed), 2, 
+                # Roll must be within 5 degrees
+                self.assertLess(np.abs(roll - observed), 5, 
                                     msg='HA = {:.2f} hr, dec = {:.2f}, roll = {:.1f}, observed = {:.1f}'.format(ha_hr, dec, roll, observed))
                 
 

--- a/python/tests/unit_test_calc_utils.py
+++ b/python/tests/unit_test_calc_utils.py
@@ -1,0 +1,55 @@
+""" 
+Unit tests for: PiFinder.calc_utils: Coordinate transformations, etc.
+
+Run from PiFinder/python:
+`> python -m tests.unit_test_calc_utils`
+"""
+
+import unittest
+from PiFinder.calc_utils import hadec_to_pa
+
+class UnitTestCalcUtils(unittest.TestCase):
+    """
+    Unit tests for calc_utils.py which does coordinate transformations.
+    """
+
+    def test_hadec_to_pa0(self):
+        """ Test hadec_to_pa() for the special case when HA = 0 """
+        # Define the inputs:
+        ha_deg = 0.0
+        lat_deg = 51.0  # Approximately Greenwich Observatory
+        dec_degs = [90, 60, 51, 30, 0, -30]
+        
+        # At HA = 0, expect pa = 0 or 180 deg
+        for dec in dec_degs:
+            pa_deg = hadec_to_pa(ha_deg, dec, lat_deg)
+            if dec >= lat_deg:
+                self.assertAlmostEqual(pa_deg, 180.0, places=3, 
+                                       msg='HA = 0: dec={:.1f}'.format(dec))
+            else:
+                self.assertAlmostEqual(pa_deg, 0.0, places=3, 
+                                       msg='HA = 0: dec={:.1f}'.format(dec))
+    
+"""
+    def test_hadec_to_pa(self):
+        # Define the inputs:        
+        ha_deg = 60.0
+        lat_deg = 51.0  # Approximately Greenwich Observatory
+        dec_degs = [90, 60, 51, 30, 0, -30]
+        # Expected values
+        exp_pa_degs = []
+        
+        expected_pa_degs = []  # For HA=+60 deg
+        for dec, expected in zip(dec_degs, expected_pa_degs):
+            # +ve HA case:
+            pa_deg = hadec_to_pa(ha_deg, dec, lat_deg)
+            self.assertAlmostEqual(pa_deg, expected, places=3, 
+                                   message='HA = {:.2f}, dec = {:.2f}'.format(ha_deg, dec))
+            # -ve HA case (expect -ve values):
+            pa_deg = hadec_to_pa(-ha_deg, dec, lat_deg)
+            self.assertAlmostEqual(pa_deg, -expected, places=3, 
+                                   message='HA = {:.2f}, dec = {:.2f}'.format(-ha_deg, dec))
+"""
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/tests/unit_test_calc_utils.py
+++ b/python/tests/unit_test_calc_utils.py
@@ -14,7 +14,7 @@ class UnitTestCalcUtils(unittest.TestCase):
     """
 
     def test_hadec_to_pa0(self):
-        """ Test hadec_to_pa() for the special case when HA = 0 """
+        """ Unit test hadec_to_pa() for the special case when HA = 0 """
         # Define the inputs:
         ha_deg = 0.0
         lat_deg = 51.0  # Approximately Greenwich Observatory
@@ -30,26 +30,26 @@ class UnitTestCalcUtils(unittest.TestCase):
                 self.assertAlmostEqual(pa_deg, 0.0, places=3, 
                                        msg='HA = 0: dec={:.1f}'.format(dec))
     
-"""
+
     def test_hadec_to_pa(self):
+        """ Unit test haddec_to_pa() for when HA != 0 """
         # Define the inputs:        
         ha_deg = 60.0
         lat_deg = 51.0  # Approximately Greenwich Observatory
         dec_degs = [90, 60, 51, 30, 0, -30]
-        # Expected values
-        exp_pa_degs = []
-        
-        expected_pa_degs = []  # For HA=+60 deg
+        # Expected values for +ve HA (exp. values for -ve HA are the -ves)
+        expected_pa_degs = [120.00000, 77.9774, 65.8349, 46.5827, 35.0417, 33.2789]
+
         for dec, expected in zip(dec_degs, expected_pa_degs):
             # +ve HA case:
             pa_deg = hadec_to_pa(ha_deg, dec, lat_deg)
             self.assertAlmostEqual(pa_deg, expected, places=3, 
-                                   message='HA = {:.2f}, dec = {:.2f}'.format(ha_deg, dec))
+                                   msg='HA = {:.2f}, dec = {:.2f}'.format(ha_deg, dec))
             # -ve HA case (expect -ve values):
             pa_deg = hadec_to_pa(-ha_deg, dec, lat_deg)
             self.assertAlmostEqual(pa_deg, -expected, places=3, 
-                                   message='HA = {:.2f}, dec = {:.2f}'.format(-ha_deg, dec))
-"""
+                                   msg='HA = {:.2f}, dec = {:.2f}'.format(-ha_deg, dec))
+
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
First try at resolving the roll issue. During IMU dead-reckoning, integrator.py calls calc_utils.sf_utils.radec_to_roll() to calculate the expected roll at (RA, Dec) give the observer's location and time. The roll value is saved to solved["Roll"].

The functions/methods have been unit tested but not system tested in a PiFinder. It also needs to be field tested to check it fixes the roll issue.