### PR TITLE
Planet names - replace generic planet identifiers PL 1 and PL 2 with meaningful planet names …

### DIFF
--- a/python/PiFinder/composite_object.py
+++ b/python/PiFinder/composite_object.py
@@ -97,9 +97,12 @@ class CompositeObject:
     def from_dict(cls, d):
         return cls(**d)
 
+    # Planets use their common name; all other catalogs use the standard format.
     @property
     def display_name(self):
         """
         Returns the display name for this object
         """
+        if self.catalog_code == "PL" and self.names:
+            return self.names[0]
         return f"{self.catalog_code} {self.sequence}"

--- a/python/PiFinder/ui/object_list.py
+++ b/python/PiFinder/ui/object_list.py
@@ -358,10 +358,24 @@ class UIObjectList(UITextMenu):
         result = ", ".join(dedups)
         return result
 
+    # Use 3-letter abbreviations for planets instead of PL1, PL2, etc.
+    # Falls back to full name if planet is not in the dictionary.
     def create_shortname_text(self, obj: CompositeObject) -> str:
-        name = f"{obj.catalog_code}{obj.sequence}"
-        return name
-        # return f"{name: <7}"
+        if obj.catalog_code == "PL" and obj.names:
+            planet_abbrevs = {
+                "Mercury": "MER",
+                "Venus":   "VEN",
+                "Moon":    "MON",
+                "Mars":    "MAR",
+                "Jupiter": "JUP",
+                "Saturn":  "SAT",
+                "Uranus":  "URA",
+                "Neptune": "NEP",
+                "Pluto":   "PLU",
+            }
+            return planet_abbrevs.get(obj.names[0], obj.names[0])
+        return f"{obj.catalog_code}{obj.sequence}"
+
 
     def create_locate_text(self, obj: CompositeObject) -> str:
         az, alt = aim_degrees(
@@ -372,6 +386,7 @@ class UIObjectList(UITextMenu):
             distance = f"{az_txt} {alt_txt}"
         else:
             distance = "--- ---"
+            # distance = obj.names[0] if obj.names else "--- ---"
 
         return distance
 


### PR DESCRIPTION
# Planet Display Changes

## Summary

Two code changes across two files to replace generic planet identifiers
(`PL1`, `PL2`) with meaningful planet names in both the object list and
the details/navigation screen.

---

## Change 1 — Object List: Abbreviated Planet Name as Row Label

**File:** `python/PiFinder/ui/object_list.py`
**Method:** `create_shortname_text`

### What it does
Replaces the generic `PL1`, `PL2` row labels in the object list with
3-letter planet abbreviations (e.g. `MER`, `VEN`). All other catalogs
are unaffected.

### Before
```python
def create_shortname_text(self, obj: CompositeObject) -> str:
    name = f"{obj.catalog_code}{obj.sequence}"
    return name
```

### After
```python
def create_shortname_text(self, obj: CompositeObject) -> str:
    # Use 3-letter abbreviations for planets instead of PL1, PL2, etc.
    # Falls back to full name if planet is not in the dictionary.
    if obj.catalog_code == "PL" and obj.names:
        planet_abbrevs = {
            "Mercury": "MER",
            "Venus":   "VEN",
            "Moon":    "MON",
            "Mars":    "MAR",
            "Jupiter": "JUP",
            "Saturn":  "SAT",
            "Uranus":  "URA",
            "Neptune": "NEP",
            "Pluto":   "PLU",
        }
        return planet_abbrevs.get(obj.names[0], obj.names[0])
    return f"{obj.catalog_code}{obj.sequence}"
```

---

## Change 2 — Object Details Screen: Full Planet Name as Designator

**File:** `python/PiFinder/composite_object.py`
**Property:** `display_name`

### What it does
`display_name` drives the header, title bar, and name deduplication on the
Object Details screen. Overriding it here for planets fixes all of those in
one place — the screen now shows `Mercury` instead of `PL 1`.

### Before
```python
@property
def display_name(self):
    """
    Returns the display name for this object
    """
    return f"{self.catalog_code} {self.sequence}"
```

### After
```python
@property
def display_name(self):
    """
    Returns the display name for this object.
    For the Planet catalog, returns the full planet name (e.g. "Mercury")
    instead of the generic sequence label (e.g. "PL 1").
    """
    # Planets use their common name; all other catalogs use the standard format.
    if self.catalog_code == "PL" and self.names:
        return self.names[0]
    return f"{self.catalog_code} {self.sequence}"
```

---

## Files Changed

| File | Method / Property | Purpose |
|---|---|---|
| `python/PiFinder/ui/object_list.py` | `create_shortname_text` | Abbreviated planet name as list row label |
| `python/PiFinder/composite_object.py` | `display_name` | Full planet name on Object Details screen |