### PR TITLE
fix: use default_factory for mutable dataclass default in MarkingMenu

### DIFF
--- a/python/PiFinder/ui/marking_menus.py
+++ b/python/PiFinder/ui/marking_menus.py
@@ -11,7 +11,7 @@ from typing import Any, Union
 
 from PIL import Image, ImageDraw, ImageChops
 from PiFinder.ui.fonts import Font
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from PiFinder.displays import DisplayBase
 
 
@@ -35,7 +35,9 @@ class MarkingMenu:
     down: MarkingMenuOption
     left: MarkingMenuOption
     right: MarkingMenuOption
-    up: MarkingMenuOption = MarkingMenuOption(label="HELP")
+    up: MarkingMenuOption = field(
+        default_factory=lambda: MarkingMenuOption(label="HELP")
+    )
 
     def select_none(self):
         self.up.selected = False


### PR DESCRIPTION
## Summary
- Python 3.11+ enforces that dataclass fields cannot have mutable defaults
- `MarkingMenu.up` used `MarkingMenuOption(label="HELP")` as a default value, which raises `ValueError` on 3.11+
- Changed to `field(default_factory=lambda: MarkingMenuOption(label="HELP"))` which is backwards-compatible with Python 3.9+

## Test plan
- [x] `ruff check` passes
- [x] `ruff format` passes
- [ ] Verify marking menu still works correctly on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)