### PR TITLE
Fix missing roll from plate-only solves

### DIFF
--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -132,7 +132,6 @@ def solver(
                     # RA, Dec, Roll at the target pixel:
                     solved["RA"] = solved["RA_target"]
                     solved["Dec"] = solved["Dec_target"]
-                    solved["Roll"] = None  # To be calculated in integrator.py
                     if last_image_metadata["imu"]:
                         solved["imu_pos"] = last_image_metadata["imu"]["pos"]
                         solved["imu_quat"] = last_image_metadata["imu"]["quat"]


### PR DESCRIPTION
This was set to none to make it obvious when it was not being calculated from alt/az info... but it meant the chart would not update with only a solve but required GPS as well.

Now roll is set to camera_roll initially and is overridden if there is a calculated roll.