### PR TITLE
fix: update observed filter cache after logging

### DIFF
--- a/python/PiFinder/db/observations_db.py
+++ b/python/PiFinder/db/observations_db.py
@@ -121,6 +121,10 @@ class ObservationsDatabase(Database):
         )
         self.conn.commit()
 
+        # Update cache so filters reflect the new observation immediately
+        if (catalog, sequence) not in self.observed_objects_cache:
+            self.observed_objects_cache.append((catalog, sequence))
+
         observation_id = self.cursor.execute(
             "select last_insert_rowid() as id"
         ).fetchone()["id"]

--- a/python/PiFinder/ui/log.py
+++ b/python/PiFinder/ui/log.py
@@ -282,6 +282,7 @@ class UILog(UIModule):
             solution=self.shared_state.solution(),
             notes=notes,
         )
+        self.object.logged = True
         self.reset_config()
 
     def key_number(self, number: int):


### PR DESCRIPTION
## Summary

- After logging an observation, the in-memory `observed_objects_cache` was not updated, so filtering by "observed/not observed" gave stale results within the same session
- Add `(catalog, sequence)` to the cache immediately after `log_object()` commits
- Set `obj.logged = True` on the `CompositeObject` so catalog filters see the change without a cache lookup

## Test plan

- [ ] Log an observation on an object
- [ ] Without restarting, filter catalog by "observed = Yes" — newly logged object should appear
- [ ] Filter by "observed = No" — newly logged object should no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)