### PR TITLE
exit on error, allow reruns, disable unwanted ModemManager

### DIFF
--- a/pifinder_setup.sh
+++ b/pifinder_setup.sh
@@ -1,22 +1,38 @@
-#! /usr/bin/bash
+#!/usr/bin/bash
+# This script installs the PiFinder software on a prepared Raspberry Pi OS.
+# See https://pifinder.readthedocs.io/en/release/software.html for more info.
+
+set -e
+
+cd ~pifinder/
+
 sudo apt-get install -y git python3-pip samba samba-common-bin dnsmasq hostapd dhcpd gpsd
 
-git clone --recursive --branch release https://github.com/brickbots/PiFinder.git
-cd PiFinder
-sudo pip install -r python/requirements.txt
+if [[ -d PiFinder/ ]]; then
+    cd PiFinder/ && git config pull.rebase false && git pull
+else
+    git clone --recursive --branch release https://github.com/brickbots/PiFinder.git
+fi
+cd ~/PiFinder/ && sudo pip install -r python/requirements.txt
 
 # Setup GPSD
 sudo dpkg-reconfigure -plow gpsd
 sudo cp ~/PiFinder/pi_config_files/gpsd.conf /etc/default/gpsd
 
 # data dirs
+[[ -d ~/PiFinder_data ]] || \
 mkdir ~/PiFinder_data
+[[ -d ~/PiFinder_data/captures ]] || \
 mkdir ~/PiFinder_data/captures
+[[ -d ~/PiFinder_data/obslists ]] || \
 mkdir ~/PiFinder_data/obslists
+[[ -d ~/PiFinder_data/screenshots ]] || \
 mkdir ~/PiFinder_data/screenshots
+[[ -d ~/PiFinder_data/solver_debug_dumps ]] || \
 mkdir ~/PiFinder_data/solver_debug_dumps
+[[ -d ~/PiFinder_data/logs ]] || \
 mkdir ~/PiFinder_data/logs
-chmod -R 777 ~/PiFinder_data
+find ~/PiFinder_data -type d -exec chmod 755 {} \;
 
 # Wifi config
 sudo cp ~/PiFinder/pi_config_files/dhcpcd.* /etc
@@ -33,14 +49,26 @@ sudo chmod 666 /etc/wpa_supplicant/wpa_supplicant.conf
 sudo cp ~/PiFinder/pi_config_files/smb.conf /etc/samba/smb.conf
 
 # Hipparcos catalog
-wget -O /home/pifinder/PiFinder/astro_data/hip_main.dat https://cdsarc.cds.unistra.fr/ftp/cats/I/239/hip_main.dat
+HIP_MAIN_DAT="/home/pifinder/PiFinder/astro_data/hip_main.dat"
+if [[ ! -e $HIP_MAIN_DAT ]]; then
+    wget -O $HIP_MAIN_DAT https://cdsarc.cds.unistra.fr/ftp/cats/I/239/hip_main.dat
+fi
 
 # Enable interfaces
-echo "dtparam=spi=on" | sudo tee -a /boot/config.txt
-echo "dtparam=i2c_arm=on" | sudo tee -a /boot/config.txt
-echo "dtparam=i2c_arm_baudrate=10000" | sudo tee -a /boot/config.txt
-echo "dtoverlay=pwm,pin=13,func=4" | sudo tee -a /boot/config.txt
-echo "dtoverlay=uart3" | sudo tee -a /boot/config.txt
+grep -q "dtparam=spi=on" /boot/config.txt || \
+   echo "dtparam=spi=on" | sudo tee -a /boot/config.txt
+grep -q "dtparam=i2c_arm=on" /boot/config.txt || \
+   echo "dtparam=i2c_arm=on" | sudo tee -a /boot/config.txt
+grep -q "dtparam=i2c_arm_baudrate=10000" /boot/config.txt || \
+   echo "dtparam=i2c_arm_baudrate=10000" | sudo tee -a /boot/config.txt
+grep -q "dtoverlay=pwm,pin=13,func=4" /boot/config.txt || \
+   echo "dtoverlay=pwm,pin=13,func=4" | sudo tee -a /boot/config.txt
+grep -q "dtoverlay=uart3" /boot/config.txt || \
+   echo "dtoverlay=uart3" | sudo tee -a /boot/config.txt
+# Note: camera types are added lateron by python/PiFinder/switch_camera.py
+
+# Disable unwanted services
+sudo systemctl disable ModemManager
 
 # Enable service
 sudo cp /home/pifinder/PiFinder/pi_config_files/pifinder.service /lib/systemd/system/pifinder.service


### PR DESCRIPTION
There should be 0 impact on existing use. Changes are:
- exit on error, so the script becomes reliable
- the script can now be run multiple times, it skips/adapts to parts already done
- disable the unused modem manager service, this frees up memory and improves battery life