### PR TITLE
Add User Observing Equipment Config

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -49,43 +49,26 @@
             {
                 "make": "Generic",
                 "name": "Plossl",
-                "focal_length": 25,
+                "focal_length_mm": 25,
                 "afov": 50,
                 "field_stop": 21.2
             },
             {
                 "make": "Generic",
                 "name": "Plossl",
-                "focal_length": 11,
+                "focal_length_mm": 11,
                 "afov": 50,
                 "field_stop": 9.1
             },
             {
                 "make": "Generic",
                 "name": "Plossl",
-                "focal_length": 8,
+                "focal_length_mm": 8,
                 "afov": 50,
                 "field_stop": 6.5
             }
         ],
-        "active_telescope": {
-            "make": "Generic",
-            "name": "Dobsonian",
-            "aperture_mm": 200,
-            "focal_length_mm": 1000,
-            "obstruction_perc": 17.0,
-            "mount_type": "alt/az",
-            "flip_image": false,
-            "flop_image": true,
-            "reverse_arrow_a": false,
-            "reverse_arrow_b": false
-        },
-        "active_eyepiece": {
-            "make": "Generic",
-            "name": "Plossl",
-            "focal_length": 25,
-            "afov": 50,
-            "field_stop": 21.2
-        }
+        "active_telescope_index": 0,
+        "active_eyepiece_index": 0
     }
 }

--- a/default_config.json
+++ b/default_config.json
@@ -29,5 +29,63 @@
         "Str",
         "PL",
         "RDS"
-    ]
+    ],
+    "equipment": {
+        "telescopes": [
+            {
+                "make": "Generic",
+                "name": "Dobsonian",
+                "aperture_mm": 200,
+                "focal_length_mm": 1000,
+                "obstruction_perc": 17.0,
+                "mount_type": "alt/az",
+                "flip_image": false,
+                "flop_image": true,
+                "reverse_arrow_a": false,
+                "reverse_arrow_b": false
+            }
+        ],
+        "eyepieces": [
+            {
+                "make": "Generic",
+                "name": "Plossl",
+                "focal_length": 25,
+                "afov": 50,
+                "field_stop": 21.2
+            },
+            {
+                "make": "Generic",
+                "name": "Plossl",
+                "focal_length": 11,
+                "afov": 50,
+                "field_stop": 9.1
+            },
+            {
+                "make": "Generic",
+                "name": "Plossl",
+                "focal_length": 8,
+                "afov": 50,
+                "field_stop": 6.5
+            }
+        ],
+        "active_telescope": {
+            "make": "Generic",
+            "name": "Dobsonian",
+            "aperture_mm": 200,
+            "focal_length_mm": 1000,
+            "obstruction_perc": 17.0,
+            "mount_type": "alt/az",
+            "flip_image": false,
+            "flop_image": true,
+            "reverse_arrow_a": false,
+            "reverse_arrow_b": false
+        },
+        "active_eyepiece": {
+            "make": "Generic",
+            "name": "Plossl",
+            "focal_length": 25,
+            "afov": 50,
+            "field_stop": 21.2
+        }
+    }
 }

--- a/python/PiFinder/config.py
+++ b/python/PiFinder/config.py
@@ -7,7 +7,7 @@ This module handles non-volatile config options
 import json
 import os
 from pathlib import Path
-from PiFinder import utils
+from PiFinder import utils, equipment
 from typing import Any
 
 
@@ -33,6 +33,19 @@ class Config:
         # Set up session config items
         # These are transient
         self._session_config_dict = {}
+
+        # Load the equipment config
+        eq_config = self.get_option("equipment")
+        if eq_config is None:
+            self.equipment = equipment.Equipment(telescopes=[], eyepieces=[])
+        else:
+            self.equipment = equipment.Equipment.from_dict(eq_config)
+
+    def save_equipment(self):
+        """
+        Saves the equipment object state
+        """
+        self.set_option("equipment", self.equipment.to_dict())
 
     def dump_config(self):
         """

--- a/python/PiFinder/equipment.py
+++ b/python/PiFinder/equipment.py
@@ -7,9 +7,9 @@ from typing import Union
 class Eyepiece:
     make: str
     name: str
-    focal_length: int
+    focal_length_mm: int
     afov: int
-    field_stop: float
+    field_stop: float = 0
 
 
 @dataclass
@@ -31,5 +31,72 @@ class Telescope:
 class Equipment:
     telescopes: list[Telescope]
     eyepieces: list[Eyepiece]
-    active_telescope: Union[None, Telescope] = None
-    active_eyepiece: Union[None, Eyepiece] = None
+    active_telescope_index: Union[None, int] = None
+    active_eyepiece_index: Union[None, int] = None
+
+    def set_active_telescope(self, telescope: Telescope):
+        self.active_telescope_index = self.telescopes.index(telescope)
+
+    def set_active_eyepiece(self, eyepiece: Eyepiece):
+        self.active_eyepiece_index = self.eyepieces.index(eyepiece)
+
+    @property
+    def active_telescope(self):
+        try:
+            return self.telescopes[self.active_telescope_index]
+        except (IndexError, TypeError):
+            return None
+
+    @property
+    def active_eyepiece(self):
+        try:
+            return self.eyepieces[self.active_eyepiece_index]
+        except (IndexError, TypeError):
+            return None
+
+    def calc_magnification(
+        self,
+        telescope: Union[None, Telescope] = None,
+        eyepiece: Union[None, Eyepiece] = None,
+    ) -> float:
+        """
+        Returns calculated magnification for a specific telescope/eyepiece combination
+        If no telescope or eyepiece are provided, use the current active selections
+
+        returns -1 if unable to calculate
+        """
+        if telescope is None:
+            telescope = self.active_telescope
+
+        if eyepiece is None:
+            eyepiece = self.active_eyepiece
+
+        if eyepiece is None or telescope is None:
+            return -1
+
+        return telescope.focal_length_mm / eyepiece.focal_length_mm
+
+    def calc_tfov(
+        self,
+        telescope: Union[None, Telescope] = None,
+        eyepiece: Union[None, Eyepiece] = None,
+    ) -> float:
+        """
+        Returns calculated true field of view for a specific telescope/eyepiece combination
+        If no telescope or eyepiece are provided, use the current active selections
+
+        returns -1 if unable to calculate
+        """
+        if telescope is None:
+            telescope = self.active_telescope
+
+        if eyepiece is None:
+            eyepiece = self.active_eyepiece
+
+        if eyepiece is None or telescope is None:
+            return -1
+
+        if eyepiece.field_stop == 0:
+            return eyepiece.afov / self.calc_magnification(telescope, eyepiece)
+        else:
+            return eyepiece.field_stop / telescope.focal_length_mm * 57.2958

--- a/python/PiFinder/equipment.py
+++ b/python/PiFinder/equipment.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from dataclasses_json import dataclass_json
+from typing import Union
+
+
+@dataclass
+class Eyepiece:
+    make: str
+    name: str
+    focal_length: int
+    afov: int
+    field_stop: float
+
+
+@dataclass
+class Telescope:
+    make: str
+    name: str
+    aperture_mm: int
+    focal_length_mm: int
+    obstruction_perc: float
+    mount_type: str
+    flip_image: bool
+    flop_image: bool
+    reverse_arrow_a: bool
+    reverse_arrow_b: bool
+
+
+@dataclass_json
+@dataclass
+class Equipment:
+    telescopes: list[Telescope]
+    eyepieces: list[Eyepiece]
+    active_telescope: Union[None, Telescope] = None
+    active_eyepiece: Union[None, Eyepiece] = None

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,6 +2,7 @@ adafruit-blinka==8.12.0
 adafruit-circuitpython-bno055
 bottle==0.12.25
 cheroot==10.0.0
+dataclasses_json==0.6.7
 gpsdclient==1.3.2
 grpcio==1.60.0
 json5==0.9.25


### PR DESCRIPTION
Added Telescope and Eyepiece dataclass 
Added Equipment class containing a list of Telescopes and Eyepieces + active_telescope and active_eyepiece attributes.

Modified Config object to load/save/instantiate Equipment class.  Having the Config class hold this should make it avialble pretty universally and ties into the existing config file system.

Added some default equipment to the default_config.json file (200mm f5 dob + selection of Plossl eyepieces).

Todo:
- [x] Add some functions to compute eyepiece/telescope params, like True Field of View, Magnification, etc.