### PR TITLE
Log rotation

### DIFF
--- a/python/PiFinder/gps_ubx_parser.py
+++ b/python/PiFinder/gps_ubx_parser.py
@@ -209,7 +209,7 @@ class UBXParser:
                             ck_b = (ck_b + ck_a) & 0xFF
                         if msg_data[-2] == ck_a and msg_data[-1] == ck_b:
                             parsed = self._parse_ubx(bytes(msg_data))
-                            if parsed.get("class"):
+                            if "class" in parsed:
                                 logger.debug(f"Parsed UBX message: {parsed}")
                                 yield parsed
                         else:
@@ -266,16 +266,20 @@ class UBXParser:
         ecefZ = int.from_bytes(data[20:24], "little", signed=True) / 100.0
         pAcc = int.from_bytes(data[24:28], "little") / 100.0
         numSV = data[47]
-        lla = self._ecef_to_lla(ecefX, ecefY, ecefZ)
-        result = {
-            "class": "NAV-SOL",
-            "mode": gpsFix,
-            "lat": lla["latitude"],
-            "lon": lla["longitude"],
-            "altHAE": lla["altitude"],
-            "ecefpAcc": pAcc,
-            "satellites": numSV,
-        }
+        result = {}
+        if ecefX == 0 or ecefY == 0 or ecefZ == 0:
+            logging.debug(f"nav_sol zeroes: ecefX: {ecefX}, ecefY: {ecefY}, ecefZ: {ecefZ}, pAcc: {pAcc}, numSV: {numSV}")
+        else:
+            lla = self._ecef_to_lla(ecefX, ecefY, ecefZ)
+            result = {
+                "class": "NAV-SOL",
+                "mode": gpsFix,
+                "lat": lla["latitude"],
+                "lon": lla["longitude"],
+                "altHAE": lla["altitude"],
+                "ecefpAcc": pAcc,
+                "satellites": numSV,
+            }
         logger.debug(f"NAV-SOL result: {result}")
         return result
 
@@ -417,13 +421,17 @@ class UBXParser:
         ecefX = int.from_bytes(data[4:8], "little", signed=True) / 100.0
         ecefY = int.from_bytes(data[8:12], "little", signed=True) / 100.0
         ecefZ = int.from_bytes(data[12:16], "little", signed=True) / 100.0
-        lla = self._ecef_to_lla(ecefX, ecefY, ecefZ)
-        result = {
-            "class": "NAV-POSECEF",
-            "lat": lla["latitude"],
-            "lon": lla["longitude"],
-            "altHAE": lla["altitude"],
-        }
+        result = {}
+        if ecefX == 0 or ecefY == 0 or ecefZ == 0:
+            logging.debug(f"nav_posecef zeroes: ecefX: {ecefX}, ecefY: {ecefY}, ecefZ: {ecefZ}")
+        else:
+            lla = self._ecef_to_lla(ecefX, ecefY, ecefZ)
+            result = {
+                "class": "NAV-POSECEF",
+                "lat": lla["latitude"],
+                "lon": lla["longitude"],
+                "altHAE": lla["altitude"],
+            }
         logger.debug(f"NAV-POSECEF result: {result}")
         return result
 

--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -765,38 +765,12 @@ def main(
             exit()
 
 
-def rotate_logs() -> Path:
-    """
-    Rotates log files, returns the log file to use
-    """
-    log_index = list(range(5))
-    log_index.reverse()
-    for i in log_index:
-        try:
-            shutil.copyfile(
-                utils.data_dir / f"pifinder.{i}.log",
-                utils.data_dir / f"pifinder.{i+1}.log",
-            )
-        except FileNotFoundError:
-            pass
-
-    try:
-        shutil.move(
-            utils.data_dir / "pifinder.log",
-            utils.data_dir / "pifinder.0.log",
-        )
-    except FileNotFoundError:
-        pass
-
-    return utils.data_dir / "pifinder.log"
-
-
 if __name__ == "__main__":
     print("Bootstrap logging configuration ...")
     logging.basicConfig(format="%(asctime)s BASIC %(name)s: %(levelname)s %(message)s")
     rlogger = logging.getLogger()
     rlogger.setLevel(logging.INFO)
-    log_path = rotate_logs()
+    log_path = utils.data_dir / "pifinder.log"
     try:
         log_helper = MultiprocLogging(
             Path("pifinder_logconf.json"),

--- a/python/PiFinder/multiproclogging.py
+++ b/python/PiFinder/multiproclogging.py
@@ -121,8 +121,10 @@ class MultiprocLogging:
         for hdlr in hdlrs:
             rLogger.removeHandler(hdlr)
 
-        # configure logging to store everything in output
-        h = logging.handlers.WatchedFileHandler(output)
+        # Set maxBytes to 50MB (50 * 1024 * 1024 bytes) and keep 5 backup files
+        h = logging.handlers.RotatingFileHandler(
+            output, maxBytes=50*1024*1024, backupCount=5, encoding='utf-8'
+        )
         f = logging.Formatter(self._formatter)
         h.setFormatter(f)
         rLogger.addHandler(h)


### PR DESCRIPTION
- removes the manual log rotation from main
- changes the watchedfilehandler from multiproclogging with a rotatingfilehandler
- configures 5 log files of maximum 50Mb each (I've seen 300Mb+ log files before this fix)

Numbers can be discussed of course.