### PR TITLE
Equipment 

### DIFF
--- a/python/PiFinder/equipment.py
+++ b/python/PiFinder/equipment.py
@@ -7,7 +7,7 @@ from typing import Union
 class Eyepiece:
     make: str
     name: str
-    focal_length_mm: int
+    focal_length_mm: float
     afov: int
     field_stop: float = 0
 

--- a/python/PiFinder/server.py
+++ b/python/PiFinder/server.py
@@ -5,7 +5,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 
-import pydeepskylog as pds  # type: ignore[no-redef]
+import pydeepskylog as pds
 from PIL import Image
 from PiFinder import utils, calc_utils, config
 from PiFinder.db.observations_db import (
@@ -374,7 +374,7 @@ class Server:
                         aperture_mm=int(instrument["diameter"]),
                         focal_length_mm=int(instrument["diameter"] * instrument["fd"]),
                         obstruction_perc=0,
-                        mount_type="",
+                        mount_type="alt/az",
                         flip_image=flip,
                         flop_image=flop,
                         reverse_arrow_a=False,

--- a/python/PiFinder/server.py
+++ b/python/PiFinder/server.py
@@ -1,9 +1,18 @@
-import logging
 import io
-import uuid
 import json
-from datetime import datetime, timezone
+import logging
 import time
+import uuid
+from datetime import datetime, timezone
+
+import pydeepskylog as pds  # type: ignore[no-redef]
+from PIL import Image
+from PiFinder import utils, calc_utils, config
+from PiFinder.db.observations_db import (
+    ObservationsDatabase,
+)
+from PiFinder.equipment import Telescope, Eyepiece
+from PiFinder.keyboard_interface import KeyboardInterface
 from PiFinder.multiproclogging import MultiprocLogging
 from bottle import (
     Bottle,
@@ -17,13 +26,6 @@ from bottle import (
     CherootServer,
 )
 
-from PIL import Image
-
-from PiFinder.keyboard_interface import KeyboardInterface
-from PiFinder import utils, calc_utils
-from PiFinder.db.observations_db import (
-    ObservationsDatabase,
-)
 sys_utils = utils.get_sys_utils()
 
 logger = logging.getLogger("Server")
@@ -147,7 +149,7 @@ class Server:
             password = request.forms.get("password")
             origin_url = request.forms.get("origin_url", "/")
             if sys_utils.verify_password("pifinder", password):
-                # set auth cookie, doesnt matter whats in it, just as long
+                # set auth cookie, doesn't matter what's in it, just as long
                 # as it's there and cryptographically valid
                 response.set_cookie("pf_auth", str(uuid.uuid4()), secret=SESSION_SECRET)
                 redirect(origin_url)
@@ -292,6 +294,234 @@ class Server:
             """
             sys_utils.restart_pifinder()
             return "restarting"
+
+        @app.route("/equipment")
+        @auth_required
+        def equipment():
+            return template("equipment", equipment=config.Config().equipment)
+
+        @app.route("/equipment/set_active_instrument/<instrument_id:int>")
+        @auth_required
+        def set_active_instrument(instrument_id: int):
+            cfg = config.Config()
+            cfg.equipment.set_active_telescope(cfg.equipment.telescopes[instrument_id])
+            cfg.save_equipment()
+            return template(
+                "equipment",
+                equipment=cfg.equipment,
+                success_message=cfg.equipment.active_telescope.make
+                + " "
+                + cfg.equipment.active_telescope.name
+                + " set as active instrument.",
+            )
+
+        @app.route("/equipment/set_active_eyepiece/<eyepiece_id:int>")
+        @auth_required
+        def set_active_eyepiece(eyepiece_id: int):
+            cfg = config.Config()
+            cfg.equipment.set_active_eyepiece(cfg.equipment.eyepieces[eyepiece_id])
+            cfg.save_equipment()
+            return template(
+                "equipment",
+                equipment=cfg.equipment,
+                success_message=cfg.equipment.active_eyepiece.make
+                + " "
+                + cfg.equipment.active_eyepiece.name
+                + " set as active eyepiece.",
+            )
+
+        @app.route("/equipment/import_from_deepskylog", method="post")
+        @auth_required
+        def equipment_import():
+            username = request.forms.get("dsl_name")
+            cfg = config.Config()
+            if username:
+                instruments = pds.dsl_instruments(username)
+                for instrument in instruments:
+                    if instrument["type"] == 0:
+                        # Skip the naked eye
+                        continue
+
+                    # Convert the html special characters (ampersand, quote, ...) in instrument["name"]
+                    # to the corresponding character
+                    instrument["name"] = instrument["name"].replace("&amp;", "&")
+                    instrument["name"] = instrument["name"].replace("&quot;", '"')
+                    instrument["name"] = instrument["name"].replace("&apos;", "'")
+                    instrument["name"] = instrument["name"].replace("&lt;", "<")
+                    instrument["name"] = instrument["name"].replace("&gt;", ">")
+
+                    flip = False
+                    flop = False
+
+                    if (
+                        instrument["type"] == 2
+                        or instrument["type"] == 4
+                        or instrument["type"] == 6
+                        or instrument["type"] == 8
+                        or instrument["type"] == 9
+                    ):
+                        # Refractor (2), Finderscope (4), Cassegrain (6), Maksutov (8), Schmidt Cassegrain (9)
+                        flip = True
+                        flop = False
+                    elif instrument["type"] == 3 or instrument["type"] == 7:
+                        # Reflector (3), Kutter (7)
+                        flip = True
+                        flop = True
+
+                    new_instrument = Telescope(
+                        make="",
+                        name=instrument["name"],
+                        aperture_mm=int(instrument["diameter"]),
+                        focal_length_mm=int(instrument["diameter"] * instrument["fd"]),
+                        obstruction_perc=0,
+                        mount_type="",
+                        flip_image=flip,
+                        flop_image=flop,
+                        reverse_arrow_a=False,
+                        reverse_arrow_b=False,
+                    )
+                    try:
+                        cfg.equipment.telescopes.index(new_instrument)
+                    except ValueError:
+                        cfg.equipment.telescopes.append(new_instrument)
+
+                # Add the eyepieces from deepskylog
+                eyepieces = pds.dsl_eyepieces(username)
+                for eyepiece in eyepieces:
+                    # Convert the html special characters (ampersand, quote, ...) in eyepiece["name"]
+                    # to the corresponding character
+                    eyepiece["name"] = eyepiece["name"].replace("&amp;", "&")
+                    eyepiece["name"] = eyepiece["name"].replace("&quot;", '"')
+                    eyepiece["name"] = eyepiece["name"].replace("&apos;", "'")
+                    eyepiece["name"] = eyepiece["name"].replace("&lt;", "<")
+                    eyepiece["name"] = eyepiece["name"].replace("&gt;", ">")
+
+                    new_eyepiece = Eyepiece(
+                        make="",
+                        name=eyepiece["name"],
+                        focal_length_mm=float(eyepiece["focalLength"]),
+                        afov=int(eyepiece["apparentFOV"]),
+                        field_stop=0.0,
+                    )
+                    try:
+                        cfg.equipment.eyepieces.index(new_eyepiece)
+                    except ValueError:
+                        cfg.equipment.eyepieces.append(new_eyepiece)
+
+                cfg.save_equipment()
+            return template("equipment", equipment=config.Config().equipment)
+
+        @app.route("/equipment/edit_eyepiece/<eyepiece_id:int>")
+        @auth_required
+        def edit_eyepiece(eyepiece_id: int):
+            if eyepiece_id >= 0:
+                eyepiece = config.Config().equipment.eyepieces[eyepiece_id]
+            else:
+                eyepiece = Eyepiece(
+                    make="", name="", focal_length_mm=0, afov=0, field_stop=0
+                )
+
+            return template("edit_eyepiece", eyepiece=eyepiece, eyepiece_id=eyepiece_id)
+
+        @app.route("/equipment/add_eyepiece/<eyepiece_id:int>", method="post")
+        @auth_required
+        def equipment_add_eyepiece(eyepiece_id: int):
+            cfg = config.Config()
+
+            try:
+                eyepiece = Eyepiece(
+                    make=request.forms.get("make"),
+                    name=request.forms.get("name"),
+                    focal_length_mm=float(request.forms.get("focal_length_mm")),
+                    afov=int(request.forms.get("afov")),
+                    field_stop=float(request.forms.get("field_stop")),
+                )
+
+                if eyepiece_id >= 0:
+                    cfg.equipment.eyepieces[eyepiece_id] = eyepiece
+                else:
+                    try:
+                        index = cfg.equipment.telescopes.index(eyepiece)
+                        cfg.equipment.eyepieces[index] = eyepiece
+                    except ValueError:
+                        cfg.equipment.eyepieces.append(eyepiece)
+
+                cfg.save_equipment()
+            except Exception as e:
+                logger.error(f"Error adding eyepiece: {e}")
+
+            return template("equipment", equipment=config.Config().equipment)
+
+        @app.route("/equipment/delete_eyepiece/<eyepiece_id:int>")
+        @auth_required
+        def equipment_delete_eyepiece(eyepiece_id: int):
+            cfg = config.Config()
+            cfg.equipment.eyepieces.pop(eyepiece_id)
+            cfg.save_equipment()
+            return template("equipment", equipment=config.Config().equipment)
+
+        @app.route("/equipment/edit_instrument/<instrument_id:int>")
+        @auth_required
+        def edit_instrument(instrument_id: int):
+            if instrument_id >= 0:
+                telescope = config.Config().equipment.telescopes[instrument_id]
+            else:
+                telescope = Telescope(
+                    make="",
+                    name="",
+                    aperture_mm=0,
+                    focal_length_mm=0,
+                    obstruction_perc=0,
+                    mount_type="",
+                    flip_image=False,
+                    flop_image=False,
+                    reverse_arrow_a=False,
+                    reverse_arrow_b=False,
+                )
+
+            return template(
+                "edit_instrument", telescope=telescope, instrument_id=instrument_id
+            )
+
+        @app.route("/equipment/add_instrument/<instrument_id:int>", method="post")
+        @auth_required
+        def equipment_add_instrument(instrument_id: int):
+            cfg = config.Config()
+
+            try:
+                instrument = Telescope(
+                    make=request.forms.get("make"),
+                    name=request.forms.get("name"),
+                    aperture_mm=request.forms.get("aperture"),
+                    focal_length_mm=request.forms.get("focal_length_mm"),
+                    obstruction_perc=float(request.forms.get("obstruction_perc")),
+                    mount_type=request.forms.get("mount_type"),
+                    flip_image=bool(request.forms.get("flip")),
+                    flop_image=bool(request.forms.get("flop")),
+                    reverse_arrow_a=bool(request.forms.get("reverse_arrow_a")),
+                    reverse_arrow_b=bool(request.forms.get("reverse_arrow_b")),
+                )
+                if instrument_id >= 0:
+                    cfg.equipment.telescopes[instrument_id] = instrument
+                else:
+                    try:
+                        index = cfg.equipment.telescopes.index(instrument)
+                        cfg.equipment.telescopes[index] = instrument
+                    except ValueError:
+                        cfg.equipment.telescopes.append(instrument)
+
+                cfg.save_equipment()
+            except Exception as e:
+                logger.error(f"Error adding instrument: {e}")
+            return template("equipment", equipment=config.Config().equipment)
+
+        @app.route("/equipment/delete_instrument/<instrument_id:int>")
+        @auth_required
+        def equipment_delete_instrument(instrument_id: int):
+            cfg = config.Config()
+            cfg.equipment.telescopes.pop(instrument_id)
+            cfg.save_equipment()
+            return template("equipment", equipment=config.Config().equipment)
 
         @app.route("/observations")
         @auth_required

--- a/python/PiFinder/ui/equipment.py
+++ b/python/PiFinder/ui/equipment.py
@@ -1,0 +1,89 @@
+import time
+
+from luma.core.device import sleep
+
+from PiFinder.ui.base import UIModule
+from PiFinder import utils
+from PiFinder.state_utils import sleep_for_framerate
+from PiFinder.ui.ui_utils import TextLayouter, SpaceCalculatorFixed
+from PiFinder import config
+sys_utils = utils.get_sys_utils()
+
+
+class UIEquipment(UIModule):
+    """
+    Displays various status information
+    """
+
+    __title__ = "Equipment"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def update(self, force=False):
+        sleep_for_framerate(self.shared_state)
+        cfg = config.Config()
+        self.clear_screen()
+
+        if cfg.equipment.active_telescope is None:
+            self.draw.text(
+                (10, 30),
+                "No telescope selected",
+                font=self.fonts.small.font,
+                fill=self.colors.get(128),
+            )
+        else:
+            self.draw.text(
+                (10, 30),
+                (cfg.equipment.active_telescope.make + " " + cfg.equipment.active_telescope.name).strip(),
+                font=self.fonts.small.font,
+                fill=self.colors.get(128),
+            )
+
+        if cfg.equipment.active_eyepiece is None:
+            self.draw.text(
+                (10, 50),
+                "No eyepiece selected",
+                font=self.fonts.small.font,
+                fill=self.colors.get(128),
+            )
+        else:
+            self.draw.text(
+                (10, 50),
+                (cfg.equipment.active_eyepiece.make + " " + cfg.equipment.active_eyepiece.name).strip(),
+                font=self.fonts.small.font,
+                fill=self.colors.get(128),
+            )
+
+        if cfg.equipment.active_telescope is not None and cfg.equipment.active_eyepiece is not None:
+            mag = cfg.equipment.calc_magnification()
+            if mag > 0:
+                self.draw.text(
+                    (10, 70),
+                    f"Mag: {mag:.0f}x",
+                    font=self.fonts.base.font,
+                    fill=self.colors.get(128),
+                )
+
+                tfov = cfg.equipment.calc_tfov()
+                tfov_degrees = int(tfov)
+                tfov_minutes = int((tfov - tfov_degrees) * 60)
+                self.draw.text(
+                    (10, 90),
+                    f"TFOV: {tfov_degrees:.0f}°{tfov_minutes:02.0f}'",
+                    font=self.fonts.base.font,
+                    fill=self.colors.get(128),
+                )
+        return self.screen_update()
+
+    # def key_up(self):
+    #     self.text_layout.previous()
+    #
+    # def key_down(self):
+    #     self.text_layout.next()
+
+    def active(self):
+        """
+        Called when a module becomes active
+        i.e. foreground controlling display
+        """

--- a/python/PiFinder/ui/equipment.py
+++ b/python/PiFinder/ui/equipment.py
@@ -1,12 +1,13 @@
 import time
 
-from luma.core.device import sleep
-
 from PiFinder.ui.base import UIModule
 from PiFinder import utils
 from PiFinder.state_utils import sleep_for_framerate
+from PiFinder.ui.marking_menus import MarkingMenuOption, MarkingMenu
+from PiFinder.ui.text_menu import UITextMenu
 from PiFinder.ui.ui_utils import TextLayouter, SpaceCalculatorFixed
 from PiFinder import config
+
 sys_utils = utils.get_sys_utils()
 
 
@@ -20,21 +21,86 @@ class UIEquipment(UIModule):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self.menu_index = 0  # Telescope
+        # Marking Menu - Just default help for now
+        self.marking_menu = MarkingMenu(
+            left=MarkingMenuOption(),
+            right=MarkingMenuOption(),
+            down=MarkingMenuOption(),
+        )
+
+        cfg = config.Config()
+
+        eyepieces = cfg.equipment.eyepieces
+        # Loop over eyepieces
+        eyepiece_menu_items = []
+        cnt = 0
+        for eyepiece in eyepieces:
+            eyepiece_menu_items.append(
+                {
+                    "name": eyepiece.make + " " + eyepiece.name,
+                    "value": cnt,
+                }
+            )
+            cnt += 1
+
+        self.eyepiece_menu = {
+            "name": "Eyepiece",
+            "class": UITextMenu,
+            "select": "single",
+            "config_option": "session.log_eyepiece",
+            "items": eyepiece_menu_items,
+        }
+
+        telescopes = cfg.equipment.telescopes
+        # Loop over telescopes
+        telescope_menu_items = []
+        cnt = 0
+        for telescope in telescopes:
+            telescope_menu_items.append(
+                {
+                    "name": telescope.make + " " + telescope.name,
+                    "value": cnt,
+                }
+            )
+            cnt += 1
+
+        self.telescope_menu = {
+            "name": "Telescope",
+            "class": UITextMenu,
+            "select": "single",
+            "config_option": "session.log_telescope",
+            "items": telescope_menu_items,
+        }
+
     def update(self, force=False):
         sleep_for_framerate(self.shared_state)
         cfg = config.Config()
         self.clear_screen()
 
+        selected_eyepiece = self.config_object.get_option("session.log_eyepiece", "")
+        selected_telescope = self.config_object.get_option("session.log_telescope", "")
+
+        if selected_eyepiece != "":
+            cfg.equipment.set_active_eyepiece(cfg.equipment.eyepieces[selected_eyepiece])
+            cfg.save_equipment()
+            self.config_object.set_option("session.log_eyepiece", "")
+
+        if selected_telescope != "":
+            cfg.equipment.set_active_telescope(cfg.equipment.telescopes[selected_telescope])
+            cfg.save_equipment()
+            self.config_object.set_option("session.log_telescope", "")
+
         if cfg.equipment.active_telescope is None:
             self.draw.text(
-                (10, 30),
+                (10, 20),
                 "No telescope selected",
                 font=self.fonts.small.font,
                 fill=self.colors.get(128),
             )
         else:
             self.draw.text(
-                (10, 30),
+                (10, 20),
                 (cfg.equipment.active_telescope.make + " " + cfg.equipment.active_telescope.name).strip(),
                 font=self.fonts.small.font,
                 fill=self.colors.get(128),
@@ -42,14 +108,14 @@ class UIEquipment(UIModule):
 
         if cfg.equipment.active_eyepiece is None:
             self.draw.text(
-                (10, 50),
+                (10, 35),
                 "No eyepiece selected",
                 font=self.fonts.small.font,
                 fill=self.colors.get(128),
             )
         else:
             self.draw.text(
-                (10, 50),
+                (10, 35),
                 (cfg.equipment.active_eyepiece.make + " " + cfg.equipment.active_eyepiece.name).strip(),
                 font=self.fonts.small.font,
                 fill=self.colors.get(128),
@@ -59,7 +125,7 @@ class UIEquipment(UIModule):
             mag = cfg.equipment.calc_magnification()
             if mag > 0:
                 self.draw.text(
-                    (10, 70),
+                    (10, 50),
                     f"Mag: {mag:.0f}x",
                     font=self.fonts.base.font,
                     fill=self.colors.get(128),
@@ -69,18 +135,59 @@ class UIEquipment(UIModule):
                 tfov_degrees = int(tfov)
                 tfov_minutes = int((tfov - tfov_degrees) * 60)
                 self.draw.text(
-                    (10, 90),
+                    (10, 70),
                     f"TFOV: {tfov_degrees:.0f}°{tfov_minutes:02.0f}'",
                     font=self.fonts.base.font,
                     fill=self.colors.get(128),
                 )
+
+        horiz_pos = self.display_class.titlebar_height + 70
+
+        self.draw.text(
+            (10, horiz_pos),
+            "Telescope...",
+            font=self.fonts.large.font,
+            fill=self.colors.get(192),
+        )
+        if self.menu_index == 0:
+            self.draw_menu_pointer(horiz_pos)
+
+        horiz_pos += 18
+
+        self.draw.text(
+            (10, horiz_pos),
+            "Eyepiece...",
+            font=self.fonts.large.font,
+            fill=self.colors.get(192),
+        )
+        if self.menu_index == 1:
+            self.draw_menu_pointer(horiz_pos)
+
         return self.screen_update()
 
-    # def key_up(self):
-    #     self.text_layout.previous()
-    #
-    # def key_down(self):
-    #     self.text_layout.next()
+    def key_down(self):
+        self.menu_index += 1
+        if self.menu_index > 4:
+            self.menu_index = 4
+
+    def key_up(self):
+        self.menu_index -= 1
+        if self.menu_index < 0:
+            self.menu_index = 0
+
+    def key_right(self):
+        if self.menu_index == 0:
+            self.add_to_stack(self.telescope_menu)
+        if self.menu_index == 1:
+            self.add_to_stack(self.eyepiece_menu)
+
+    def draw_menu_pointer(self, horiz_position: int):
+        self.draw.text(
+            (2, horiz_position),
+            self._RIGHT_ARROW,
+            font=self.fonts.large.font,
+            fill=self.colors.get(255),
+        )
 
     def active(self):
         """

--- a/python/PiFinder/ui/equipment.py
+++ b/python/PiFinder/ui/equipment.py
@@ -38,7 +38,7 @@ class UIEquipment(UIModule):
         for eyepiece in eyepieces:
             eyepiece_menu_items.append(
                 {
-                    "name": eyepiece.make + " " + eyepiece.name,
+                    "name": eyepiece.name,
                     "value": cnt,
                 }
             )
@@ -59,7 +59,7 @@ class UIEquipment(UIModule):
         for telescope in telescopes:
             telescope_menu_items.append(
                 {
-                    "name": telescope.make + " " + telescope.name,
+                    "name": telescope.name,
                     "value": cnt,
                 }
             )

--- a/python/PiFinder/ui/equipment.py
+++ b/python/PiFinder/ui/equipment.py
@@ -101,8 +101,8 @@ class UIEquipment(UIModule):
         else:
             self.draw.text(
                 (10, 20),
-                (cfg.equipment.active_telescope.make + " " + cfg.equipment.active_telescope.name).strip(),
-                font=self.fonts.small.font,
+                cfg.equipment.active_telescope.name.strip(),
+                font=self.fonts.base.font,
                 fill=self.colors.get(128),
             )
 
@@ -116,8 +116,8 @@ class UIEquipment(UIModule):
         else:
             self.draw.text(
                 (10, 35),
-                (cfg.equipment.active_eyepiece.make + " " + cfg.equipment.active_eyepiece.name).strip(),
-                font=self.fonts.small.font,
+                cfg.equipment.active_eyepiece.name.strip(),
+                font=self.fonts.base.font,
                 fill=self.colors.get(128),
             )
 

--- a/python/PiFinder/ui/log.py
+++ b/python/PiFinder/ui/log.py
@@ -11,6 +11,7 @@ from PiFinder import obslog
 from PiFinder.ui.marking_menus import MarkingMenuOption, MarkingMenu
 from PiFinder.ui.base import UIModule
 from PiFinder.ui.text_menu import UITextMenu
+from PiFinder import config
 
 from PiFinder.db.observations_db import ObservationsDatabase
 
@@ -126,33 +127,32 @@ class UILog(UIModule):
             ],
         }
 
+        cfg = config.Config()
+
+        eyepieces_list = cfg.equipment.eyepieces
+
+        # Loop over eyepieces and add to menu
+        eyepiece_items = [
+            {
+                "name": "NA",
+                "value": "NA",
+            },
+        ]
+        for eyepiece in eyepieces_list:
+            eyepiece_items.append(
+                {
+                    "name": eyepiece.name,
+
+                    "value": (eyepiece.make + " " + eyepiece.name).lstrip(),
+                }
+            )
+
         self.eyepiece_menu = {
             "name": "Eyepiece",
             "class": UITextMenu,
             "select": "single",
             "config_option": "session.log_eyepiece",
-            "items": [
-                {
-                    "name": "NA",
-                    "value": "NA",
-                },
-                {
-                    "name": "32mm",
-                    "value": "32mm",
-                },
-                {
-                    "name": "25mm",
-                    "value": "25mm",
-                },
-                {
-                    "name": "13mm",
-                    "value": "13mm",
-                },
-                {
-                    "name": "9mm",
-                    "value": "9mm",
-                },
-            ],
+            "items": eyepiece_items
         }
 
         self.reset_config()

--- a/python/PiFinder/ui/menu_structure.py
+++ b/python/PiFinder/ui/menu_structure.py
@@ -7,6 +7,7 @@ from PiFinder.ui.chart import UIChart
 from PiFinder.ui.align import UIAlign
 from PiFinder.ui.textentry import UITextEntry
 from PiFinder.ui.preview import UIPreview
+from PiFinder.ui.equipment import UIEquipment
 import PiFinder.ui.callbacks as callbacks
 
 pifinder_menu = {
@@ -823,6 +824,7 @@ pifinder_menu = {
             "select": "single",
             "items": [
                 {"name": "Status", "class": UIStatus},
+                {"name": "Equipment", "class": UIEquipment},
                 {"name": "Console", "class": UIConsole},
                 {"name": "Software Upd", "class": UISoftware},
                 {"name": "Test Mode", "callback": callbacks.activate_debug},

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -11,6 +11,7 @@ luma.lcd==2.11.0
 pillow==10.4.0
 numpy==1.26.2
 pandas==1.5.3
+pydeepskylog==1.3
 pyjwt==2.8.0
 pytz==2022.7.1
 requests==2.28.2

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -11,7 +11,7 @@ luma.lcd==2.11.0
 pillow==10.4.0
 numpy==1.26.2
 pandas==1.5.3
-pydeepskylog==1.3
+pydeepskylog==1.3.1
 pyjwt==2.8.0
 pytz==2022.7.1
 requests==2.28.2

--- a/python/views/edit_eyepiece.tpl
+++ b/python/views/edit_eyepiece.tpl
@@ -1,0 +1,59 @@
+% include("header.tpl", title="Add eyepiece")
+
+<div class="row valign-wrapper" style="margin: 0;">
+    <div class="col s12">
+% if eyepiece_id < 0:
+            <h3 class="grey-text">Add a new eyepiece</h3>
+% else:
+            <h3 class="grey-text">Edit eyepiece</h3>
+% end
+    </div>
+</div>
+
+<form action="/equipment/add_eyepiece/{{eyepiece_id}}" method="post" id="add_eyepiece" class="col s12">
+    <div class="row">
+        <div class="input-field col s12">
+            <input value="{{eyepiece.make}}" id="make" type="text" name="make">
+            <label for="make">Make</label>
+        </div>
+    </div>
+    <div class="row">
+        <div class="input-field col s12">
+            <input value="{{eyepiece.name}}" id="name" type="text" name="name">
+            <label for="name">Name</label>
+        </div>
+    </div>
+    <div class="row">
+        <div class="input-field col s12">
+            <input value="{{eyepiece.focal_length_mm}}" id="focal_length_mm" type="number" name="focal_length_mm">
+            <label for="focal_length_mm">Focal Length (in mm)</label>
+        </div>
+    </div>
+    <div class="row">
+        <div class="input-field col s12">
+            <input value="{{eyepiece.afov}}" id="afov" type="number" name="afov">
+            <label for="afov">Apparent Field of View (in °)</label>
+        </div>
+    </div>
+    <div class="row">
+        <div class="input-field col s12">
+            <input value="{{eyepiece.field_stop}}" id="field_stop" type="number" name="field_stop">
+            <label for="field_stop">Field stop (in mm)</label>
+        </div>
+    </div>
+</form>
+<a href="#" onClick="document.getElementById('add_eyepiece').submit();"
+   class="btn">
+
+    % if eyepiece_id < 0:
+    Add eyepiece!
+    % else:
+    Update eyepiece!
+    % end
+    </a>
+<a href="/equipment" class="btn">Cancel</a>
+
+<br />
+<br />
+
+% include("footer.tpl")

--- a/python/views/edit_instrument.tpl
+++ b/python/views/edit_instrument.tpl
@@ -1,0 +1,149 @@
+% include("header.tpl", title="Add instrument")
+
+% if telescope.mount_type == "alt/az":
+    % altaz_selected = "selected"
+    % equatorial_selected = ""
+% else:
+    % altaz_selected = ""
+    % equatorial_selected = "selected"
+% end
+% if telescope.flip_image:
+    % flip_selected = "checked"
+% else:
+    % flip_selected = ""
+% end
+% if telescope.flop_image:
+    % flop_selected = "checked"
+% else:
+    % flop_selected = ""
+% end
+% if telescope.reverse_arrow_a:
+    % reverse_arrow_a_selected = "checked"
+% else:
+    % reverse_arrow_a_selected = ""
+% end
+% if telescope.reverse_arrow_b:
+    % reverse_arrow_b_selected = "checked"
+% else:
+    % reverse_arrow_b_selected = ""
+% end
+
+<div class="row valign-wrapper" style="margin: 0;">
+    <div class="col s12">
+% if instrument_id < 0:
+            <h3 class="grey-text">Add a new instrument</h3>
+% else:
+            <h3 class="grey-text">Edit instrument</h3>
+% end
+    </div>
+</div>
+
+% if defined("error_message"):
+<div class="row">
+    <div class="col s12">
+        <p class="red-text">{{error_message}}
+    </div>
+</div>
+% end
+
+<form action="/equipment/add_instrument/{{instrument_id}}" method="post" id="add_instrument" class="col s12">
+    <div class="row">
+        <div class="row">
+            <div class="input-field col s12">
+                <input value="{{telescope.make}}" id="make" type="text" name="make">
+                <label for="make">Make</label>
+            </div>
+        </div>
+        <div class="row">
+            <div class="input-field col s12">
+                <input value="{{telescope.name}}" id="name" type="text" name="name">
+                <label for="name">Instrument Name</label>
+            </div>
+        </div>
+        <div class="row">
+            <div class="input-field col s12">
+                <input value="{{telescope.aperture_mm}}" id="aperture" type="number" name="aperture">
+                <label for="aperture">Aperture (in mm)</label>
+            </div>
+        </div>
+        <div class="row">
+            <div class="input-field col s12">
+                <input value="{{telescope.focal_length_mm}}" id="focal_length_mm" type="number" name="focal_length_mm">
+                <label for="focal_length_mm">Focal Length (in mm)</label>
+            </div>
+        </div>
+        <div class="row">
+            <div class="input-field col s12">
+                <input value="{{telescope.obstruction_perc}}" id="obstruction_perc" type="number" name="obstruction_perc">
+                <label for="obstruction_perc">Obstruction %</label>
+            </div>
+        </div>
+        <div class="row">
+            <div class="input-field col s12">
+                <select name="mount_type">
+                    <option value="alt/az" {{altaz_selected}}>Alt/Az</option>
+                    <option value="equatorial" {{equatorial_selected}}>Equatorial</option>
+                </select>
+                <label>
+                    Mount Type
+                </label>
+            </div>
+        </div>
+        <div class="row">
+            <div class="input-field col s12">
+                <label>
+                    <input type="checkbox" id="flip" {{flip_selected}} name="flip" />
+                    <span>Flip image (upside down)</span>
+                </label>
+            </div>
+        </div>
+        <div class="row">
+            <div class="input-field col s12">
+                <label>
+                    <input type="checkbox" id="flop" {{flop_selected}} name="flop" />
+                    <span>Flop image (left right)</span>
+                </label>
+            </div>
+        </div>
+        <div class="row">
+            <div class="input-field col s12">
+                <label>
+                    <input type="checkbox" id="reverse_arrow_a" {{reverse_arrow_a_selected}} name="reverse_arrow_a" />
+                    <span>Reverse Arrow A</span>
+                </label>
+            </div>
+        </div>
+        <div class="row">
+            <div class="input-field col s12">
+                <label>
+                    <input type="checkbox" id="reverse_arrow_b" {{reverse_arrow_b_selected}} name="reverse_arrow_b" />
+                    <span>Reverse Arrow B</span>
+                </label>
+            </div>
+        </div>
+    </div>
+</form>
+
+<a href="#" onClick="document.getElementById('add_instrument').submit();"
+   class="btn">
+
+    % if instrument_id < 0:
+    Add instrument!
+    % else:
+    Update instrument!
+    % end
+    </a>
+<a href="/equipment" class="btn">Cancel</a>
+
+<br />
+<br />
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        let elems = document.querySelectorAll('select');
+        let instances = M.FormSelect.init(elems);
+    });
+</script>
+
+% include("footer.tpl")
+

--- a/python/views/equipment.tpl
+++ b/python/views/equipment.tpl
@@ -1,0 +1,171 @@
+% include("header.tpl", title="Equipment")
+<div class="row valign-wrapper" style="margin: 0;">
+    <div class="col s12">
+        <h3 class="grey-text">Equipment</h3>
+    </div>
+</div>
+
+% if defined("error_message"):
+<div class="row">
+    <div class="col s12">
+        <p class="red-text">{{error_message}}
+    </div>
+</div>
+% end
+
+% if defined("success_message"):
+<div class="row">
+    <div class="col s12">
+        <p class="green-text">{{success_message}}
+    </div>
+</div>
+% end
+
+<div class="row">
+    <div class="col s3 center-align grey-text">
+        <h6 class="grey-text text-lighten-1">Instruments</h6>
+            {{len(equipment.telescopes)}}
+    </div>
+    <div class="col s3 center-align grey-text">
+        <h6 class="grey-text text-lighten-1">Eyepieces</h6>
+            {{len(equipment.eyepieces)}}
+    </div>
+    <div class="col s3 center-align grey-text">
+        <h6 class="grey-text text-lighten-1">Import from DeepskyLog</h6>
+        <a href="#modal_import_from_deepskylog" class="modal-trigger"><i
+                    class="material-icons small">download</i></a>
+    </div>
+</div>
+
+<div id="modal_import_from_deepskylog" class="modal">
+    <div class="modal-content">
+        <h4>Download instruments from DeepskyLog</h4>
+        <p>This will delete all instruments and eyepieces from your PiFinder and replace them
+            with the instruments and eyepieces from DeepskyLog. Are you sure?</p>
+        <form action="/equipment/import_from_deepskylog" method="post" id="deepskylog_form" class="col s12">
+            <div class="row">
+                <div class="input-field col s12">
+                    <input value="" id="dsl_name" type="text" name="dsl_name">
+                    <label for="dsl_name">DeepskyLog User Name</label>
+                </div>
+            </div>
+        </form>
+    </div>
+    <div class="modal-footer">
+        <a href="#" onClick="document.getElementById('deepskylog_form').submit();"
+           class="modal-close btn-flat">Import!</a>
+        <a href="#!" class="modal-close btn-flat">Cancel</a>
+    </div>
+</div>
+
+<a href="/equipment/edit_instrument/-1" class="btn modal-trigger">Add new instrument</a>
+<a href="/equipment/edit_eyepiece/-1" class="btn modal-trigger">Add new eyepiece</a>
+
+
+<h5 class="grey-text">Instruments</h5>
+<table class="grey darken-2 grey-text z-depth-1">
+    <tr>
+        <th>Make</th>
+        <th>Name</th>
+        <th>Aperture</th>
+        <th>Focal Length (mm)</th>
+        <th>Obstruction %</th>
+        <th>Mount Type</th>
+        <th>Flip</th>
+        <th>Flop</th>
+        <th>Reverse Arrow A</th>
+        <th>Reverse Arrow B</th>
+        <th>Active</th>
+        <th>Actions</th>
+    </tr>
+    % for instrument in equipment.telescopes:
+    <tr>
+        <td>{{instrument.make}}</td>
+        <td>{{instrument.name}}</td>
+        <td>{{instrument.aperture_mm}}</td>
+        <td>{{instrument.focal_length_mm}}</td>
+        <td>{{instrument.obstruction_perc}}</td>
+        <td>{{instrument.mount_type}}</td>
+        <td>{{instrument.flip_image}}</td>
+        <td>{{instrument.flop_image}}</td>
+        <td>{{instrument.reverse_arrow_a}}</td>
+        <td>{{instrument.reverse_arrow_b}}</td>
+        <td>
+                <label>
+                    <a href="/equipment/set_active_instrument/{{equipment.telescopes.index(instrument)}}">
+                        <input type="radio"
+                        % if equipment.active_telescope == instrument:
+                            checked
+                        % end
+                        />
+                        <span></span>
+                    </a>
+                </label>
+        </td>
+        <td>
+            <a href="/equipment/edit_instrument/{{equipment.telescopes.index(instrument)}}"><i class="material-icons">edit</i></a>
+            <a href="/equipment/delete_instrument/{{equipment.telescopes.index(instrument)}}"><i class="material-icons">delete</i></a>
+       </td>
+    </tr>
+    % end
+</table>
+
+<h5 class="grey-text">Eyepieces</h5>
+<table class="grey darken-2 grey-text z-depth-1">
+    <tr>
+        <th>Make</th>
+        <th>Name</th>
+        <th>Focal Length (mm)</th>
+        <th>Apparent FOV</th>
+        <th>Field Stop</th>
+        <th>Active</th>
+        <th>Actions</th>
+    </tr>
+
+    % for eyepiece in equipment.eyepieces:
+    <tr>
+        <td>{{eyepiece.make}}</td>
+        <td>{{eyepiece.name}}</td>
+        <td>{{eyepiece.focal_length_mm}}</td>
+        <td>{{eyepiece.afov}}</td>
+        <td>{{eyepiece.field_stop}}</td>
+        <td>
+                <label>
+                    <a href="/equipment/set_active_eyepiece/{{equipment.eyepieces.index(eyepiece)}}">
+                        <input type="radio"
+                        % if equipment.active_eyepiece == eyepiece:
+                            checked
+                        % end
+                        />
+                        <span></span>
+                    </a>
+                </label>
+        </td>
+        <td>
+            <a href="/equipment/edit_eyepiece/{{equipment.eyepieces.index(eyepiece)}}"><i class="material-icons">edit</i></a>
+            <a href="/equipment/delete_eyepiece/{{equipment.eyepieces.index(eyepiece)}}"><i class="material-icons">delete</i></a>
+        </td>
+    </tr>
+    % end
+</table>
+
+<br/>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        let elems = document.querySelectorAll('select');
+        let instances = M.FormSelect.init(elems);
+    });
+
+    document.addEventListener('DOMContentLoaded', function () {
+        let elems = document.querySelectorAll('.modal');
+        let instances = M.Modal.init(elems);
+    });
+
+    function set_instrument_id(id) {
+        let instrument_id = id;
+    }
+</script>
+
+% include("footer.tpl")
+

--- a/python/views/equipment.tpl
+++ b/python/views/equipment.tpl
@@ -41,7 +41,7 @@
     <div class="modal-content">
         <h4>Download instruments from DeepskyLog</h4>
         <p>This will delete all instruments and eyepieces from your PiFinder and replace them
-            with the instruments and eyepieces from DeepskyLog. Are you sure?</p>
+            with the instruments and eyepieces from DeepskyLog. Are you really sure?</p>
         <form action="/equipment/import_from_deepskylog" method="post" id="deepskylog_form" class="col s12">
             <div class="row">
                 <div class="input-field col s12">

--- a/python/views/header.tpl
+++ b/python/views/header.tpl
@@ -19,6 +19,7 @@
         <li><a href="/network">Network Setup</a></li>
         <li><a href="/observations">Observations</a></li>
         <li><a href="/tools">Tools</a></li>
+        <li><a href="/equipment">Equipment</a></li>
       </ul>
 
       <ul id="nav-mobile" class="sidenav">
@@ -27,6 +28,7 @@
         <li><a href="/network">Network Setup</a></li>
         <li><a href="/observations">Observations</a></li>
         <li><a href="/tools">Tools</a></li>
+        <li><a href="/equipment">Equipment</a></li>
       </ul>
       <a href="#" data-target="nav-mobile" class="sidenav-trigger"><i class="material-icons">menu</i></a>
     </div>


### PR DESCRIPTION
This is a pull request for the addition of equipment in PiFinder.

At this moment, the following functionality is added:
- Addition of telescopes and eyepieces from the web interface (in the /equipment tab)
- Added page in the Tools menu of PiFinder to show the used telescope / eyepiece and the magnification and True Field of View.
- Change eyepiece and telescope from the PiFinder page.
- Use correct list of eyepieces when logging an observation