### PR TITLE
fix: handle MPC comet data with unparseable orbital elements

### DIFF
--- a/python/PiFinder/comets.py
+++ b/python/PiFinder/comets.py
@@ -4,6 +4,7 @@ from skyfield.data import mpc
 from skyfield.constants import GM_SUN_Pitjeva_2005_km3_s2 as GM_SUN
 from PiFinder.utils import Timer, comet_file
 from PiFinder.calc_utils import sf_utils
+import pandas as pd
 import requests
 import os
 import logging
@@ -187,6 +188,39 @@ def calc_comets(
         with open(comet_file, "rb") as f:
             comets_df = mpc.load_comets_dataframe(f)
 
+        # Ensure orbital element columns are numeric — MPC data sometimes
+        # contains rows that Skyfield's parser can't handle (e.g. MPEC
+        # 2026-F34 historical comets), which causes the entire column to
+        # become dtype=object (strings).  Skyfield's comet_orbit() then
+        # crashes on every comet with a numpy UFuncNoLoopError.
+        numeric_cols = [
+            "perihelion_year",
+            "perihelion_month",
+            "perihelion_day",
+            "argument_of_perihelion_degrees",
+            "longitude_of_ascending_node_degrees",
+            "inclination_degrees",
+            "eccentricity",
+            "perihelion_distance_au",
+            "magnitude_g",
+            "magnitude_k",
+        ]
+        for col in numeric_cols:
+            if col in comets_df.columns:
+                comets_df[col] = pd.to_numeric(comets_df[col], errors="coerce")
+
+        # Drop rows where essential orbital elements couldn't be parsed
+        essential = [
+            "perihelion_year",
+            "perihelion_month",
+            "perihelion_day",
+            "eccentricity",
+            "perihelion_distance_au",
+        ]
+        comets_df = comets_df.dropna(
+            subset=[c for c in essential if c in comets_df.columns]
+        )
+
         # Report progress after file loading (roughly 33% of setup time)
         if progress_callback:
             progress_callback(1)
@@ -208,7 +242,11 @@ def calc_comets(
 
         for comet in comet_data:
             if comet_names is None or comet[0] in comet_names:
-                result = process_comet(comet, dt)
+                try:
+                    result = process_comet(comet, dt)
+                except Exception as e:
+                    logger.warning(f"Skipping comet {comet[0]}: {e}")
+                    result = {}
                 if result:
                     comet_dict[result["name"]] = result
 


### PR DESCRIPTION
## Summary

- MPC's comet data file (CometEls.txt) periodically includes rows that Skyfield's `load_comets_dataframe()` can't parse correctly (e.g. MPEC 2026-F34 added 27 historical comets with malformed fixed-width fields). When even a single row has an unparseable `perihelion_year`, pandas falls back to `dtype=object` for the **entire column**, turning every year value into a string like `'2028'` instead of an integer. Skyfield's `comet_orbit()` then crashes on **every comet** with `numpy UFuncNoLoopError: ufunc 'add' did not contain a loop with signature matching types (dtype('<U4'), dtype('float64'))`.
- Force `pd.to_numeric(errors="coerce")` on all orbital element columns after loading to ensure proper numeric dtypes regardless of bad rows
- Drop rows where essential fields (perihelion year/month/day, eccentricity, distance) couldn't be parsed
- Add try/except safety net around individual comet orbit calculations so a single bad entry can't crash the entire catalog

## Test plan

- [x] Verified crash reproduces with March 17 2026 MPC data file (297KB, 1728 rows, 27 unparseable)
- [x] Verified fix correctly parses remaining 1701 comets after dropping bad rows
- [x] Verified smaller/older MPC files (no bad rows) still work unchanged
- [x] CI lint/format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)