### PR TITLE
Add type annotations to get a clean mypy log.

### DIFF
--- a/python/PiFinder/catalog_base.py
+++ b/python/PiFinder/catalog_base.py
@@ -171,7 +171,7 @@ class VirtualIDManager:
 class TimerMixin:
     """Provides timer functionality via composition"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.timer: Optional[threading.Timer] = None
         self.is_running: bool = False
         self.time_delay_seconds: Union[int, Callable[[], int]] = (

--- a/python/PiFinder/catalog_imports/database.py
+++ b/python/PiFinder/catalog_imports/database.py
@@ -4,11 +4,12 @@ Shared database module for catalog imports.
 This module provides centralized access to database objects for all catalog loaders.
 """
 
-from .catalog_import_utils import init_databases
+from typing import Optional
+from .catalog_import_utils import init_databases, ObjectsDatabase, ObservationsDatabase
 
 # Global database objects shared across all catalog loaders
-objects_db = None
-observations_db = None
+objects_db: Optional[ObjectsDatabase] = None
+observations_db: Optional[ObservationsDatabase] = None
 
 
 def init_shared_database():

--- a/python/PiFinder/catalog_imports/harris_loader.py
+++ b/python/PiFinder/catalog_imports/harris_loader.py
@@ -381,7 +381,8 @@ def create_cluster_object(entry: npt.NDArray, seq: int) -> Dict[str, Any]:
     return result
 
 
-def load_harris():
+def load_harris() -> None:
+    assert objects_db is not None, "Database not initialized before load_harris()"
     logging.info("Loading Harris Globular Cluster catalog")
     catalog: str = "Har"
     obj_type: str = "Gb"  # Globular Cluster

--- a/python/PiFinder/state.py
+++ b/python/PiFinder/state.py
@@ -238,7 +238,7 @@ class Location:
 
 
 class SharedStateObj:
-    def __init__(self):
+    def __init__(self) -> None:
         self.__power_state = 1  # 0 = sleep state, 1 = awake state
         # self.__solve_state
         # None = No solve attempted yet

--- a/python/PiFinder/ui/radec_entry.py
+++ b/python/PiFinder/ui/radec_entry.py
@@ -586,7 +586,7 @@ class LayoutConfig:
 class UIRADecEntry(UIModule):
     __title__ = _("RA/DEC Entry")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self.callback = self.item_definition.get("callback")

--- a/python/PiFinder/ui/sqm_calibration.py
+++ b/python/PiFinder/ui/sqm_calibration.py
@@ -52,7 +52,7 @@ class UISQMCalibration(UIModule):
     __title__ = "SQM CAL"
     __help_name__ = ""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         # Wizard state machine

--- a/python/PiFinder/ui/textentry.py
+++ b/python/PiFinder/ui/textentry.py
@@ -5,7 +5,8 @@ from PiFinder.ui.object_list import UIObjectList
 from PiFinder.ui.ui_utils import format_number
 import time
 import threading
-from typing import Any, TYPE_CHECKING
+from typing import Any, List, TYPE_CHECKING
+from PiFinder.composite_object import CompositeObject
 
 if TYPE_CHECKING:
 
@@ -80,7 +81,7 @@ class KeyPad:
 
 
 class UITextEntry(UIModule):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         # Get mode from item_definition
@@ -105,7 +106,7 @@ class UITextEntry(UIModule):
         self.KEYPRESS_TIMEOUT = 1
         self.last_key_press_time = 0
         self.char_index = 0
-        self.search_results = []
+        self.search_results: List[CompositeObject] = []
         self.search_results_len_str = "0"
         self.show_keypad = True
         self.keys = KeyPad()


### PR DESCRIPTION
A couple of source code files accumulated mypy notes, due to using type annotations in the body, but not annotating the function call the annotated code was in. 

This PR gets rid of these notes (minimal change contributed by Claude).

<!-- branch-stack-start -->

-------------------------
- main
  - **Add type annotations to get a clean mypy log.** :point_left:

<sup>[Stack](https://www.git-town.com/how-to/proposal-breadcrumb.html) generated by [Git Town](https://github.com/git-town/git-town)</sup>

<!-- branch-stack-end -->

