### PR TITLE
fix: preserve insertion order of object names

### DIFF
--- a/python/PiFinder/db/objects_db.py
+++ b/python/PiFinder/db/objects_db.py
@@ -194,7 +194,7 @@ class ObjectsDatabase(Database):
         logging.info("Starting get_object_id_to_names query...")
 
         query_start = time.time()
-        self.cursor.execute("SELECT object_id, common_name FROM names;")
+        self.cursor.execute("SELECT object_id, common_name FROM names ORDER BY rowid;")
         results = self.cursor.fetchall()
         query_time = time.time() - query_start
         logging.info(
@@ -206,7 +206,7 @@ class ObjectsDatabase(Database):
         for object_id, common_name in results:
             name_dict[object_id].append(common_name.strip())
         for object_id in name_dict:
-            name_dict[object_id] = list(set(name_dict[object_id]))
+            name_dict[object_id] = list(dict.fromkeys(name_dict[object_id]))
         process_time = time.time() - process_start
         logging.info(
             f"Processing took {process_time:.2f}s, created {len(name_dict)} object entries"


### PR DESCRIPTION
## Summary
- Fixes Bright Star catalog (and other multi-name objects) displaying names in inconsistent, run-to-run varying order — e.g. "Str3 Alpha Crucis, Acrux" instead of the source-data order "Str3 Acrux, Alpha Crucis".
- Root cause: `get_object_id_to_names` used `list(set(...))` to deduplicate, which is non-deterministic due to Python hash randomization. Also, the underlying SELECT had no `ORDER BY`.
- Fix: use `dict.fromkeys()` to dedupe while preserving insertion order, and add `ORDER BY rowid` to guarantee SQLite returns rows in insertion order.

Reported by waterman480 on Discord — order of common vs. Latin names was flipping between runs on v2.4 and v2.5.

## Test plan
- [ ] Launch PiFinder, navigate to Bright Star catalog, verify Str2/3/6/7/8 show common name first (e.g. "Str3 Acrux, Alpha Crucis", "Str6 Alcor, 80 Ursae Majoris")
- [ ] Restart the app and confirm the order is stable across runs
- [ ] Spot-check other catalogs with multiple aka names (NGC/Messier) to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)