### PR TITLE
Fix empty logs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportUndefinedVariable": "none"
+  },
+  "files.associations": {
+    "*logconf*.json": "jsonc"
+  }
+}
+

--- a/python/PiFinder/comets.py
+++ b/python/PiFinder/comets.py
@@ -4,6 +4,7 @@ from skyfield.data import mpc
 from skyfield.constants import GM_SUN_Pitjeva_2005_km3_s2 as GM_SUN
 from PiFinder.utils import Timer, comet_file
 from PiFinder.calc_utils import sf_utils
+import pandas as pd
 import requests
 import os
 import logging
@@ -196,6 +197,14 @@ def calc_comets(
             .groupby("designation", as_index=False)
             .last()
             .set_index("designation", drop=False)
+        )
+
+        # groupby/last can coerce numeric columns to strings when NaN values
+        # are present; ensure perihelion date fields are numeric before use
+        for col in ("perihelion_year", "perihelion_month", "perihelion_day"):
+            comets_df[col] = pd.to_numeric(comets_df[col], errors="coerce")
+        comets_df = comets_df.dropna(
+            subset=["perihelion_year", "perihelion_month", "perihelion_day"]
         )
 
         # Report progress after pandas processing (roughly 66% of setup time)

--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -35,6 +35,7 @@ from PiFinder import solver
 from PiFinder import config
 from PiFinder import pos_server
 from PiFinder import utils
+from PiFinder import server
 from PiFinder import keyboard_interface
 
 from PiFinder.multiproclogging import MultiprocLogging

--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -35,7 +35,6 @@ from PiFinder import solver
 from PiFinder import config
 from PiFinder import pos_server
 from PiFinder import utils
-from PiFinder import server
 from PiFinder import keyboard_interface
 
 from PiFinder.multiproclogging import MultiprocLogging
@@ -50,6 +49,8 @@ from PiFinder.state import SharedStateObj, UIState
 from PiFinder.image_util import subtract_background
 
 from PiFinder.displays import DisplayBase, get_display
+
+import PiFinder.manager_patch as patch
 
 from typing import Any, TYPE_CHECKING
 
@@ -122,6 +123,9 @@ def setup_dirs():
     utils.create_path(Path(utils.data_dir, "solver_debug_dumps"))
     utils.create_path(Path(utils.data_dir, "logs"))
     os.chmod(Path(utils.data_dir), 0o777)
+
+
+patch.apply()
 
 
 class StateManager(BaseManager):
@@ -347,10 +351,6 @@ def main(
         "messages", "locale", languages=[lang], fallback=(lang == "en")
     )
     langXX.install()
-
-    import PiFinder.manager_patch as patch
-
-    patch.apply()
 
     with StateManager() as manager:
         shared_state = manager.SharedState()  # type: ignore[attr-defined]

--- a/python/PiFinder/multiproclogging.py
+++ b/python/PiFinder/multiproclogging.py
@@ -87,6 +87,10 @@ class MultiprocLogging:
             len(self._queues) >= 1
         ), "No queues in use. You should have requested at least one queue."
 
+        # Create the main-process queue BEFORE starting the sink so the sink
+        # receives it in its queue list and monitors it.
+        queue = initial_queue if initial_queue is not None else self.get_queue()
+
         self._proc = Process(
             target=self._run_sink,
             args=(
@@ -97,7 +101,6 @@ class MultiprocLogging:
         # Start separate process that consumes from the queues.
         self._proc.start()
         # Now in this process we can divert logging to the newly created class
-        queue = self.get_queue()
         MultiprocLogging.configurer(queue)
 
     def join(self):

--- a/python/PiFinder/server.py
+++ b/python/PiFinder/server.py
@@ -781,7 +781,7 @@ class Server:
         def stream_logs():
             try:
                 position = int(request.query.get("position", 0))
-                log_file = "/home/pifinder/PiFinder_data/pifinder.log"
+                log_file = str(utils.data_dir / "pifinder.log") 
 
                 try:
                     file_size = os.path.getsize(log_file)

--- a/python/PiFinder/server.py
+++ b/python/PiFinder/server.py
@@ -781,7 +781,7 @@ class Server:
         def stream_logs():
             try:
                 position = int(request.query.get("position", 0))
-                log_file = str(utils.data_dir / "pifinder.log") 
+                log_file = str(utils.data_dir / "pifinder.log")
 
                 try:
                     file_size = os.path.getsize(log_file)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -42,6 +42,9 @@ indent-width = 4
 # Assume Python 3.9
 target-version = "py39"
 
+# _ is the i18n/gettext builtin injected at runtime
+builtins = ["_"]
+
 [tool.ruff.lint]
 # Enable preview mode, allow os.env changes before imports
 preview = true


### PR DESCRIPTION
Some logs didn't get stored in the log file, due to an issue with Multiproc logger.

Along the way: 
- Silence warnings in VScode, that are catched by nox. 
   - ruff complaining about `_` not being defined.
   - flagging of comments in json
   - pylance also complaining about `_`
- Fix an exception in comet processing
- Using a dynamic path to the PiFinder_data directory, so the log tab in the website is able to read the current log file.

TODOs:
- [ ] Test on physical PiFinder unit.

<!-- branch-stack-start -->

-------------------------
- main
  - **Fix empty logs** :point_left:
    - https://github.com/brickbots/PiFinder/pull/403
      - https://github.com/brickbots/PiFinder/pull/404

<sup>[Stack](https://www.git-town.com/how-to/proposal-breadcrumb.html) generated by [Git Town](https://github.com/git-town/git-town)</sup>

<!-- branch-stack-end -->
