### PR TITLE
Unify gps status checking

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -1,13 +1,6 @@
 {
     "display_brightness": 255,
     "keypad_brightness": "0",
-    "last_location": {
-        "lat": 34.0,
-        "lon": -118.0,
-        "altitude": 51.0,
-        "gps_lock": false,
-        "timezone": "America/Los_Angeles"
-    },
     "camera_exp": 400000,
     "camera_gain": 20,
     "menu_anim_speed": 0.1,

--- a/python/PiFinder/calc_utils.py
+++ b/python/PiFinder/calc_utils.py
@@ -142,14 +142,14 @@ def aim_degrees(shared_state, mount_type, screen_direction, target):
     solution = shared_state.solution()
     location = shared_state.location()
     dt = shared_state.datetime()
-    if location and dt and solution:
+    if location.lock and dt and solution:
         if mount_type == "Alt/Az":
             if solution["Alt"]:
                 # We have position and time/date!
                 sf_utils.set_location(
-                    location["lat"],
-                    location["lon"],
-                    location["altitude"],
+                    location.lat,
+                    location.lon,
+                    location.altitude,
                 )
                 target_alt, target_az = sf_utils.radec_to_altaz(
                     target.ra,
@@ -180,8 +180,8 @@ def calc_object_altitude(shared_state, obj) -> Optional[float]:
     dt = shared_state.datetime()
     if location and dt and solution:
         aa = FastAltAz(
-            location["lat"],
-            location["lon"],
+            location.lat,
+            location.lon,
             dt,
         )
         alt, _ = aa.radec_to_altaz(
@@ -334,7 +334,7 @@ class Skyfield_utils:
         t = self.ts.from_datetime(dt)
 
         observer = self.observer_loc.at(t)
-        # logger.debug("radec_to_altaz: '%f' '%f' '%f'", ra, dec, dt)
+        # Logger.debug("radec_to_altaz: '%f' '%f' '%f'", ra, dec, dt)
         sky_pos = Star(
             ra=Angle(degrees=ra),
             dec_degrees=dec,
@@ -412,6 +412,9 @@ class Skyfield_utils:
                  'altaz': (1.667930045300066, 228.61434416619613)},
         }
         """
+        if not self.observer_loc:
+            logger.warning("no observer location set")
+            return {}
         t = self.ts.from_datetime(dt)
         observer = self.observer_loc.at(t)
         planet_dict = {}

--- a/python/PiFinder/catalogs.py
+++ b/python/PiFinder/catalogs.py
@@ -177,18 +177,17 @@ class CatalogFilter:
         self.dirty_time = time.time()
 
     def calc_fast_aa(self, shared_state):
-        solution = shared_state.solution()
-        location = shared_state.location()
-        dt = shared_state.datetime()
-        if location and dt and solution:
+        if shared_state.altaz_ready():
+            location = shared_state.location()
+            dt = shared_state.datetime()
             self.fast_aa = calc_utils.FastAltAz(
-                location["lat"],
-                location["lon"],
+                location.lat,
+                location.lon,
                 dt,
             )
         else:
             logger.warning(
-                f"Calc_fast_aa: {'solution' if not solution else 'location' if not location else 'datetime' if not dt else 'nothing'} not set"
+                f"Calc_fast_aa: {'location' if not location else 'datetime' if not dt else 'nothing'} not set"
             )
 
     def is_dirty(self) -> bool:
@@ -369,7 +368,7 @@ class Catalog(CatalogBase):
         self.filtered_objects: List[CompositeObject] = self.get_objects()
         self.filtered_objects_seq: List[int] = self._filtered_objects_to_seq()
         self.last_filtered = 0
-        self.initialised = True
+        self.initialized = True
 
     def is_selected(self):
         """
@@ -576,7 +575,7 @@ class TimerCatalog(VirtualCatalog):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.initialised = False
+        self.initialized = False
         logger.debug("in init of timercatalog")
         self.timer: Optional[threading.Timer] = None
         self.is_running: bool = False
@@ -633,11 +632,15 @@ class PlanetCatalog(TimerCatalog):
     def __init__(self, dt: datetime.datetime, shared_state: SharedStateObj):
         super().__init__("PL", "Planets")
         self.shared_state = shared_state
-        self.init_planets(dt)
 
     @property
     def time_delay_seconds(self) -> int:
-        return 307
+        if self.initialized:
+            # We've calculated at least once....
+            return 307
+        else:
+            # Check for a lock/time every 10 seconds
+            return 10
 
     def init_planets(self, dt):
         planet_dict = sf_utils.calc_planets(dt)
@@ -649,7 +652,7 @@ class PlanetCatalog(TimerCatalog):
         with self.virtual_id_lock:
             new_low = self.assign_virtual_object_ids(self, self.virtual_id_low)
             self.virtual_id_low = new_low
-        self.initialised = True
+        self.initialized = True
 
     def add_planet(self, sequence: int, name: str, planet: Dict[str, Dict[str, float]]):
         ra, dec = planet["radec"]
@@ -673,13 +676,15 @@ class PlanetCatalog(TimerCatalog):
         self.add_object(obj)
 
     def do_timed_task(self):
-        if not self.initialised:
-            return
         with Timer("Planet Catalog periodic update"):
             """ updating planet catalog data """
-            dt = self.shared_state.datetime()
-            if not dt or not sf_utils.observer_loc:
+            if not self.shared_state.altaz_ready():
                 return
+
+            dt = self.shared_state.datetime()
+            if not self.initialized:
+                self.init_planets(dt)
+
             planet_dict = sf_utils.calc_planets(dt)
             for obj in self._get_objects():
                 name = obj.names[0]
@@ -711,7 +716,7 @@ class CometCatalog(TimerCatalog):
                 success, self.age = comets.comet_data_download(comet_file)
                 if success:
                     with self._init_lock:
-                        self.initialised = self.calc_comet_first_time(dt)
+                        self.initialized = self.calc_comet_first_time(dt)
                     with self.virtual_id_lock:
                         new_low = self.assign_virtual_object_ids(
                             self, self.virtual_id_low
@@ -765,8 +770,8 @@ class CometCatalog(TimerCatalog):
         """updating comet catalog data"""
         with Timer("Comet Catalog periodic update"):
             with self._init_lock:
-                if not self.initialised:
-                    logging.debug("Comets not yet initialised, skip periodic update...")
+                if not self.initialized:
+                    logging.debug("Comets not yet initialized, skip periodic update...")
                     return
             dt = self.shared_state.datetime()
             comet_dict = comets.calc_comets(

--- a/python/PiFinder/gps_gpsd.py
+++ b/python/PiFinder/gps_gpsd.py
@@ -82,6 +82,7 @@ async def process_reading_messages(client, gps_queue, console_queue, gps_locked)
                         "lat": result.get("lat"),
                         "lon": result.get("lon"),
                         "altitude": result.get("altHAE"),
+                        "lock": True,
                     },
                 )
                 logger.debug("GPS fix: %s", msg)

--- a/python/PiFinder/imu_pi.py
+++ b/python/PiFinder/imu_pi.py
@@ -149,6 +149,20 @@ class Imu:
     def get_euler(self):
         return list(self.quat_to_euler(self.avg_quat))
 
+    def __str__(self):
+        return (
+            f"IMU Information:\n"
+            f"Calibration Status: {self.calibration}\n"
+            f"Quaternion History: {self.quat_history}\n"
+            f"Average Quaternion: {self.avg_quat}\n"
+            f"Moving: {self.moving()}\n"
+            f"Reading Difference: {self.__reading_diff}\n"
+            f"Flip Count: {self._flip_count}\n"
+            f"Last Sample Time: {self.last_sample_time}\n"
+            f"IMU Sample Frequency: {self.imu_sample_frequency}\n"
+            f"Moving Threshold: {self.__moving_threshold}\n"
+        )
+
 
 def imu_monitor(shared_state, console_queue, log_queue):
     MultiprocLogging.configurer(log_queue)
@@ -191,3 +205,12 @@ def imu_monitor(shared_state, console_queue, log_queue):
 
         if shared_state is not None and imu_calibrated:
             shared_state.set_imu(imu_data)
+
+
+if __name__ == "__main__":
+    print("Trying to read state from IMU")
+    imu = Imu()
+    for i in range(10):
+        imu.update()
+        time.sleep(0.5)
+    print(imu)

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -112,9 +112,9 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                 if location and dt:
                     # We have position and time/date!
                     calc_utils.sf_utils.set_location(
-                        location["lat"],
-                        location["lon"],
-                        location["altitude"],
+                        location.lat,
+                        location.lon,
+                        location.altitude,
                     )
                     alt, az = calc_utils.sf_utils.radec_to_altaz(
                         solved["RA"],

--- a/python/PiFinder/obslog.py
+++ b/python/PiFinder/obslog.py
@@ -57,9 +57,9 @@ class Observation_session:
 
         self.db.create_obs_session(
             local_time.timestamp(),
-            location["lat"],
-            location["lon"],
-            location["timezone"],
+            location.lat,
+            location.lon,
+            location.timezone,
             self.__session_uuid,
         )
 

--- a/python/PiFinder/server.py
+++ b/python/PiFinder/server.py
@@ -658,6 +658,9 @@ class Server:
                     "lat": lat,
                     "lon": lon,
                     "altitude": altitude,
+                    "error_in_m": 0,
+                    "source": "WEB",
+                    "lock": True,
                 },
             )
             self.gps_queue.put(msg)
@@ -699,11 +702,11 @@ class Server:
         logging.debug(
             "self shared state is %s and location is %s", self.shared_state, location
         )
-        if location["gps_lock"] is True:
+        if location.lock is True:
             self.gps_locked = True
-            self.lat = location["lat"]
-            self.lon = location["lon"]
-            self.altitude = location["altitude"]
+            self.lat = location.lat
+            self.lon = location.lon
+            self.altitude = location.altitude
         else:
             self.gps_locked = False
             self.lat = None

--- a/python/PiFinder/state.py
+++ b/python/PiFinder/state.py
@@ -13,6 +13,10 @@ from PiFinder import config
 import logging
 from typing import List
 from PiFinder.composite_object import CompositeObject
+from typing import Optional
+from dataclasses import dataclass, asdict
+import json
+from timezonefinder import TimezoneFinder
 
 logger = logging.getLogger("SharedState")
 
@@ -128,12 +132,61 @@ SharedStateObj(
               'Dec_target': 15.347716050003328, 'T_extract': 75.79255499877036, 'Alt': None, 'Az': None, 'solve_source': 'CAM', 'constellation': 'Psc'},
     imu={'moving': False, 'move_start': 1695297928.69749, 'move_end': 1695297928.764207, 'pos': [171.39798541261814, 202.7646132036331, 358.2794741322842],
          'start_pos': [171.4009455613444, 202.76321535004726, 358.2587208386012], 'status': 3},
-    location={'lat': 59.05139745, 'lon': 7.987654, 'altitude': 151.4, 'gps_lock': False, 'timezone': 'Europe/Stockholm', 'last_gps_lock': None},
+    location={'lat': 59.05139745, 'lon': 7.987654, 'altitude': 151.4, 'source': 'GPS', gps_lock': False, 'timezone': 'Europe/Stockholm', 'last_gps_lock': None},
     datetime=None,
     screen=<PIL.Image.Image image mode=RGB size=128x128 at 0xE693C910>,
     solve_pixel=[305.6970520019531, 351.9438781738281]
 )
 """
+
+
+@dataclass
+class Location:
+    """
+    the location of the observer, lat/lon/altitude and the source of the data.
+    """
+
+    lat: float = 0.0
+    lon: float = 0.0
+    altitude: float = 0.0
+    source: str = "None"
+    lock: bool = False  # lock means: we received a good enough location, not a GPS Fix
+    lock_type: int = 0
+    error_in_m: float = 0.0
+    timezone: Optional[str] = None
+    last_gps_lock: Optional[str] = None
+
+    def __str__(self):
+        return (
+            f"Location(lat={self.lat:.6f}, "
+            f"lon={self.lon:.6f}, "
+            f"alt={self.altitude:.1f}m, "
+            f"source={self.source}, "
+            f"error={self.error_in_m:.1f}m, "
+            f"lock={'Yes' if self.lock else 'No'} "
+            f"lock_type={self.lock_type}, "
+            f"{f', tz={self.timezone}' if self.timezone else ''}"
+            f"{f', last_lock={self.last_gps_lock}' if self.last_gps_lock else ''})"
+        )
+
+    def to_dict(self):
+        """Convert the Location object to a dictionary."""
+        return asdict(self)
+
+    def to_json(self):
+        """Convert the Location object to a JSON string."""
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a Location object from a dictionary."""
+        return cls(**data)
+
+    @classmethod
+    def from_json(cls, json_str):
+        """Create a Location object from a JSON string."""
+        data = json.loads(json_str)
+        return cls.from_dict(data)
 
 
 class SharedStateObj:
@@ -150,17 +203,24 @@ class SharedStateObj:
         self.__solution = None
         self.__sats = None
         self.__imu = None
-        self.__location = None
+        self.__location: Location = Location()
         self.__datetime = None
         self.__datetime_time = None
         self.__screen = None
         self.__solve_pixel = config.Config().get_option("solve_pixel")
         self.__arch = None
         self.__camera_align = False
+        # Are we prepared to do alt/az math
+        # We need gps lock and datetime
+        self.__altaz_ready = False
+        self.__tz_finder = TimezoneFinder()
 
     def serialize(self, output_file):
         with open(output_file, "wb") as f:
             pickle.dump(self, f)
+
+    def altaz_ready(self):
+        return bool(self.__location.lock and self.datetime())
 
     def solve_pixel(self, screen_space=False):
         """
@@ -221,6 +281,10 @@ class SharedStateObj:
         return self.__location
 
     def set_location(self, v):
+        # if value is not none, set the timezone
+        # before saving the value
+        if v:
+            v.timezone = self.__tz_finder.timezone_at(lat=v.lat, lng=v.lon)
         self.__location = v
 
     def last_image_metadata(self):
@@ -244,7 +308,7 @@ class SharedStateObj:
             return self.datetime()
 
         dt = self.datetime()
-        return dt.astimezone(pytz.timezone(self.__location["timezone"]))
+        return dt.astimezone(pytz.timezone(self.__location.timezone))
 
     def set_datetime(self, dt):
         if dt.tzname() is None:

--- a/python/PiFinder/ui/base.py
+++ b/python/PiFinder/ui/base.py
@@ -98,6 +98,13 @@ class UIModule:
         """
         pass
 
+    def inactive(self):
+        """
+        Called when a module becomes inactive
+        i.e. leaving a UI screen
+        """
+        pass
+
     def help(self) -> Union[None, list[Image.Image]]:
         """
         Called when help is selected from the
@@ -201,7 +208,7 @@ class UIModule:
             moving = True if imu and imu["pos"] and imu["moving"] else False
 
             # GPS status
-            if self.shared_state.location()["gps_lock"]:
+            if self.shared_state.altaz_ready():
                 self._gps_brightness = 0
             else:
                 gps_anim = int(128 * (time.time() - self.last_update_time)) + 1

--- a/python/PiFinder/ui/callbacks.py
+++ b/python/PiFinder/ui/callbacks.py
@@ -8,7 +8,6 @@ Each one takes the current ui module as an argument
 
 """
 
-import datetime
 import logging
 
 from PiFinder import utils
@@ -51,9 +50,8 @@ def activate_debug(ui_module: UIModule) -> None:
     add fake gps info
     """
     ui_module.command_queues["camera"].put("debug")
-    ui_module.command_queues["console"].put("Debug: Activated")
-    dt = datetime.datetime(2024, 6, 1, 2, 0, 0)
-    ui_module.shared_state.set_datetime(dt)
+    ui_module.command_queues["console"].put("Test Mode Activated")
+    ui_module.command_queues["ui_queue"].put("test_mode")
     ui_module.message("Test Mode")
 
 

--- a/python/PiFinder/ui/console.py
+++ b/python/PiFinder/ui/console.py
@@ -14,12 +14,15 @@ from PIL import Image
 from PiFinder.ui.base import UIModule
 from PiFinder.image_util import convert_image_to_mode
 
+
 def singleton(class_):
     instances = {}
+
     def getinstance(*args, **kwargs):
         if class_ not in instances:
             instances[class_] = class_(*args, **kwargs)
         return instances[class_]
+
     return getinstance
 
 
@@ -135,7 +138,7 @@ class UIConsole(UIModule):
             moving = True if imu and imu["pos"] and imu["moving"] else False
 
             # GPS status
-            if self.shared_state.location()["gps_lock"]:
+            if self.shared_state.altaz_ready():
                 self._gps_brightness = 0
             else:
                 gps_anim = int(128 * (time.time() - self.last_update_time)) + 1

--- a/python/PiFinder/ui/object_details.py
+++ b/python/PiFinder/ui/object_details.py
@@ -232,44 +232,43 @@ class UIObjectDetails(UIModule):
 
     def _render_pointing_instructions(self):
         # Pointing Instructions
-        indicator_color = 255 if self._unmoved else 128
-        point_az, point_alt = calc_utils.aim_degrees(
-            self.shared_state,
-            self.mount_type,
-            self.screen_direction,
-            self.object,
-        )
-        if not point_az:
-            if self.shared_state.solution() is None:
-                self.draw.text(
-                    (10, 70),
-                    "No solve",
-                    font=self.fonts.large.font,
-                    fill=self.colors.get(255),
-                )
-                self.draw.text(
-                    (10, 90),
-                    f"yet{'.' * int(self._elipsis_count / 10)}",
-                    font=self.fonts.large.font,
-                    fill=self.colors.get(255),
-                )
-            else:
-                self.draw.text(
-                    (10, 70),
-                    "Searching",
-                    font=self.fonts.large.font,
-                    fill=self.colors.get(255),
-                )
-                self.draw.text(
-                    (10, 90),
-                    f"for GPS{'.' * int(self._elipsis_count / 10)}",
-                    font=self.fonts.large.font,
-                    fill=self.colors.get(255),
-                )
+        if self.shared_state.solution() is None:
+            self.draw.text(
+                (10, 70),
+                "No solve",
+                font=self.fonts.large.font,
+                fill=self.colors.get(255),
+            )
+            self.draw.text(
+                (10, 90),
+                f"yet{'.' * int(self._elipsis_count / 10)}",
+                font=self.fonts.large.font,
+                fill=self.colors.get(255),
+            )
             self._elipsis_count += 1
             if self._elipsis_count > 39:
                 self._elipsis_count = 0
-        elif not self._check_catalog_initialised():
+            return
+
+        if not self.shared_state.altaz_ready():
+            self.draw.text(
+                (10, 70),
+                "Searching",
+                font=self.fonts.large.font,
+                fill=self.colors.get(255),
+            )
+            self.draw.text(
+                (10, 90),
+                f"for GPS{'.' * int(self._elipsis_count / 10)}",
+                font=self.fonts.large.font,
+                fill=self.colors.get(255),
+            )
+            self._elipsis_count += 1
+            if self._elipsis_count > 39:
+                self._elipsis_count = 0
+            return
+
+        if not self._check_catalog_initialised():
             self.draw.text(
                 (10, 70),
                 "Calculating",
@@ -282,60 +281,68 @@ class UIObjectDetails(UIModule):
                 font=self.fonts.large.font,
                 fill=self.colors.get(255),
             )
+            self._elipsis_count += 1
+            if self._elipsis_count > 39:
+                self._elipsis_count = 0
+            return
+
+        indicator_color = 255 if self._unmoved else 128
+        point_az, point_alt = calc_utils.aim_degrees(
+            self.shared_state,
+            self.mount_type,
+            self.screen_direction,
+            self.object,
+        )
+        if point_az < 0:
+            point_az *= -1
+            az_arrow = self._LEFT_ARROW
         else:
-            if point_az < 0:
-                point_az *= -1
-                az_arrow = self._LEFT_ARROW
-            else:
+            az_arrow = self._RIGHT_ARROW
+
+        # Check az arrow config
+        if self.config_object.get_option("pushto_az_arrows", "Default") == "Reverse":
+            if az_arrow is self._LEFT_ARROW:
                 az_arrow = self._RIGHT_ARROW
-
-            # Check az arrow config
-            if (
-                self.config_object.get_option("pushto_az_arrows", "Default")
-                == "Reverse"
-            ):
-                if az_arrow is self._LEFT_ARROW:
-                    az_arrow = self._RIGHT_ARROW
-                else:
-                    az_arrow = self._LEFT_ARROW
-
-            # Change decimal points when within 1 degree
-            if point_az < 1:
-                self.draw.text(
-                    self.az_anchor,
-                    f"{az_arrow}{point_az : >5.2f}",
-                    font=self.fonts.huge.font,
-                    fill=self.colors.get(indicator_color),
-                )
             else:
-                self.draw.text(
-                    self.az_anchor,
-                    f"{az_arrow}{point_az : >5.1f}",
-                    font=self.fonts.huge.font,
-                    fill=self.colors.get(indicator_color),
-                )
+                az_arrow = self._LEFT_ARROW
 
-            if point_alt < 0:
-                point_alt *= -1
-                alt_arrow = self._DOWN_ARROW
-            else:
-                alt_arrow = self._UP_ARROW
+        # Change decimal points when within 1 degree
+        if point_az < 1:
+            self.draw.text(
+                self.az_anchor,
+                f"{az_arrow}{point_az : >5.2f}",
+                font=self.fonts.huge.font,
+                fill=self.colors.get(indicator_color),
+            )
+        else:
+            self.draw.text(
+                self.az_anchor,
+                f"{az_arrow}{point_az : >5.1f}",
+                font=self.fonts.huge.font,
+                fill=self.colors.get(indicator_color),
+            )
 
-            # Change decimal points when within 1 degree
-            if point_alt < 1:
-                self.draw.text(
-                    self.alt_anchor,
-                    f"{alt_arrow}{point_alt : >5.2f}",
-                    font=self.fonts.huge.font,
-                    fill=self.colors.get(indicator_color),
-                )
-            else:
-                self.draw.text(
-                    self.alt_anchor,
-                    f"{alt_arrow}{point_alt : >5.1f}",
-                    font=self.fonts.huge.font,
-                    fill=self.colors.get(indicator_color),
-                )
+        if point_alt < 0:
+            point_alt *= -1
+            alt_arrow = self._DOWN_ARROW
+        else:
+            alt_arrow = self._UP_ARROW
+
+        # Change decimal points when within 1 degree
+        if point_alt < 1:
+            self.draw.text(
+                self.alt_anchor,
+                f"{alt_arrow}{point_alt : >5.2f}",
+                font=self.fonts.huge.font,
+                fill=self.colors.get(indicator_color),
+            )
+        else:
+            self.draw.text(
+                self.alt_anchor,
+                f"{alt_arrow}{point_alt : >5.1f}",
+                font=self.fonts.huge.font,
+                fill=self.colors.get(indicator_color),
+            )
 
     def update(self, force=True):
         # Clear Screen

--- a/python/PiFinder/ui/preview.py
+++ b/python/PiFinder/ui/preview.py
@@ -1,8 +1,11 @@
 #!/usr/bin/python
 # -*- coding:utf-8 -*-
 """
-This module contains all the UI Module classes
+This module contains the UIPreview class, a UI module for displaying and interacting with camera images.
 
+It handles image processing, including background subtraction and gamma correction, and provides zoom
+functionality. It also manages a marking menu for adjusting camera settings and draws reticles and star
+selectors on the images.
 """
 
 import sys

--- a/python/PiFinder/ui/status.py
+++ b/python/PiFinder/ui/status.py
@@ -270,11 +270,11 @@ class UIStatus(UIModule):
         sats = self.shared_state.sats()
         self.status_dict["GPS"] = [
             f"GPS {sats[0]}/{sats[1]}" if sats else "GPS 0/0",
-            f"{location['lat']:.2f}/{location['lon']:.2f}",
+            f"{location.lat:.2f}/{location.lon:.2f}",
         ]
 
-        self.status_dict["GPS ALT"] = f"{location['altitude']:.1f}m"
-        last_lock = location["last_gps_lock"]
+        self.status_dict["GPS ALT"] = f"{location.altitude:.1f}m"
+        last_lock = location.last_gps_lock
         self.status_dict["GPS LST"] = last_lock if last_lock else "--"
 
         dt = self.shared_state.datetime()


### PR DESCRIPTION
This PR brings in the GPS data structure refactor from pr#268 and:
* Add altaz_ready boolean to shared state - This is the preferred way to check that both time and date are available and accurate.
* Use altaz_ready in various places that used to check location/datetime in various combinations to avoid differing results
* Adjust planet catalog init/scheduling - as initial location is no longer set from config, planet catalog gen needs to wait.  altaz_ready is checked every 10 seconds to trigger initial planet catalog gen, then 307 second thereafter to update planet positions
* switch all usage of initialise to initialize - it's an arbitrary regional difference, but we have to choose one :-) 
* timezone calculation is moved to shared state to make sure it's triggered whenever location is set
* test mode now uses messages trigger centralized location/time setting in the main module

@mrosseel This may have had the side effect of preventing the solver crash when setting location/datetime from the web interface.  I've tested this a lot and it seems to not crash any longer 🤷  