### PR TITLE
Add Analog Sky Dream PiFinder type

### DIFF
--- a/python/PiFinder/cat_images.py
+++ b/python/PiFinder/cat_images.py
@@ -19,7 +19,13 @@ logger = logging.getLogger("Catalog.Images")
 
 
 def get_display_image(
-    catalog_object, eyepiece_text, fov, roll, display_class, burn_in=True, magnification=None
+    catalog_object,
+    eyepiece_text,
+    fov,
+    roll,
+    display_class,
+    burn_in=True,
+    magnification=None,
 ):
     """
     Returns a 128x128 image buffer for
@@ -128,11 +134,16 @@ def get_display_image(
             shadow_color=display_class.colors.get(0),
             outline=2,
         )
-        
-        magnification_text = f"{magnification:.0f}x" if magnification and magnification > 0 else "?x"
+
+        magnification_text = (
+            f"{magnification:.0f}x" if magnification and magnification > 0 else "?x"
+        )
         ui_utils.shadow_outline_text(
             ri_draw,
-            (display_class.resX - (display_class.fonts.base.width * 4), display_class.titlebar_height - 1),
+            (
+                display_class.resX - (display_class.fonts.base.width * 4),
+                display_class.titlebar_height - 1,
+            ),
             magnification_text,
             font=display_class.fonts.base,
             align="right",

--- a/python/PiFinder/imu_pi.py
+++ b/python/PiFinder/imu_pi.py
@@ -41,6 +41,15 @@ class Imu:
                 adafruit_bno055.AXIS_REMAP_POSITIVE,
                 adafruit_bno055.AXIS_REMAP_NEGATIVE,
             )
+        elif cfg.get_option("screen_direction") == "as_dream":
+            self.sensor.axis_remap = (
+                adafruit_bno055.AXIS_REMAP_Y,
+                adafruit_bno055.AXIS_REMAP_X,
+                adafruit_bno055.AXIS_REMAP_Z,
+                adafruit_bno055.AXIS_REMAP_POSITIVE,
+                adafruit_bno055.AXIS_REMAP_POSITIVE,
+                adafruit_bno055.AXIS_REMAP_POSITIVE,
+            )
         else:
             self.sensor.axis_remap = (
                 adafruit_bno055.AXIS_REMAP_Z,

--- a/python/PiFinder/imu_pi.py
+++ b/python/PiFinder/imu_pi.py
@@ -43,9 +43,9 @@ class Imu:
             )
         elif cfg.get_option("screen_direction") == "as_dream":
             self.sensor.axis_remap = (
-                adafruit_bno055.AXIS_REMAP_Y,
                 adafruit_bno055.AXIS_REMAP_X,
                 adafruit_bno055.AXIS_REMAP_Z,
+                adafruit_bno055.AXIS_REMAP_Y,
                 adafruit_bno055.AXIS_REMAP_POSITIVE,
                 adafruit_bno055.AXIS_REMAP_POSITIVE,
                 adafruit_bno055.AXIS_REMAP_POSITIVE,

--- a/python/PiFinder/keyboard_pi.py
+++ b/python/PiFinder/keyboard_pi.py
@@ -17,32 +17,60 @@ logger = logging.getLogger("Keyboard.Pi")
 
 
 class KeyboardPi(KeyboardInterface):
-    def __init__(self, q):
+    def __init__(self, q, dream_remap=False):
         self.q = q
 
         self.cols = [16, 23, 26, 27]
         self.rows = [19, 17, 18, 22, 20]
+
+        if dream_remap:
+            _up = self.RIGHT
+            _down = self.LEFT
+            _left = self.UP
+            _right = self.DOWN
+            _lng_up = self.LNG_RIGHT
+            _lng_down = self.LNG_LEFT
+            _lng_left = self.LNG_UP
+            _lng_right = self.LNG_DOWN
+            _alt_up = self.ALT_RIGHT
+            _alt_down = self.ALT_LEFT
+            _alt_left = self.ALT_UP
+            _alt_right = self.ALT_DOWN
+        else:
+            _up = self.UP
+            _down = self.DOWN
+            _left = self.LEFT
+            _right = self.RIGHT
+            _lng_up = self.LNG_UP
+            _lng_down = self.LNG_DOWN
+            _lng_left = self.LNG_LEFT
+            _lng_right = self.LNG_RIGHT
+            _alt_up = self.ALT_UP
+            _alt_down = self.ALT_DOWN
+            _alt_left = self.ALT_LEFT
+            _alt_right = self.ALT_RIGHT
+
         # fmt: off
         self.keymap = [
             7 , 8 , 9 , self.NA,
             4 , 5 , 6 , self.PLUS,
             1 , 2 , 3 , self.MINUS,
             self.NA, 0 , self.NA, self.SQUARE,
-            self.LEFT , self.UP , self.DOWN , self.RIGHT,
+            _left, _up , _down , _right,
         ]
         self.alt_keymap = [
             self.NA, self.NA, self.NA, self.NA,
             self.NA, self.NA, self.NA, self.ALT_PLUS,
             self.NA, self.NA, self.NA, self.ALT_MINUS,
             self.NA, self.ALT_0, self.NA, self.NA,
-            self.ALT_LEFT, self.ALT_UP, self.ALT_DOWN, self.ALT_RIGHT,
+            _alt_left, _alt_up, _alt_down, _alt_right,
         ]
         self.long_keymap = [
             self.NA, self.NA, self.NA, self.NA,
             self.NA, self.NA, self.NA, self.NA,
             self.NA, self.NA, self.NA, self.NA,
             self.NA, self.NA, self.NA, self.LNG_SQUARE,
-            self.LNG_LEFT, self.LNG_UP, self.LNG_DOWN, self.LNG_RIGHT,
+            _lng_left, _lng_up, _lng_down, _lng_right,
         ]
         # fmt: on
 
@@ -142,7 +170,7 @@ class KeyboardPi(KeyboardInterface):
                 GPIO.setup(self.rows[i], GPIO.IN)
 
 
-def run_keyboard(q, shared_state, log_queue):
+def run_keyboard(q, shared_state, log_queue, dream_remap=False):
     MultiprocLogging.configurer(log_queue)
-    keyboard = KeyboardPi(q)
+    keyboard = KeyboardPi(q, dream_remap=dream_remap)
     keyboard.run_keyboard(log_queue)

--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -288,6 +288,8 @@ def main(
     # init screen
     screen_brightness = cfg.get_option("display_brightness")
     set_brightness(screen_brightness, cfg)
+    if cfg.get_option("screen_direction") == "as_dream":
+        display_device.device.rotate = 3
 
     # Set user interface language
     lang = cfg.get_option("language", "en")
@@ -336,10 +338,14 @@ def main(
         console.write("   Keyboard")
         logger.info("   Keyboard")
         console.update()
+        if cfg.get_option("screen_direction") == "as_dream":
+            dream_key_remap = True
+        else:
+            dream_key_remap = False
         keyboard_process = Process(
             name="Keyboard",
             target=keyboard.run_keyboard,
-            args=(keyboard_queue, shared_state, keyboard_logqueue),
+            args=(keyboard_queue, shared_state, keyboard_logqueue, dream_key_remap),
         )
         keyboard_process.start()
         if script_name:

--- a/python/PiFinder/ui/menu_structure.py
+++ b/python/PiFinder/ui/menu_structure.py
@@ -885,6 +885,10 @@ pifinder_menu = {
                             "name": _("Flat v2"),
                             "value": "flat",
                         },
+                        {
+                            "name": _("AS Dream"),
+                            "value": "as_dream",
+                        },
                     ],
                 },
                 {


### PR DESCRIPTION
<img width="535" alt="Screenshot 2025-06-26 at 4 07 03 PM" src="https://github.com/user-attachments/assets/f4cacc5f-357e-40e5-b594-962c767b8470" />

Adding a new configuration for the PiFinder integrated with the Analog Sky "Dream" scope. 

* Adjust IMU axis
* Add screen rotation
* Remap directional buttons