### PR TITLE
[WIP] Contrast reserve

### DIFF
--- a/python/PiFinder/ui/object_details.py
+++ b/python/PiFinder/ui/object_details.py
@@ -5,6 +5,7 @@
 This module contains all the UI Module classes
 
 """
+
 import pydeepskylog as pds
 from PiFinder import cat_images
 from PiFinder.ui.marking_menus import MarkingMenuOption, MarkingMenu
@@ -46,6 +47,7 @@ class UIObjectDetails(UIModule):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self.contrast = None
         self.screen_direction = self.config_object.get_option("screen_direction")
         self.mount_type = self.config_object.get_option("mount_type")
         self.object = self.item_definition["object"]
@@ -71,7 +73,7 @@ class UIObjectDetails(UIModule):
             ),
         )
 
-        # Used for displaying obsevation counts
+        # Used for displaying observation counts
         self.observations_db = ObservationsDatabase()
 
         self.simpleTextLayout = functools.partial(
@@ -120,37 +122,12 @@ class UIObjectDetails(UIModule):
         designator_color = 255
         if not self.object.last_filtered_result:
             designator_color = 128
-        # TODO: Get the SQM from the shared state
-        # sqm = self.shared_state.get_sky_brightness()
-        sqm = 20.15
-        # Check if a telescope and eyepiece are set
-        if self.config_object.equipment.active_eyepiece is None or self.config_object.equipment.active_eyepiece is None:
-            contrast = ""
-        else:
-            # Calculate contrast reserve. The object diameters are given in arc seconds.
-            magnification = self.config_object.equipment.calc_magnification(
-                self.config_object.equipment.active_telescope, self.config_object.equipment.active_eyepiece)
-            if self.object.mag_str == "-":
-                contrast = ""
-            else:
-                try:
-                    contrast = pds.contrast_reserve(
-                        sqm=sqm, telescope_diameter=self.config_object.equipment.active_telescope.aperture_mm,
-                        magnification=magnification, magnitude=float(self.object.mag_str),
-                        object_diameter1=float(self.object.size) * 60.0, object_diameter2=float(self.object.size) * 60.0)
-                except:
-                    contrast = ""
-        try:
-            contrast = f"{contrast: .2f}"
-        except:
-            print(contrast)
-            contrast = ""
 
         # layout the name - contrast reserve line
         space_calculator = SpaceCalculatorFixed(14)
 
         _, typeconst = space_calculator.calculate_spaces(
-            self.object.display_name, contrast
+            self.object.display_name, self.contrast
         )
         return self.simpleTextLayout(
             typeconst,
@@ -258,6 +235,41 @@ class UIObjectDetails(UIModule):
             self.display_class,
             burn_in=self.object_display_mode in [DM_POSS, DM_SDSS],
         )
+
+        # Calculate contrast reserve
+        # TODO: Get the SQM from the shared state
+        # sqm = self.shared_state.get_sky_brightness()
+        sqm = 20.15
+        # Check if a telescope and eyepiece are set
+        if (
+            self.config_object.equipment.active_eyepiece is None
+            or self.config_object.equipment.active_eyepiece is None
+        ):
+            self.contrast = ""
+        else:
+            # Calculate contrast reserve. The object diameters are given in arc seconds.
+            magnification = self.config_object.equipment.calc_magnification(
+                self.config_object.equipment.active_telescope,
+                self.config_object.equipment.active_eyepiece,
+            )
+            if self.object.mag_str == "-":
+                self.contrast = ""
+            else:
+                try:
+                    self.contrast = pds.contrast_reserve(
+                        sqm=sqm,
+                        telescope_diameter=self.config_object.equipment.active_telescope.aperture_mm,
+                        magnification=magnification,
+                        magnitude=float(self.object.mag_str),
+                        object_diameter1=float(self.object.size) * 60.0,
+                        object_diameter2=float(self.object.size) * 60.0,
+                    )
+                except Exception:
+                    self.contrast = ""
+        try:
+            self.contrast = f"{self.contrast: .2f}"
+        except Exception:
+            self.contrast = ""
 
     def active(self):
         self.activation_time = time.time()
@@ -466,7 +478,7 @@ class UIObjectDetails(UIModule):
 
     def mm_align(self, _marking_menu, _menu_item) -> bool:
         """
-        Called from marking menu to align on curent object
+        Called from marking menu to align on current object
         """
         self.message("Aligning...", 0.1)
         if align_on_radec(

--- a/python/PiFinder/ui/object_details.py
+++ b/python/PiFinder/ui/object_details.py
@@ -257,6 +257,7 @@ class UIObjectDetails(UIModule):
                 self.contrast = ""
             else:
                 try:
+                    # Calculate the contrast reserve.
                     # The object diameters are given in arc minutes, but expected in arc seconds.
                     self.contrast = pds.contrast_reserve(
                         sqm=sqm,

--- a/python/PiFinder/ui/object_details.py
+++ b/python/PiFinder/ui/object_details.py
@@ -247,7 +247,8 @@ class UIObjectDetails(UIModule):
         ):
             self.contrast = ""
         else:
-            # Calculate contrast reserve. The object diameters are given in arc seconds.
+            # Calculate contrast reserve.
+            # Get the used magnification from the equipment configuration
             magnification = self.config_object.equipment.calc_magnification(
                 self.config_object.equipment.active_telescope,
                 self.config_object.equipment.active_eyepiece,
@@ -256,6 +257,7 @@ class UIObjectDetails(UIModule):
                 self.contrast = ""
             else:
                 try:
+                    # The object diameters are given in arc minutes, but expected in arc seconds.
                     self.contrast = pds.contrast_reserve(
                         sqm=sqm,
                         telescope_diameter=self.config_object.equipment.active_telescope.aperture_mm,


### PR DESCRIPTION
Adds the calculation of contrast reserve to PiFinder.
The value of the contrast reserve is shown in the object detail page:
![2024-12-23 15_12_20-Luma core Display Emulator (piFinder)](https://github.com/user-attachments/assets/895f5954-f893-44c5-8c63-a254eac7f9b8)

Remarks:
- [ ] As the SQM is not yet calculated by the PiFinder, I take a fixed value of 20.15 for the SQM.
- [ ] The contrast reserve is just a number... For most users, this number does not mean anything.  We still need to find out how to display the contrast reserve in a more meaningfull way

| Contrast Reserve | Visibility             |
|------------------|------------------------|
| < -0.2           | Not visible            |
| -0.2 < CR < 0.1  | Questionable           |
| 0.1 < CR < 0.35  | Difficult              |
| 0.35 < CR < 0.5  | Quite difficult to see |
| 0.5 < CR < 1.0   | Easy to see            |
| 1.0 < CR         | Very easy to see       |

This pull request will solve #129 