### PR TITLE
Compensate for roll offset (rebased) #192

### DIFF
--- a/python/PiFinder/calc_utils.py
+++ b/python/PiFinder/calc_utils.py
@@ -48,7 +48,9 @@ class FastAltAz:
             self.lat * math.pi / 180
         ) + math.cos(dec * math.pi / 180) * math.cos(
             self.lat * math.pi / 180
-        ) * math.cos(hour_angle * math.pi / 180)
+        ) * math.cos(
+            hour_angle * math.pi / 180
+        )
 
         alt = math.asin(_alt) * 180 / math.pi
         if alt_only:

--- a/python/PiFinder/calc_utils.py
+++ b/python/PiFinder/calc_utils.py
@@ -227,7 +227,7 @@ def hadec_to_roll(ha_deg, dec_deg, lat_deg):
     The roll or the field rotation angle, as returned by the Tetra3 solver,
     describes how much the source (S) is rotated on the sky as seen by and
     the observer. The roll measures the same angle as the parallactic but
-    measured with a different orientation. See ha_dec2pa() for explanation of
+    measured with a different orientation. See hadec_to_pa() for explanation of
     the parallactic angle. The roll is positive for anti-clockwise rotation of
     ZS to PS when looking out towards the sky.
 

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -109,7 +109,7 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                     )
                     solved["Alt"] = alt
                     solved["Az"] = az
-                    # Estimate the roll offset due misalignment of the 
+                    # Estimate the roll offset due misalignment of the
                     # camera sensor with the mount/scope axis
                     roll_offset = estimate_roll_offset(solved, dt)
 
@@ -153,9 +153,12 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                             )
 
                             # Find the roll at the target RA/Dec
-                            solved["Roll"] = calc_utils.sf_utils.radec_to_roll(
-                                solved["RA"], solved["Dec"], dt
-                            ) + roll_offset
+                            solved["Roll"] = (
+                                calc_utils.sf_utils.radec_to_roll(
+                                    solved["RA"], solved["Dec"], dt
+                                )
+                                + roll_offset
+                            )
 
                             solved["solve_time"] = time.time()
                             solved["solve_source"] = "IMU"
@@ -179,7 +182,7 @@ def estimate_roll_offset(solved, dt):
     """
     Estimate the roll offset due to misalignment of the camera sensor with
     the mount/scope's coordinate system. The offset is calculated at the
-    center of the camera's FoV. 
+    center of the camera's FoV.
 
     To calculate the roll with offset: roll = calculated_roll + roll_offset
     """
@@ -187,7 +190,7 @@ def estimate_roll_offset(solved, dt):
     # of the camera center.
     roll_camera_calculated = calc_utils.sf_utils.radec_to_roll(
         solved["RA_camera"], solved["Dec_camera"], dt
-        )
+    )
     roll_offset = solved["Roll_camera"] - roll_camera_calculated
 
     return roll_offset

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -56,7 +56,7 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
             "RA_camera": None,
             "Dec_camera": None,
             "Roll_camera": None,
-            # "Roll_offset": 0,  # May/may not be needed
+            "Roll_offset": 0,  # May/may not be needed - for experimentation
             "imu_pos": None,
             "Alt": None,
             "Az": None,
@@ -120,12 +120,10 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                         solved["RA"], solved["Dec"], dt
                     )
 
-                    # Disabled: Not including the Roll_offset to display the roll because
-                    # it's probably better to show the roll relative to the pole?
-                    # #
+                    # Experimental: For monitoring roll offset
                     # Estimate the roll offset due misalignment of the
                     # camera sensor with the mount/scope axis
-                    # solved["Roll_offset"] = estimate_roll_offset(solved, dt)
+                    solved["Roll_offset"] = estimate_roll_offset(solved, dt)
 
                 last_image_solve = copy.copy(solved)
                 solved["solve_source"] = "CAM"

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -60,6 +60,7 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
             "cam_solve_time": 0,
             "constellation": None,
         }
+        roll_offset = 0
         cfg = config.Config()
         if (
             cfg.get_option("screen_direction") == "left"
@@ -108,6 +109,9 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                     )
                     solved["Alt"] = alt
                     solved["Az"] = az
+                    # Estimate the roll offset due misalignment of the 
+                    # camera sensor with the mount/scope axis
+                    roll_offset = estimate_roll_offset(solved, dt)
 
                 last_image_solve = copy.copy(solved)
                 solved["solve_source"] = "CAM"
@@ -148,10 +152,10 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                                 solved["Alt"], solved["Az"], dt
                             )
 
-                            # Find the roll from the RA/Dec and time
+                            # Find the roll at the target RA/Dec
                             solved["Roll"] = calc_utils.sf_utils.radec_to_roll(
                                 solved["RA"], solved["Dec"], dt
-                            )
+                            ) + roll_offset
 
                             solved["solve_time"] = time.time()
                             solved["solve_source"] = "IMU"
@@ -169,3 +173,21 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                 shared_state.set_solve_state(True)
     except EOFError:
         logger.error("Main no longer running for integrator")
+
+
+def estimate_roll_offset(solved, dt):
+    """
+    Estimate the roll offset due to misalignment of the camera sensor with
+    the mount/scope's coordinate system. The offset is calculated at the
+    center of the camera's FoV. 
+
+    To calculate the roll with offset: roll = calculated_roll + roll_offset
+    """
+    # Calculate the expected roll at the camera center given the RA/Dec of
+    # of the camera center.
+    roll_camera_calculated = calc_utils.sf_utils.radec_to_roll(
+        solved["RA_camera"], solved["Dec_camera"], dt
+        )
+    roll_offset = solved["Roll_camera"] - roll_camera_calculated
+
+    return roll_offset

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -52,6 +52,11 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
         solved = {
             "RA": None,
             "Dec": None,
+            "Roll": None,
+            "RA_camera": None,
+            "Dec_camera": None,
+            "Roll_camera": None,
+            "Roll_offset": 0,
             "imu_pos": None,
             "Alt": None,
             "Az": None,
@@ -60,7 +65,6 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
             "cam_solve_time": 0,
             "constellation": None,
         }
-        roll_offset = 0
         cfg = config.Config()
         if (
             cfg.get_option("screen_direction") == "left"
@@ -111,7 +115,7 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                     solved["Az"] = az
                     # Estimate the roll offset due misalignment of the
                     # camera sensor with the mount/scope axis
-                    roll_offset = estimate_roll_offset(solved, dt)
+                    solved["Roll_offset"] = estimate_roll_offset(solved, dt)
 
                 last_image_solve = copy.copy(solved)
                 solved["solve_source"] = "CAM"
@@ -157,7 +161,7 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                                 calc_utils.sf_utils.radec_to_roll(
                                     solved["RA"], solved["Dec"], dt
                                 )
-                                + roll_offset
+                                + solved["Roll_offset"]
                             )
 
                             solved["solve_time"] = time.time()

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -56,7 +56,7 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
             "RA_camera": None,
             "Dec_camera": None,
             "Roll_camera": None,
-            #"Roll_offset": 0,  # May/may not be needed
+            # "Roll_offset": 0,  # May/may not be needed
             "imu_pos": None,
             "Alt": None,
             "Az": None,
@@ -115,17 +115,17 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                     solved["Az"] = az
                     # Find the roll at the target RA/Dec. Note that this doesn't include the
                     # roll offset so it's not the roll that the PiFinder camear sees but the
-                    # roll relative to the celestial pole 
+                    # roll relative to the celestial pole
                     solved["Roll"] = calc_utils.sf_utils.radec_to_roll(
-                            solved["RA"], solved["Dec"], dt
-                        )
-                    
+                        solved["RA"], solved["Dec"], dt
+                    )
+
                     # Disabled: Not including the Roll_offset to display the roll because
                     # it's probably better to show the roll relative to the pole?
-                    # # 
+                    # #
                     # Estimate the roll offset due misalignment of the
                     # camera sensor with the mount/scope axis
-                    #solved["Roll_offset"] = estimate_roll_offset(solved, dt)
+                    # solved["Roll_offset"] = estimate_roll_offset(solved, dt)
 
                 last_image_solve = copy.copy(solved)
                 solved["solve_source"] = "CAM"
@@ -166,10 +166,10 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                                 solved["Alt"], solved["Az"], dt
                             )
 
-                            # Find the roll at the target RA/Dec. 
+                            # Find the roll at the target RA/Dec.
                             solved["Roll"] = calc_utils.sf_utils.radec_to_roll(
-                                    solved["RA"], solved["Dec"], dt
-                                )
+                                solved["RA"], solved["Dec"], dt
+                            )
 
                             solved["solve_time"] = time.time()
                             solved["solve_source"] = "IMU"

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -200,6 +200,6 @@ def estimate_roll_offset(solved, dt):
     roll_camera_calculated = calc_utils.sf_utils.radec_to_roll(
         solved["RA_camera"], solved["Dec_camera"], dt
     )
-    roll_offset = solved["Roll_camera"] - roll_camera_calculated
+    roll_offset = roll_camera_calculated - solved["Roll_camera"]
 
     return roll_offset

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -200,6 +200,6 @@ def estimate_roll_offset(solved, dt):
     roll_camera_calculated = calc_utils.sf_utils.radec_to_roll(
         solved["RA_camera"], solved["Dec_camera"], dt
     )
-    roll_offset = roll_camera_calculated - solved["Roll_camera"]
+    roll_offset = solved["Roll_camera"] - roll_camera_calculated
 
     return roll_offset

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -56,7 +56,7 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
             "RA_camera": None,
             "Dec_camera": None,
             "Roll_camera": None,
-            "Roll_offset": 0,
+            #"Roll_offset": 0,  # May/may not be needed
             "imu_pos": None,
             "Alt": None,
             "Az": None,
@@ -113,9 +113,19 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                     )
                     solved["Alt"] = alt
                     solved["Az"] = az
+                    # Find the roll at the target RA/Dec. Note that this doesn't include the
+                    # roll offset so it's not the roll that the PiFinder camear sees but the
+                    # roll relative to the celestial pole 
+                    solved["Roll"] = calc_utils.sf_utils.radec_to_roll(
+                            solved["RA"], solved["Dec"], dt
+                        )
+                    
+                    # Disabled: Not including the Roll_offset to display the roll because
+                    # it's probably better to show the roll relative to the pole?
+                    # # 
                     # Estimate the roll offset due misalignment of the
                     # camera sensor with the mount/scope axis
-                    solved["Roll_offset"] = estimate_roll_offset(solved, dt)
+                    #solved["Roll_offset"] = estimate_roll_offset(solved, dt)
 
                 last_image_solve = copy.copy(solved)
                 solved["solve_source"] = "CAM"
@@ -156,13 +166,10 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                                 solved["Alt"], solved["Az"], dt
                             )
 
-                            # Find the roll at the target RA/Dec
-                            solved["Roll"] = (
-                                calc_utils.sf_utils.radec_to_roll(
+                            # Find the roll at the target RA/Dec. 
+                            solved["Roll"] = calc_utils.sf_utils.radec_to_roll(
                                     solved["RA"], solved["Dec"], dt
                                 )
-                                + solved["Roll_offset"]
-                            )
 
                             solved["solve_time"] = time.time()
                             solved["solve_source"] = "IMU"

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -35,8 +35,14 @@ def solver(
     )
     last_solve_time = 0
     solved = {
+        # RA, Dec, Roll solved at the center of the camera FoV:
+        "RA_camera": None,
+        "Dec_camera": None,
+        "Roll_camera": None,
+        # RA, Dec, Roll at the target pixel
         "RA": None,
         "Dec": None,
+        "Roll": None,
         "imu_pos": None,
         "solve_time": None,
         "cam_solve_time": 0,
@@ -119,9 +125,14 @@ def solver(
                     logger.warn("Long solver time: %i", total_tetra_time)
 
                 if solved["RA"] is not None:
-                    # map the RA/DEC to the target pixel RA/DEC
-                    solved["RA"] = solved["RA_target"]
+                    # RA, Dec, Roll at the center of the camera's FoV:
+                    solved["RA_camera"] = solved["RA"]
+                    solved["Dec_camera"] = solved["Dec"]
+                    solved["Roll_camera"] = solved["Roll"]
+                    # RA, Dec, Roll at the target pixel:
+                    solved["RA"] = solved["RA_target"]  
                     solved["Dec"] = solved["Dec_target"]
+                    solved["Roll"] = None  # To be calculated in integrator.py
                     if last_image_metadata["imu"]:
                         solved["imu_pos"] = last_image_metadata["imu"]["pos"]
                         solved["imu_quat"] = last_image_metadata["imu"]["quat"]

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -130,7 +130,7 @@ def solver(
                     solved["Dec_camera"] = solved["Dec"]
                     solved["Roll_camera"] = solved["Roll"]
                     # RA, Dec, Roll at the target pixel:
-                    solved["RA"] = solved["RA_target"]  
+                    solved["RA"] = solved["RA_target"]
                     solved["Dec"] = solved["Dec_target"]
                     solved["Roll"] = None  # To be calculated in integrator.py
                     if last_image_metadata["imu"]:


### PR DESCRIPTION
Compensates for the roll offset between the roll seen by the camera and the expected roll at the (RA, Dec). This should also fix issue https://github.com/brickbots/PiFinder/issues/117.

The roll at the camera center is different from the roll at the target pixel. To address this, the (RA, Dec, Roll) at the camera center get stored as solution["RA_camera"], solution["Dec_camera"] and solution["Roll_camera"]. The coordinates at the target pixels are still the same: solution["RA"], etc.

The roll offset is calculated at the camera center in integrator.py and stored as solution["Roll_offset"] every plate solve. solution["Roll"] at the target is calculated from the expected roll at the target (RA, Dec) and compensated with the Roll_offset.

This should display the constellation with the correct roll as seen by an observer. This PR hasn't been system-tested on a PiFinder or field-tested. It's possible that the sign for the roll_offset is the wrong way round. If so, this can be changed in integrator.estimate_roll_offset().