### PR TITLE
Run web tests manually from a GitHub Action

### DIFF
--- a/.github/workflows/web-integration-tests.yml
+++ b/.github/workflows/web-integration-tests.yml
@@ -7,7 +7,8 @@ permissions:
   issues: write
 
 jobs:
-  web-integration:
+  web-integration-tests:
+    name: Web Integration Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -40,6 +41,11 @@ jobs:
           git submodule update --init --recursive
           ln -s PiFinder/tetra3/tetra3 tetra3 
 
+      - name: Download hip_main.dat star catalog
+        run: |
+          wget -q -O astro_data/hip_main.dat \
+            https://cdsarc.cds.unistra.fr/ftp/cats/I/239/hip_main.dat
+
       - name: Set up PiFinder_data directory
         run: |
           mkdir -p ~/PiFinder_data/obslists
@@ -50,8 +56,7 @@ jobs:
         working-directory: python
         run: |
           source .venv/bin/activate
-          SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy \
-            python -m PiFinder.main -fh --camera debug --keyboard local \
+          SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python -m PiFinder.main -fh --camera debug --keyboard local \
             > /tmp/pifinder.log 2>&1 &
           echo $! > /tmp/pifinder.pid
           echo "PiFinder started with PID $(cat /tmp/pifinder.pid)"

--- a/.github/workflows/web-integration-tests.yml
+++ b/.github/workflows/web-integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Initialize tetra3
         working-directory: python
         run: |
-          git submodules update --init --recursive
+          git submodule update --init --recursive
           ln -s PiFinder/tetra3/tetra3 tetra3 
 
       - name: Set up PiFinder_data directory

--- a/.github/workflows/web-integration-tests.yml
+++ b/.github/workflows/web-integration-tests.yml
@@ -28,9 +28,15 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements_dev.txt
 
+      - name: Use webserver log configuration
+        working-directory: python
+        run: |
+          ln -s logconf_webserver.json pifinder_logconf.json
+
       - name: Initialize tetra3
         working-directory: python
         run: |
+          git submodule sync
           git submodule update --init --recursive
           ln -s PiFinder/tetra3/tetra3 tetra3 
 

--- a/.github/workflows/web-integration-tests.yml
+++ b/.github/workflows/web-integration-tests.yml
@@ -2,15 +2,6 @@ name: Web Integration Tests
 
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: Branch to run tests on
-        required: true
-        default: main
-        type: choice
-        options:
-          - main
-          - release
 
 permissions:
   issues: write
@@ -22,8 +13,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
 
       - name: Set up Python 3.9.2
         uses: actions/setup-python@v5

--- a/.github/workflows/web-integration-tests.yml
+++ b/.github/workflows/web-integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.9.2
+      - name: Set up Python 3.9.25
         uses: actions/setup-python@v5
         with:
           python-version: '3.9.2'

--- a/.github/workflows/web-integration-tests.yml
+++ b/.github/workflows/web-integration-tests.yml
@@ -1,0 +1,130 @@
+name: Web Integration Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to run tests on
+        required: true
+        default: main
+        type: choice
+        options:
+          - main
+          - release
+
+permissions:
+  issues: write
+
+jobs:
+  web-integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Set up Python 3.9.2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9.2'
+
+      - name: Create virtual environment and install dependencies
+        working-directory: python
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements_dev.txt
+
+      - name: Set up PiFinder_data directory
+        run: |
+          mkdir -p ~/PiFinder_data/obslists
+          mkdir -p ~/PiFinder_data/captures
+          cp default_config.json ~/PiFinder_data/config.json
+
+      - name: Start PiFinder with fake hardware
+        working-directory: python
+        run: |
+          source .venv/bin/activate
+          SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy \
+            python -m PiFinder.main -fh --camera debug --keyboard none \
+            > /tmp/pifinder.log 2>&1 &
+          echo $! > /tmp/pifinder.pid
+          echo "PiFinder started with PID $(cat /tmp/pifinder.pid)"
+
+      - name: Wait for PiFinder web server (port 8080)
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/ > /dev/null 2>&1; then
+              echo "PiFinder web server is ready"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "ERROR: server did not start within 150s"
+              cat /tmp/pifinder.log
+              exit 1
+            fi
+            echo "Attempt $i/30, sleeping 5s..."
+            sleep 5
+          done
+
+      - name: Run web tests
+        id: pytest_first
+        continue-on-error: true
+        working-directory: python
+        env:
+          PIFINDER_HOMEPAGE: http://localhost:8080
+        run: |
+          source .venv/bin/activate
+          pytest -m web --local -v
+
+      - name: Rerun failed tests with --lf
+        id: pytest_rerun
+        if: steps.pytest_first.outcome == 'failure'
+        continue-on-error: true
+        working-directory: python
+        env:
+          PIFINDER_HOMEPAGE: http://localhost:8080
+        run: |
+          source .venv/bin/activate
+          pytest -m web --local -v --lf
+
+      - name: Alert maintainers via GitHub Issue
+        if: steps.pytest_rerun.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "Web Integration Tests failed — $(date -u '+%Y-%m-%d %H:%M UTC')" \
+            --body "Web integration tests failed on both the initial run and the --lf rerun.
+
+          **Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Triggered by:** ${{ github.actor }}
+          **Branch:** ${{ inputs.branch }}" \
+            --label "bug"
+
+      - name: Fail job after persistent test failure
+        if: steps.pytest_first.outcome == 'failure' && steps.pytest_rerun.outcome != 'failure'
+        run: |
+          echo "First run failed but --lf rerun passed — treating as flaky, not failing job."
+
+      - name: Fail job if rerun also failed
+        if: steps.pytest_rerun.outcome == 'failure'
+        run: exit 1
+
+      - name: Upload PiFinder log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pifinder-log
+          path: /tmp/pifinder.log
+
+      - name: Stop PiFinder
+        if: always()
+        run: |
+          if [ -f /tmp/pifinder.pid ]; then
+            kill "$(cat /tmp/pifinder.pid)" || true
+          fi

--- a/.github/workflows/web-integration-tests.yml
+++ b/.github/workflows/web-integration-tests.yml
@@ -28,6 +28,12 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements_dev.txt
 
+      - name: Initialize tetra3
+        working-directory: python
+        run: |
+          git submodules update --init --recursive
+          ln -s PiFinder/tetra3/tetra3 tetra3 
+
       - name: Set up PiFinder_data directory
         run: |
           mkdir -p ~/PiFinder_data/obslists

--- a/.github/workflows/web-integration-tests.yml
+++ b/.github/workflows/web-integration-tests.yml
@@ -41,7 +41,17 @@ jobs:
           git submodule update --init --recursive
           ln -s PiFinder/tetra3/tetra3 tetra3 
 
+      - name: Use cache of hip_main.dat star catalog
+        
+        id: cache-hip-main
+        uses: actions/cache@v4
+        with:
+          path: astro_data/hip_main.dat
+          key: hip_main-dat-v1
+          # Bump this key, to force redownloading the catalog if it changes or if we want to refresh the cache
+
       - name: Download hip_main.dat star catalog
+        if: steps.cache-hip-main.outputs.cache-hit != 'true'
         run: |
           wget -q -O astro_data/hip_main.dat \
             https://cdsarc.cds.unistra.fr/ftp/cats/I/239/hip_main.dat
@@ -85,7 +95,7 @@ jobs:
           PIFINDER_HOMEPAGE: http://localhost:8080
         run: |
           source .venv/bin/activate
-          pytest -m web --local -v
+          pytest -ra -m web --local -v
 
       - name: Rerun failed tests with --lf
         id: pytest_rerun
@@ -96,7 +106,7 @@ jobs:
           PIFINDER_HOMEPAGE: http://localhost:8080
         run: |
           source .venv/bin/activate
-          pytest -m web --local -v --lf
+          pytest -ra -m web --local -v --lf
 
       - name: Alert maintainers via GitHub Issue
         if: steps.pytest_rerun.outcome == 'failure'

--- a/.github/workflows/web-integration-tests.yml
+++ b/.github/workflows/web-integration-tests.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           source .venv/bin/activate
           SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy \
-            python -m PiFinder.main -fh --camera debug --keyboard none \
+            python -m PiFinder.main -fh --camera debug --keyboard local \
             > /tmp/pifinder.log 2>&1 &
           echo $! > /tmp/pifinder.pid
           echo "PiFinder started with PID $(cat /tmp/pifinder.pid)"

--- a/.github/workflows/web-integration-tests.yml
+++ b/.github/workflows/web-integration-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3.9.25
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9.2'
+          python-version: '3.9.25'
 
       - name: Create virtual environment and install dependencies
         working-directory: python


### PR DESCRIPTION
With this action, you can run the web tests headless on a GitHub runner (ubuntu, Chrome headless, against the locally running PiFinder with fake hardware. 

At the moment, you need to manually trigger this action.
It caches hip_main.dat, so unistra.fr is hit only once a week at most. 

Remaining issue: As it's starting from a clean slate, there's no test location present on the first run. For the moment I am just rerunning the tests.

