### PR TITLE
Fix endless logging & collect early log messages in the log file

### DIFF
--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -664,7 +664,8 @@ if __name__ == "__main__":
     try:
         datenow = datetime.datetime.now()
         log_helper = MultiprocLogging(
-            Path("pifinder_logconf.json"), Path(f"PiFinder-{datenow:%Y%m%d-%H_%M_%S}.log")
+            Path("pifinder_logconf.json"),
+            Path(f"PiFinder-{datenow:%Y%m%d-%H_%M_%S}.log"),
         )
         # MultiprocLogging.configurer(log_helper.get_initial_queue()) # BUG This leads to an endless log loop. Means we loose some logs at the moment
     except FileNotFoundError:
@@ -770,12 +771,15 @@ if __name__ == "__main__":
 
     if args.keyboard.lower() == "pi":
         from PiFinder import keyboard_pi as keyboard
+
         rlogger.info("using pi keyboard hat")
     elif args.keyboard.lower() == "local":
         from PiFinder import keyboard_local as keyboard  # type: ignore[no-redef]
+
         rlogger.info("using local keyboard")
     elif args.keyboard.lower() == "none":
         from PiFinder import keyboard_none as keyboard  # type: ignore[no-redef]
+
         rlogger.warn("using no keyboard")
 
     # if args.log:

--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -195,9 +195,6 @@ def main(
     integrator_logqueque: Queue = log_helper.get_queue()
     imu_logqueue: Queue = log_helper.get_queue()
 
-    # from logging_tree import printout
-    # printout()
-
     # Start log consolidation process first.
     log_helper.start()
 
@@ -667,7 +664,7 @@ if __name__ == "__main__":
             Path("pifinder_logconf.json"),
             Path(f"PiFinder-{datenow:%Y%m%d-%H_%M_%S}.log"),
         )
-        # MultiprocLogging.configurer(log_helper.get_initial_queue()) # BUG This leads to an endless log loop. Means we loose some logs at the moment
+        MultiprocLogging.configurer(log_helper.get_queue())
     except FileNotFoundError:
         rlogger.warning(
             "Cannot find log configuration file, proceeding with basic configuration."

--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -177,9 +177,6 @@ def main(
     # Instantiate base keyboard class for keycode
     keyboard_base = keyboard_interface.KeyboardInterface()
 
-    os_detail, platform, arch = utils.get_os_info()
-    logger.info("PiFinder running on %s, %s, %s", os_detail, platform, arch)
-
     # init queues
     console_queue: Queue = Queue()
     keyboard_queue: Queue = Queue()
@@ -198,8 +195,14 @@ def main(
     integrator_logqueque: Queue = log_helper.get_queue()
     imu_logqueue: Queue = log_helper.get_queue()
 
+    # from logging_tree import printout
+    # printout()
+
     # Start log consolidation process first.
     log_helper.start()
+
+    os_detail, platform, arch = utils.get_os_info()
+    logger.info("PiFinder running on %s, %s, %s", os_detail, platform, arch)
 
     # init UI Modes
     command_queues = {
@@ -266,7 +269,7 @@ def main(
         server_process = Process(
             name="Webserver",
             target=server.run_server,
-            args=(keyboard_queue, gps_queue, shared_state, verbose, server_logqueue),
+            args=(keyboard_queue, gps_queue, shared_state, server_logqueue, verbose),
         )
         server_process.start()
 
@@ -323,8 +326,8 @@ def main(
                 solver_queue,
                 camera_image,
                 console_queue,
-                verbose,
                 solver_logqueue,
+                verbose,
             ),
         )
         solver_process.start()
@@ -339,8 +342,8 @@ def main(
                 shared_state,
                 solver_queue,
                 console_queue,
-                verbose,
                 integrator_logqueque,
+                verbose,
             ),
         )
         integrator_process.start()
@@ -655,21 +658,23 @@ def main(
 
 if __name__ == "__main__":
     print("Boostrap logging configuration ...")
+    logging.basicConfig(format="%(asctime)s BASIC %(name)s: %(levelname)s %(message)s")
     rlogger = logging.getLogger()
+    rlogger.setLevel(logging.INFO)
     try:
+        datenow = datetime.datetime.now()
         log_helper = MultiprocLogging(
-            Path("pifinder_logconf.json"), Path("PiFinder.log")
+            Path("pifinder_logconf.json"), Path(f"PiFinder-{datenow:%Y%m%d-%H_%M_%S}.log")
         )
+        # MultiprocLogging.configurer(log_helper.get_initial_queue()) # BUG This leads to an endless log loop. Means we loose some logs at the moment
     except FileNotFoundError:
         rlogger.warning(
             "Cannot find log configuration file, proceeding with basic configuration."
         )
         rlogger.warning("Logs will not be stored on disk, unless you use --log")
-        rlogger.setLevel(logging.INFO)
         logging.getLogger("PIL.PngImagePlugin").setLevel(logging.WARNING)
         logging.getLogger("tetra3.Tetra3").setLevel(logging.WARNING)
         logging.getLogger("picamera2.picamera2").setLevel(logging.WARNING)
-        logging.basicConfig(format="%(asctime)s %(name)s: %(levelname)s %(message)s")
 
     rlogger.info("Starting PiFinder ...")
     parser = argparse.ArgumentParser(description="eFinder")
@@ -765,10 +770,13 @@ if __name__ == "__main__":
 
     if args.keyboard.lower() == "pi":
         from PiFinder import keyboard_pi as keyboard
+        rlogger.info("using pi keyboard hat")
     elif args.keyboard.lower() == "local":
         from PiFinder import keyboard_local as keyboard  # type: ignore[no-redef]
+        rlogger.info("using local keyboard")
     elif args.keyboard.lower() == "none":
         from PiFinder import keyboard_none as keyboard  # type: ignore[no-redef]
+        rlogger.warn("using no keyboard")
 
     # if args.log:
     #    datenow = datetime.datetime.now()

--- a/python/PiFinder/multiproclogging.py
+++ b/python/PiFinder/multiproclogging.py
@@ -78,7 +78,7 @@ class MultiprocLogging:
             len(self._queues) >= 1 or self._initial_queue is not None
         ), "No queues in use. You should have requested at least one queue."
         if self._initial_queue is not None:
-             self._queues.append(self._initial_queue)
+            self._queues.append(self._initial_queue)
         self._proc = Process(
             target=self._run_sink,
             args=(
@@ -160,7 +160,9 @@ class MultiprocLogging:
         log messages.
         """
         assert queue is not None, "You passed a None to configurer! You cannot do that"
-        assert isinstance(queue, multiprocessing.queues.Queue), "That's not a Queue! You have to pass a queue" 
+        assert isinstance(
+            queue, multiprocessing.queues.Queue
+        ), "That's not a Queue! You have to pass a queue"
 
         h = logging.handlers.QueueHandler(queue)
         root = logging.getLogger()

--- a/python/PiFinder/multiproclogging.py
+++ b/python/PiFinder/multiproclogging.py
@@ -7,8 +7,10 @@ Due to `logging` not being compatible out of the box with concurrency using proc
 the approach implemented here: A single process that is fed log records using `Queue`s.
 """
 
+import multiprocessing.queues
 from pathlib import Path
 from multiprocessing import Queue, Process
+import multiprocessing
 from queue import Empty
 from time import sleep
 from typing import TextIO, List, Optional
@@ -63,8 +65,11 @@ class MultiprocLogging:
         self._formatter = formatter
         self._proc: Optional[Process] = None
 
-        if log_conf is not None:
-            with open(log_conf, "r") as f:
+        self.apply_config()
+
+    def apply_config(self):
+        if self._log_conf_file is not None:
+            with open(self._log_conf_file, "r") as f:
                 self.read_config(f)
 
     def start(self, initial_queue: Optional[Queue] = None):
@@ -73,7 +78,7 @@ class MultiprocLogging:
             len(self._queues) >= 1 or self._initial_queue is not None
         ), "No queues in use. You should have requested at least one queue."
         if self._initial_queue is not None:
-            self._queues.append(self._initial_queue)
+             self._queues.append(self._initial_queue)
         self._proc = Process(
             target=self._run_sink,
             args=(
@@ -141,9 +146,10 @@ class MultiprocLogging:
         This is to catch
 
         """
-        new_queue = Queue()
-        self._initial_queue = new_queue
-        return new_queue
+        if self._initial_queue is None:
+            new_queue = Queue()
+            self._initial_queue = new_queue
+        return self._initial_queue
 
     @staticmethod
     def configurer(queue: Queue):
@@ -153,6 +159,9 @@ class MultiprocLogging:
         This method needs to be called once in each process, so that log records get forwarded to the single process writing
         log messages.
         """
+        assert queue is not None, "You passed a None to configurer! You cannot do that"
+        assert isinstance(queue, multiprocessing.queues.Queue), "That's not a Queue! You have to pass a queue" 
+
         h = logging.handlers.QueueHandler(queue)
         root = logging.getLogger()
         root.addHandler(h)

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -115,6 +115,7 @@ def solver(
                 total_tetra_time = t_extract + solved["T_solve"]
                 if total_tetra_time > 1000:
                     console_queue.put(f"SLV: Long: {total_tetra_time}")
+                    logger.warn("Long solver time: %i", total_tetra_time)
 
                 if solved["RA"] is not None:
                     # map the RA/DEC to the target pixel RA/DEC

--- a/python/logconf_default.json
+++ b/python/logconf_default.json
@@ -1,7 +1,7 @@
 {
     // Note that the JSON5 library that we use for configuration supports comments in JSON files. 
     "version": 1,
-    "disable_existing_loggers": true,
+    "disable_existing_loggers": false, // THIS MUST BE FALSE for logging to work
     "formatters": {
         "default": {
             "format": "%(asctime)s %(processName)s-%(name)s:%(levelname)s:%(message)s"
@@ -13,6 +13,10 @@
             "level": "DEBUG",
             "formatter": "default",
             "stream": "ext://sys.stdout"
+        },
+        "null": {
+            "class": "logging.NullHandler",
+            "level": "ERROR"
         }
     },
     "loggers": {
@@ -71,9 +75,9 @@
         // Supported logger hierarchy: 
         //   Solver
         //
-        // "Solver": {
-        //   "level": "DEBUG"
-        // }
+        "Solver": {
+            "level": "WARNING"
+        },
 
         /////////////////////////////////////////////////////////////////
         ////// GPS Subsystem
@@ -185,6 +189,11 @@
         },
         "picamera2.picamera2": {
             "level": "WARNING"
+        },
+        "grpc": {
+            "level": "ERROR",
+            "propagate": false,
+            "handlers": ["null"]
         },
    }
 }

--- a/python/logconf_default.json
+++ b/python/logconf_default.json
@@ -28,7 +28,7 @@
         // This is the main logging configuration
         //
         "": {
-            "level": "WARNING",
+            "level": "INFO",
             "handlers": ["console"]
             // The file handler is added automatically by code
         },

--- a/python/tests/test_multiproclogging.py
+++ b/python/tests/test_multiproclogging.py
@@ -155,3 +155,31 @@ def test_logging_before_start():
         assert "Another msg" in str
         # print(str)
         # assert False
+        
+        
+def test_basicconfig_interplay():
+    logging.getLogger().setLevel(logging.DEBUG)
+    logging.basicConfig(format="%(asctime)s BASIC %(name)s: %(levelname)s %(message)s")
+    with tempfile.TemporaryDirectory() as d:
+        log_file = os.path.join(d, "test.log")
+        Mpl = mpl.MultiprocLogging(out_file=log_file)
+
+        # Log to the initial queque before starting MultiprocLogging ...
+        q = Mpl.get_initial_queue()
+        mpl.MultiprocLogging.configurer(q)
+        logging.getLogger("before").info("A log message")
+
+        # ... then start the logging process and log something.
+        Mpl.start()
+        logging.getLogger("after").info("Another msg")
+
+        # Both messages should now be in the log file.
+        Mpl.join()
+        str = open(log_file, "r").read()
+        assert "before" in str
+        assert "after" in str
+        assert "A log message" in str
+        assert "Another msg" in str
+        # print(str)
+        # assert False
+

--- a/python/tests/test_multiproclogging.py
+++ b/python/tests/test_multiproclogging.py
@@ -131,14 +131,14 @@ def test_2logs_2procs():
         # assert False
 
 
-def test_logging_before_start():
+def test_beforestart():
     logging.getLogger().setLevel(logging.DEBUG)
     with tempfile.TemporaryDirectory() as d:
         log_file = os.path.join(d, "test.log")
         Mpl = mpl.MultiprocLogging(out_file=log_file)
 
         # Log to the initial queque before starting MultiprocLogging ...
-        q = Mpl.get_initial_queue()
+        q = Mpl.get_queue()
         mpl.MultiprocLogging.configurer(q)
         logging.getLogger("before").info("A log message")
 
@@ -155,31 +155,3 @@ def test_logging_before_start():
         assert "Another msg" in str
         # print(str)
         # assert False
-        
-        
-def test_basicconfig_interplay():
-    logging.getLogger().setLevel(logging.DEBUG)
-    logging.basicConfig(format="%(asctime)s BASIC %(name)s: %(levelname)s %(message)s")
-    with tempfile.TemporaryDirectory() as d:
-        log_file = os.path.join(d, "test.log")
-        Mpl = mpl.MultiprocLogging(out_file=log_file)
-
-        # Log to the initial queque before starting MultiprocLogging ...
-        q = Mpl.get_initial_queue()
-        mpl.MultiprocLogging.configurer(q)
-        logging.getLogger("before").info("A log message")
-
-        # ... then start the logging process and log something.
-        Mpl.start()
-        logging.getLogger("after").info("Another msg")
-
-        # Both messages should now be in the log file.
-        Mpl.join()
-        str = open(log_file, "r").read()
-        assert "before" in str
-        assert "after" in str
-        assert "A log message" in str
-        assert "Another msg" in str
-        # print(str)
-        # assert False
-


### PR DESCRIPTION
There was a bug in Multiproclogging that could lead to an endless loop: 
 - logger.handle() was called for elements in the queue
 - which lead to an additional entry in the queue.

This is now fixed, by removing all handlers in the logging process and then creating a filehandler for writing to the logfile.