### PR TITLE
imx462 support

### DIFF
--- a/python/PiFinder/camera_pi.py
+++ b/python/PiFinder/camera_pi.py
@@ -35,6 +35,11 @@ class CameraPI(CameraInterface):
             self.camera_type = "imx296"
             # maximum analog gain for this sensor
             self.gain = 15
+
+        if "imx290" in self.camera.camera.id:
+            self.camera_type = "imx462"
+            self.gain = 30
+
         self.camType = f"PI {self.camera_type}"
         self.initialize()
 
@@ -50,6 +55,13 @@ class CameraPI(CameraInterface):
                     "size": (512, 512),
                 },
                 raw={"size": (1456, 1088), "format": "R10"},
+            )
+        elif self.camera_type == "imx462":
+            cam_config = self.camera.create_still_configuration(
+                {
+                    "size": (512, 512),
+                },
+                raw={"size": (1920, 1080), "format": "SRGGB12"},
             )
         else:
             # using this smaller scale auto-selects binning on the sensor...
@@ -78,6 +90,10 @@ class CameraPI(CameraInterface):
             raw_capture = raw_capture.copy().view(np.uint16)[:, 184:-184]
             # Sensor orientation is different
             raw_capture = np.rot90(raw_capture, 2)
+        elif self.camera_type == "imx462":
+            # crop to square and resample to 16 bit from 2 8 bit entries
+            # to get the right FOV, we want a 980 square....
+            raw_capture = raw_capture.copy().view(np.uint16)[50:-50, 470:-470]
         else:
             # crop to square and resample to 16 bit from 2 8 bit entries
             raw_capture = raw_capture.copy().view(np.uint16)[:, 256:-256]

--- a/python/PiFinder/switch_camera.py
+++ b/python/PiFinder/switch_camera.py
@@ -7,6 +7,9 @@ def switch_boot(cam_type: str) -> None:
     Edit /boot/config.txt to swap camera drive
     must be run as roo
     """
+    if cam_type == "imx462":
+        # The 462 uses the 290 driver
+        cam_type = "imx290"
 
     # read config.txt into a list
     with open("/boot/config.txt", "r") as boot_in:
@@ -28,7 +31,10 @@ def switch_boot(cam_type: str) -> None:
             cam_added = True
 
     if not cam_added:
-        boot_lines.append(f"dtoverlay={cam_type}\n")
+        if cam_type == "imx290":
+            boot_lines.append(f"dtoverlay={cam_type},clock-frequency=74250000\n")
+        else:
+            boot_lines.append(f"dtoverlay={cam_type}\n")
         cam_added = True
 
     with open("/boot/config.txt", "w") as boot_out:

--- a/python/PiFinder/sys_utils.py
+++ b/python/PiFinder/sys_utils.py
@@ -319,3 +319,8 @@ def switch_cam_imx477() -> None:
 def switch_cam_imx296() -> None:
     logger.info("SYS: Switching cam to imx296")
     sh.sudo("python", "-m", "PiFinder.switch_camera", "imx296")
+
+
+def switch_cam_imx462() -> None:
+    logger.info("SYS: Switching cam to imx462")
+    sh.sudo("python", "-m", "PiFinder.switch_camera", "imx462")

--- a/python/PiFinder/ui/callbacks.py
+++ b/python/PiFinder/ui/callbacks.py
@@ -101,6 +101,29 @@ def switch_cam_imx296(ui_module: UIModule) -> None:
     restart_system(ui_module)
 
 
+def switch_cam_imx462(ui_module: UIModule) -> None:
+    ui_module.message("Switching cam", 2)
+    sys_utils.switch_cam_imx462()
+    restart_system(ui_module)
+
+
+def get_camera_type(ui_module: UIModule) -> list:
+    print("Looking for cammmm")
+    cam_id = "000"
+
+    # read config.txt into a list
+    with open("/boot/config.txt", "r") as boot_in:
+        boot_lines = list(boot_in)
+
+    # Look for the line without a comment...
+    for line in boot_lines:
+        if line.startswith("dtoverlay=imx"):
+            cam_id = line[10:16]
+            print("found cam " + cam_id)
+
+    return [cam_id]
+
+
 def go_wifi_ap(ui_module: UIModule) -> None:
     ui_module.message("WiFi to AP", 2)
     sys_utils.go_wifi_ap()

--- a/python/PiFinder/ui/menu_structure.py
+++ b/python/PiFinder/ui/menu_structure.py
@@ -822,14 +822,22 @@ pifinder_menu = {
                     "name": "Camera Type",
                     "class": UITextMenu,
                     "select": "single",
+                    "value_callback": callbacks.get_camera_type,
                     "items": [
                         {
                             "name": "v2 - imx477",
                             "callback": callbacks.switch_cam_imx477,
+                            "value": "imx477",
                         },
                         {
                             "name": "v3 - imx296",
                             "callback": callbacks.switch_cam_imx296,
+                            "value": "imx296",
+                        },
+                        {
+                            "name": "v3 - imx462",
+                            "callback": callbacks.switch_cam_imx462,
+                            "value": "imx290",
                         },
                     ],
                 },

--- a/python/PiFinder/ui/text_menu.py
+++ b/python/PiFinder/ui/text_menu.py
@@ -40,6 +40,13 @@ class UITextMenu(UIModule):
         )
 
         self._selected_values = []
+        if self.item_definition.get("value_callback"):
+            self._selected_values = self.item_definition.get("value_callback")(self)
+            # Set current item index based on selection
+            for i, _item in enumerate(self.item_definition["items"]):
+                if _item["value"] == self._selected_values[0]:
+                    self._current_item_index = i
+
         if config_option := self.item_definition.get("config_option"):
             if self._menu_type == "multi":
                 self._selected_values = self.config_object.get_option(config_option)


### PR DESCRIPTION
This PRadds support for imx462 sensor cameras from innomaker.  Performance is very similar to the imx296, but a little more expensive.

* Support for imx462 in boot/config.txt
* Support for imx462 in camera_pi raw procesing
* New callback system for figuring out selected state in text_menu ui module.  This is used to show which camera is selected
