### PR TITLE
Make align system more dynamic and user-friendly

### DIFF
--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -53,9 +53,18 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
             "RA": None,
             "Dec": None,
             "Roll": None,
-            "RA_camera": None,
-            "Dec_camera": None,
-            "Roll_camera": None,
+            "camera_center": {
+                "RA": None,
+                "Dec": None,
+                "Roll": None,
+                "Alt": None,
+                "Az": None,
+            },
+            "camera_solve": {
+                "RA": None,
+                "Dec": None,
+                "Roll": None,
+            },
             "Roll_offset": 0,  # May/may not be needed - for experimentation
             "imu_pos": None,
             "Alt": None,
@@ -115,6 +124,14 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                     solved["Alt"] = alt
                     solved["Az"] = az
 
+                    alt, az = calc_utils.sf_utils.radec_to_altaz(
+                        solved["camera_center"]["RA"],
+                        solved["camera_center"]["Dec"],
+                        dt,
+                    )
+                    solved["camera_center"]["Alt"] = alt
+                    solved["camera_center"]["Az"] = az
+
                     # Experimental: For monitoring roll offset
                     # Estimate the roll offset due misalignment of the
                     # camera sensor with the Pole-to-Source great circle.
@@ -129,7 +146,19 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                     # as seen by the camera.
                     solved["Roll"] = roll_target_calculated + solved["Roll_offset"]
 
-                last_image_solve = copy.copy(solved)
+                    # calculate roll for camera center
+                    roll_target_calculated = calc_utils.sf_utils.radec_to_roll(
+                        solved["camera_center"]["RA"],
+                        solved["camera_center"]["Dec"],
+                        dt,
+                    )
+                    # Compensate for the roll offset. This gives the roll at the target
+                    # as seen by the camera.
+                    solved["camera_center"]["Roll"] = (
+                        roll_target_calculated + solved["Roll_offset"]
+                    )
+
+                last_image_solve = copy.deepcopy(solved)
                 solved["solve_source"] = "CAM"
 
             # Use IMU dead-reckoning from the last camera solve:
@@ -150,14 +179,17 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                                 alt_offset = ((alt_offset + 180) % 360 - 180) * -1
                             else:
                                 alt_offset = (alt_offset + 180) % 360 - 180
-                            alt_upd = (last_image_solve["Alt"] - alt_offset) % 360
+                            solved["Alt"] = (last_image_solve["Alt"] - alt_offset) % 360
+                            solved["camera_center"]["Alt"] = (
+                                last_image_solve["camera_center"]["Alt"] - alt_offset
+                            ) % 360
 
                             az_offset = imu_pos[IMU_AZ] - lis_imu[IMU_AZ]
                             az_offset = (az_offset + 180) % 360 - 180
-                            az_upd = (last_image_solve["Az"] + az_offset) % 360
-
-                            solved["Alt"] = alt_upd
-                            solved["Az"] = az_upd
+                            solved["Az"] = (last_image_solve["Az"] + az_offset) % 360
+                            solved["camera_center"]["Az"] = (
+                                last_image_solve["camera_center"]["Az"] + az_offset
+                            ) % 360
 
                             # N.B. Assumes that location hasn't changed since last solve
                             # Turn this into RA/DEC
@@ -167,11 +199,29 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                             ) = calc_utils.sf_utils.altaz_to_radec(
                                 solved["Alt"], solved["Az"], dt
                             )
-
                             # Calculate the roll at the target RA/Dec and compensate for the offset.
                             solved["Roll"] = (
                                 calc_utils.sf_utils.radec_to_roll(
                                     solved["RA"], solved["Dec"], dt
+                                )
+                                + solved["Roll_offset"]
+                            )
+
+                            # Now for camera centered solve
+                            (
+                                solved["camera_center"]["RA"],
+                                solved["camera_center"]["Dec"],
+                            ) = calc_utils.sf_utils.altaz_to_radec(
+                                solved["camera_center"]["Alt"],
+                                solved["camera_center"]["Az"],
+                                dt,
+                            )
+                            # Calculate the roll at the target RA/Dec and compensate for the offset.
+                            solved["camera_center"]["Roll"] = (
+                                calc_utils.sf_utils.radec_to_roll(
+                                    solved["camera_center"]["RA"],
+                                    solved["camera_center"]["Dec"],
+                                    dt,
                                 )
                                 + solved["Roll_offset"]
                             )
@@ -205,8 +255,8 @@ def estimate_roll_offset(solved, dt):
     # Calculate the expected roll at the camera center given the RA/Dec of
     # of the camera center.
     roll_camera_calculated = calc_utils.sf_utils.radec_to_roll(
-        solved["RA_camera"], solved["Dec_camera"], dt
+        solved["camera_center"]["RA"], solved["camera_center"]["Dec"], dt
     )
-    roll_offset = solved["Roll_camera"] - roll_camera_calculated
+    roll_offset = solved["camera_center"]["Roll"] - roll_camera_calculated
 
     return roll_offset

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -45,10 +45,22 @@ def solver(
     align_ra = 0
     align_dec = 0
     solved = {
-        # RA, Dec, Roll solved at the center of the camera FoV:
-        "RA_camera": None,
-        "Dec_camera": None,
-        "Roll_camera": None,
+        # RA, Dec, Roll solved at the center of the camera FoV
+        # update by integrator
+        "camera_center": {
+            "RA": None,
+            "Dec": None,
+            "Roll": None,
+            "Alt": None,
+            "Az": None,
+        },
+        # RA, Dec, Roll from the camera, not
+        # affected by IMU in integrator
+        "camera_solve": {
+            "RA": None,
+            "Dec": None,
+            "Roll": None,
+        },
         # RA, Dec, Roll at the target pixel
         "RA": None,
         "Dec": None,
@@ -165,9 +177,14 @@ def solver(
 
                     if solved["RA"] is not None:
                         # RA, Dec, Roll at the center of the camera's FoV:
-                        solved["RA_camera"] = solved["RA"]
-                        solved["Dec_camera"] = solved["Dec"]
-                        solved["Roll_camera"] = solved["Roll"]
+                        solved["camera_center"]["RA"] = solved["RA"]
+                        solved["camera_center"]["Dec"] = solved["Dec"]
+                        solved["camera_center"]["Roll"] = solved["Roll"]
+
+                        # RA, Dec, Roll at the center of the camera's not imu:
+                        solved["camera_solve"]["RA"] = solved["RA"]
+                        solved["camera_solve"]["Dec"] = solved["Dec"]
+                        solved["camera_solve"]["Roll"] = solved["Roll"]
                         # RA, Dec, Roll at the target pixel:
                         solved["RA"] = solved["RA_target"]
                         solved["Dec"] = solved["Dec_target"]

--- a/python/PiFinder/ui/align.py
+++ b/python/PiFinder/ui/align.py
@@ -118,7 +118,7 @@ class UIAlign(UIModule):
 
         if not self.align_mode:
             self.reticle_position = self.starfield.radec_to_xy(
-                self.solution["RA_target"], self.solution["Dec_target"]
+                self.solution["RA"], self.solution["Dec"]
             )
 
         x_pos = round(self.reticle_position[0])
@@ -190,9 +190,9 @@ class UIAlign(UIModule):
                 # We want to use the CAMERA center here as we'll be moving
                 # the reticle to the star
                 image_obj, self.visible_stars = self.starfield.plot_starfield(
-                    self.solution["RA_camera"],
-                    self.solution["Dec_camera"],
-                    self.solution["Roll_camera"],
+                    self.solution["camera_center"]["RA"],
+                    self.solution["camera_center"]["Dec"],
+                    self.solution["camera_center"]["Roll"],
                     constellation_brightness,
                     shade_frustrum=True,
                 )
@@ -202,7 +202,9 @@ class UIAlign(UIModule):
                 self.screen.paste(image_obj)
 
                 self.last_update = last_solve_time
-                self.draw_reticle()
+                # draw_reticle if we have a camera solve
+                if self.solution["solve_source"]=="CAM":
+                    self.draw_reticle()
 
         else:
             self.draw.rectangle(
@@ -318,12 +320,12 @@ class UIAlign(UIModule):
         return
 
     def key_plus(self):
-        if not self.align_mode:
-            self.change_fov(-1)
+        #if not self.align_mode:
+        self.change_fov(-1)
 
     def key_minus(self):
-        if not self.align_mode:
-            self.change_fov(1)
+        #if not self.align_mode:
+        self.change_fov(1)
 
     def key_square(self):
         if self.align_mode:

--- a/python/PiFinder/ui/align.py
+++ b/python/PiFinder/ui/align.py
@@ -108,6 +108,7 @@ class UIAlign(UIModule):
             down=MarkingMenuOption(),
             right=MarkingMenuOption(),
         )
+
     def draw_reticle(self):
         """
         draw the reticle if desired
@@ -249,11 +250,13 @@ class UIAlign(UIModule):
                 # draw the help text
                 if not self.align_mode:
                     # Prompt to start align
-                    hint_text = "Start Align"
+                    hint_text = f"  {self._SQUARE_} START ALIGN"
+                elif self.alignment_star is None:
+                    hint_text = f"{self._ARROWS_} SELECT STAR"
                 else:
-                    hint_text = "Pick Star"
+                    hint_text = f"{self._SQUARE_} SAVE / 0 CANCEL"
                 self.draw.text(
-                    (5,self.display_class.resY - self.fonts.base.height),
+                    (15, self.display_class.resY - self.fonts.base.height - 2),
                     hint_text,
                     font=self.fonts.base.font,
                     fill=self.colors.get(255),
@@ -265,13 +268,19 @@ class UIAlign(UIModule):
                 fill=self.colors.get(0),
             )
             self.draw.text(
-                (20,self.display_class.titlebar_height + 10),
+                (16, self.display_class.titlebar_height + 10),
                 "Can't plot",
                 font=self.fonts.large.font,
                 fill=self.colors.get(255),
             )
             self.draw.text(
-                (30,self.display_class.titlebar_height + 10 + self.fonts.large.height + 4),
+                (
+                    26,
+                    self.display_class.titlebar_height
+                    + 10
+                    + self.fonts.large.height
+                    + 4,
+                ),
                 "No Solve Yet",
                 font=self.fonts.base.font,
                 fill=self.colors.get(255),
@@ -373,11 +382,11 @@ class UIAlign(UIModule):
         return
 
     def key_plus(self):
-        #if not self.align_mode:
+        # if not self.align_mode:
         self.change_fov(-1)
 
     def key_minus(self):
-        #if not self.align_mode:
+        # if not self.align_mode:
         self.change_fov(1)
 
     def key_square(self):

--- a/python/PiFinder/ui/base.py
+++ b/python/PiFinder/ui/base.py
@@ -32,6 +32,11 @@ class UIModule:
     _UP_ARROW = ""
     _DOWN_ARROW = ""
     _CHECKMARK = ""
+    _SQUARE_ = "󰝤"
+    _ARROWS_ = ""
+    _PLUS_ = "󰐕"
+    _MINUS_ = "󰍴"
+    _PLUSMINUS_ = "󰐕/󰍴"
     _gps_brightness = 0
     _unmoved = False  # has the telescope moved since the last cam solve?
     _display_mode_list = [None]  # List of display modes

--- a/python/PiFinder/ui/chart.py
+++ b/python/PiFinder/ui/chart.py
@@ -203,13 +203,19 @@ class UIChart(UIModule):
                 fill=self.colors.get(0),
             )
             self.draw.text(
-                (20,self.display_class.titlebar_height + 10),
+                (16, self.display_class.titlebar_height + 10),
                 "Can't plot",
                 font=self.fonts.large.font,
                 fill=self.colors.get(255),
             )
             self.draw.text(
-                (30,self.display_class.titlebar_height + 10 + self.fonts.large.height + 4),
+                (
+                    26,
+                    self.display_class.titlebar_height
+                    + 10
+                    + self.fonts.large.height
+                    + 4,
+                ),
                 "No Solve Yet",
                 font=self.fonts.base.font,
                 fill=self.colors.get(255),

--- a/python/PiFinder/ui/chart.py
+++ b/python/PiFinder/ui/chart.py
@@ -195,25 +195,26 @@ class UIChart(UIModule):
 
                 self.last_update = last_solve_time
 
+                self.draw_reticle()
+
         else:
             self.draw.rectangle(
                 [0, 0, self.display_class.resX, self.display_class.resY],
                 fill=self.colors.get(0),
             )
             self.draw.text(
-                (self.display_class.titlebar_height + 2, 20),
+                (20,self.display_class.titlebar_height + 10),
                 "Can't plot",
                 font=self.fonts.large.font,
                 fill=self.colors.get(255),
             )
             self.draw.text(
-                (self.display_class.titlebar_height + 2 + self.fonts.large.height, 50),
+                (30,self.display_class.titlebar_height + 10 + self.fonts.large.height + 4),
                 "No Solve Yet",
                 font=self.fonts.base.font,
                 fill=self.colors.get(255),
             )
 
-        self.draw_reticle()
         return self.screen_update()
 
     def change_fov(self, direction):


### PR DESCRIPTION
Based on great feedback from @mrosseel this is a PR to polish up the Align feature:

* Use IMU updated camera center position for chart while not in star selection mode
* Allow zoom in/out when in star selection mode
* Use standard reticle to indicate current alignment point before entering star select mode
* Provide prompts along the bottom of the screen to indicate next steps

I tried to use the IMU during the entire process, but it made it much more confusing as the selection point would move to the star's location when the arrow was pressed, but this would almost alwasys be a little different in the next moment due to the imu motion from interacting with the PiFinder.  This would make it seem like it was not selecting the star, but was slightly offset.  Tying the location to the camera solve during star selection makes for a nicer experience as the selected star is well indicated and the set of stars is stable for selection.

To help guide the process and avoid user confusion, the chart starts dynamic using the IMU and shows the current alignment using the normal reticle pattern.  A prompt is displayed along the bottom to guide the user through and should, hopefully, make the process more understandable.
