### PR TITLE
Imu fix chart orientation

### DIFF
--- a/python/PiFinder/calc_utils.py
+++ b/python/PiFinder/calc_utils.py
@@ -388,6 +388,25 @@ class Skyfield_utils:
 
         return ha_hrs * 180 / 12  # Hour angle [deg]
 
+    def radec_to_pa(self, ra_deg, dec_deg, dt):
+        """
+        Returns the parallactic angle of an object at (ra, dec) as seen from an
+        observer at latitiude, lat and time, dt. See hadec_to_pa() for how
+        parallactic angle is defined.
+
+        INPUTS:
+        ra_deg: Right ascension [deg]
+        dec_deg: Declination [deg]
+        dt: Python datetime object (must be timezone-aware)
+
+        RETURNS:
+        pa_deg: Parallactic angle [deg]
+        """
+        ha_deg = self.ra_to_ha(ra_deg, dt)  # Note that HA is in deg
+        lat_deg = self._observer_geoid.latitude.degrees
+        pa_deg = hadec_to_pa(ha_deg, dec_deg, lat_deg)
+        return pa_deg  # Parallactic angle [deg]
+
     def radec_to_roll(self, ra_deg, dec_deg, dt):
         """
         Returns the roll (field rotation) of an object at (ra, dec) as

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -13,7 +13,10 @@ TODO:
 - Refactor into class PointingTracker
 
 """
-from __future__ import annotations  # To support | in typehints (remove this for Python 3.10+)
+
+from __future__ import (
+    annotations,
+)  # To support | in typehints (remove this for Python 3.10+)
 
 import queue
 import time
@@ -21,6 +24,7 @@ import copy
 import logging
 import numpy as np
 import quaternion  # numpy-quaternion
+import datetime
 
 from PiFinder import config
 from PiFinder import state_utils
@@ -59,10 +63,12 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
         # This holds the last image solve position info
         # so we can delta for IMU updates
         last_image_solve = None
-        #last_solve_time = time.time()
+        last_solve_time = time.time()
 
         while True:
-            pointing_updated = False  # Flag to track if pointing was updated in this loop
+            pointing_updated = (
+                False  # Flag to track if pointing was updated in this loop
+            )
             state_utils.sleep_for_framerate(shared_state)
 
             # Check for new camera solve in queue
@@ -111,7 +117,9 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                     # TODO: In this case, it should run update_imu()
                     # Failed solve - clear constellation
                     solved["solve_source"] = "CAM_FAILED"
-                    solved["constellation"] = ""  # NOTE: This gets over-written by IMU dead-reckoning
+                    solved["constellation"] = (
+                        ""  # NOTE: This gets over-written by IMU dead-reckoning
+                    )
                     # Push failed solved immediately
                     # This ensures auto-exposure sees Matches=0 for failed solves
                     shared_state.set_solution(solved)
@@ -122,30 +130,35 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                 # the last plate solved coordinates.
                 imu = shared_state.imu()
                 if imu:
-                    #last_solve_time = time.time()
+                    # last_solve_time = time.time()
                     update_imu(imu_dead_reckoning, solved, last_image_solve, imu)
                     pointing_updated = True
 
-            # Update Alt, Az, Roll only if newer than last push
-            if pointing_updated:
-                #last_solve_time = time.time()
-                # Set location for roll and altaz calculations.
-                # TODO: Is it necessary to set location?
+            # Update Alt, Az only if newer than last push
+            if pointing_updated and solved["solve_time"] > last_solve_time:
+                solved["constellation"] = get_constellation(solved["RA"], solved["Dec"])
+
                 # TODO: Altaz doesn't seem to be required for catalogs when in
-                #  EQ mode? Could be disabled in future when in EQ mode?
-                update_solved_coords(solved, 
-                                     location=shared_state.location(), 
-                                     dt=shared_state.datetime(),
-                                     mount_type=mount_type)
-                # Push IMU update
-                shared_state.set_solution(solved)
-                shared_state.set_solve_state(True)
+                # EQ mode? Could be disabled in future when in EQ mode?
+                solved["Alt"], solved["Az"] = get_alt_az(
+                    solved["RA"],
+                    solved["Dec"],
+                    shared_state.location(),
+                    shared_state.datetime(),
+                )
+
+                if (solved["RA"] is not None) and (solved["Dec"] is not None):
+                    # Push new solved to shared state
+                    shared_state.set_solution(solved)
+                    shared_state.set_solve_state(True)
+                    last_solve_time = solved["solve_time"]
 
     except EOFError:
         logger.error("Main no longer running for integrator")
 
 
 # ======== Wrapper and helper functions ===============================
+
 
 def update_plate_solve_and_imu(imu_dead_reckoning: ImuDeadReckoning, solved: dict):
     """
@@ -265,13 +278,37 @@ def update_solved_coords(solved, location, dt, mount_type):
         calc_utils.sf_utils.set_location(location.lat, location.lon, location.altitude)
         # Set Alt/Az
         solved["Alt"], solved["Az"] = calc_utils.sf_utils.radec_to_altaz(
-            solved["RA"], solved["Dec"], dt)
+            solved["RA"], solved["Dec"], dt
+        )
         # Set the roll so that the chart is displayed appropriately for the mount type
         solved["Roll"] = get_roll_by_mount_type(
-            solved["RA"], solved["Dec"], location, dt, mount_type)
+            solved["RA"], solved["Dec"], location, dt, mount_type
+        )
     else:
         solved["Alt"], solved["Az"] = None, None
         solved["Roll"] = None
+
+
+def get_constellation(RA_deg, Dec_deg) -> str:
+    """
+    Get constellation name from the current RA/Dec position.
+    """
+    if RA_deg is None or Dec_deg is None:
+        return ""
+    else:
+        return calc_utils.sf_utils.radec_to_constellation(RA_deg, Dec_deg)
+
+
+def get_alt_az(RA_deg, Dec_deg, location, dt) -> tuple[float | None, float | None]:
+    """
+    Get Alt/Az from RA/Dec, location and datetime.
+    RETURNS: alt_deg, az_deg
+    """
+    if RA_deg is None or Dec_deg is None or location is None or dt is None:
+        return None, None
+    else:
+        calc_utils.sf_utils.set_location(location.lat, location.lon, location.altitude)
+        return calc_utils.sf_utils.radec_to_altaz(RA_deg, Dec_deg, dt)
 
 
 def set_cam2scope_alignment(imu_dead_reckoning: ImuDeadReckoning, solved: dict):
@@ -294,3 +331,60 @@ def set_cam2scope_alignment(imu_dead_reckoning: ImuDeadReckoning, solved: dict):
 
     # Set alignment in imu_dead_reckoning
     imu_dead_reckoning.set_cam2scope_alignment(solved_cam, solved_scope)
+
+
+def get_roll_by_mount_type(
+    ra_deg: float,  # Right Ascension of the target in degrees
+    dec_deg: float,  # Declination of the target in degrees
+    location,  # astropy EarthLocation object or None
+    dt: datetime.datetime,  # datetime.datetime object or None
+    mount_type: str,  # "Alt/Az" or "EQ"
+) -> float:
+    """
+    Returns the roll (in degrees) depending on the mount type so that the chart
+    is displayed appropriately for the mount type. The RA and Dec of the target
+    should be provided (in degrees).
+
+    * Alt/Az mount: Display the chart in the horizontal coordinate so that up
+      in the chart points to the Zenith.
+    * EQ mount: Display the chart in the equatorial coordinate system with the
+      NCP up so roll = 0.
+
+    Assumes that location has already been set in calc_utils.sf_utils.
+    """
+    if mount_type == "Alt/Az":
+        # Altaz mounts: Display chart in horizontal coordinates
+        if location and dt:
+            """
+            # We have location and time/date (and assume that location has been set)
+            # Roll at the target RA/Dec in the horizontal frame
+            roll_deg = calc_utils.sf_utils.radec_to_roll(ra_deg, dec_deg, dt)
+
+            # HACK:
+            # The IMU direction flips at a certaint point. Could due to a
+            # an issue in the formula in calc_utils.sf_utils.hadec_to_roll()
+            # This is a temperary hack for testing.
+            ha_deg = calc_utils.sf_utils.ra_to_ha(ra_deg, dt)
+            roll_deg = (
+                roll_deg - np.sign(ha_deg) * 180
+            )  # In essence, gives: roll_deg = -pa_deg
+            # End of HACK
+            """
+            # chart.py uses roll to rotate the chart around the target center
+            # by roll in anti-clockwise direction. Use -parallactic_angle
+            roll_deg = -calc_utils.sf_utils.radec_to_pa(ra_deg, dec_deg, dt)
+        else:
+            # No position or time/date available. Default to display in equatorial coordinate
+            roll_deg = 0.0  # NCP up
+    elif mount_type == "EQ":
+        # EQ-mounts: Display chart in equatorial coordinates
+        roll_deg = 0.0  # NCP up
+        # If location is available, adjust roll for hemisphere:
+        if location:
+            if location.lat < 0.0:
+                roll_deg = 180.0  # SCP up (for southern hemisphere)
+    else:
+        logger.error(f"Unknown mount type: {mount_type}. Cannot set roll.")
+        roll_deg = 0.0  # NCP up
+
+    return roll_deg

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -161,7 +161,6 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
 
                 # Set Alt/Az because it's needed for the catalogs for the
                 # Alt/Az mount type. TODO: Can this be moved to the catalog?
-                dt = shared_state.datetime()
                 if location and dt:
                     solved["Alt"], solved["Az"] = calc_utils.sf_utils.radec_to_altaz(
                         solved["RA"], solved["Dec"], dt

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -342,20 +342,17 @@ def get_roll_by_mount_type(
             # by roll in anti-clockwise direction. Use -parallactic_angle
             roll_deg = -calc_utils.sf_utils.radec_to_pa(ra_deg, dec_deg, dt)
         else:
-            # No position or time/date available, so set roll to 0.0
+            # No position or time/date available. Default to display in equatorial coordinate
             roll_deg = 0.0  # NCP up
     elif mount_type == "EQ":
-        # EQ-mounts: Display chart with NCP up so roll = 0.0
+        # EQ-mounts: Display chart in equatorial coordinates
         roll_deg = 0.0  # NCP up
+        # If location is available, adjust roll for hemisphere:
+        if location:
+            if location.lat < 0.0:
+                roll_deg = 180.0  # SCP up (for southern hemisphere)
     else:
         logger.error(f"Unknown mount type: {mount_type}. Cannot set roll.")
-        roll_deg = 0.0
-
-    # If location is available, adjust roll for hemisphere:
-    # Altaz: North up in northern hemisphere, South up in southern hemisphere
-    # EQ mounts: NCP up in northern hemisphere, SCP up in southern hemisphere
-    if location:
-        if location.lat < 0.0:
-            roll_deg += 180.0  # Southern hemisphere TODO: Verify this
+        roll_deg = 0.0  # NCP up
 
     return roll_deg

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -319,6 +319,7 @@ def get_roll_by_mount_type(
     if mount_type == "Alt/Az":
         # Altaz mounts: Display chart in horizontal coordinates
         if location and dt:
+            """
             # We have location and time/date (and assume that location has been set)
             # Roll at the target RA/Dec in the horizontal frame
             roll_deg = calc_utils.sf_utils.radec_to_roll(ra_deg, dec_deg, dt)
@@ -332,12 +333,16 @@ def get_roll_by_mount_type(
                 roll_deg - np.sign(ha_deg) * 180
             )  # In essence, gives: roll_deg = -pa_deg
             # End of HACK
+            """
+            # chart.py uses roll to rotate the chart around the target center
+            # by roll in anti-clockwise direction. Use -parallactic_angle
+            roll_deg = -calc_utils.sf_utils.radec_to_pa(ra_deg, dec_deg, dt)
         else:
             # No position or time/date available, so set roll to 0.0
-            roll_deg = 0.0
+            roll_deg = 0.0  # NCP up
     elif mount_type == "EQ":
         # EQ-mounts: Display chart with NCP up so roll = 0.0
-        roll_deg = 0.0
+        roll_deg = 0.0  # NCP up
     else:
         logger.error(f"Unknown mount type: {mount_type}. Cannot set roll.")
         roll_deg = 0.0
@@ -347,6 +352,6 @@ def get_roll_by_mount_type(
     # EQ mounts: NCP up in northern hemisphere, SCP up in southern hemisphere
     if location:
         if location.lat < 0.0:
-            roll_deg += 180.0  # Southern hemisphere
+            roll_deg += 180.0  # Southern hemisphere TODO: Verify this
 
     return roll_deg

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -62,9 +62,10 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
         # This holds the last image solve position info
         # so we can delta for IMU updates
         last_image_solve = None
-        last_solve_time = time.time()
+        #last_solve_time = time.time()
 
         while True:
+            pointing_updated = False  # Flag to track if pointing was updated in this loop
             state_utils.sleep_for_framerate(shared_state)
 
             # Check for new camera solve in queue
@@ -101,19 +102,15 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                 # For failed solves, preserve ALL position data from previous solve
                 # Don't recalculate from GPS (causes drift from GPS noise)
 
-                # Set solve_source and push camera solves immediately
                 if solved["RA"] is not None:
+                    # Successfully plate-solved:
                     last_image_solve = copy.deepcopy(solved)
                     solved["solve_source"] = "CAM"
-                    # Calculate constellation for successful solve
-                    solved["constellation"] = (
-                        calc_utils.sf_utils.radec_to_constellation(
-                            solved["RA"], solved["Dec"]
-                        )
-                    )
                     shared_state.set_solve_state(True)
                     # We have a new image solve: Use plate-solving for RA/Dec
                     update_plate_solve_and_imu(imu_dead_reckoning, solved)
+                    #last_solve_time = solved["solve_time"]
+                    pointing_updated = True
                 else:
                     # TODO: In this case, it should run update_imu()
                     # Failed solve - clear constellation
@@ -125,20 +122,18 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                     shared_state.set_solution(solved)
                     shared_state.set_solve_state(False)
 
-            elif imu_dead_reckoning.tracking:
+            if imu_dead_reckoning.tracking and not pointing_updated:
                 # Previous plate-solve exists so use IMU dead-reckoning from
                 # the last plate solved coordinates.
                 imu = shared_state.imu()
                 if imu:
+                    #last_solve_time = time.time()
                     update_imu(imu_dead_reckoning, solved, last_image_solve, imu)
+                    pointing_updated = True
 
             # Update Alt, Az, Roll only if newer than last push
-            if (
-                solved["RA"] is not None and solved["solve_time"] > last_solve_time
-                # and solved["solve_source"] == "IMU"
-            ):
-                last_solve_time = time.time()  # TODO: solve_time is ambiguous because it's also used for IMU dead-reckoning
-
+            if pointing_updated:
+                #last_solve_time = time.time()
                 # Set location for roll and altaz calculations.
                 # TODO: Is it necessary to set location?
                 # TODO: Altaz doesn't seem to be required for catalogs when in

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -75,6 +75,7 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                 pass
 
             if type(next_image_solve) is dict:
+                # TODO: Refactor this bit:
                 # For camera solves, always start from last successful camera solve
                 # NOT from shared_state (which may contain IMU drift)
                 # This prevents IMU noise accumulation during failed solves
@@ -114,6 +115,7 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                     # We have a new image solve: Use plate-solving for RA/Dec
                     update_plate_solve_and_imu(imu_dead_reckoning, solved)
                 else:
+                    # TODO: In this case, it should run update_imu()
                     # Failed solve - clear constellation
                     solved["solve_source"] = "CAM_FAILED"
                     solved["constellation"] = ""
@@ -130,9 +132,9 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                 if imu:
                     update_imu(imu_dead_reckoning, solved, last_image_solve, imu)
 
-            # Push IMU updates only if newer than last push
+            # Update Alt, Az, Roll only if newer than last push
             if (
-                solved["RA"] and solved["solve_time"] > last_solve_time
+                solved["RA"] is not None and solved["solve_time"] > last_solve_time
                 # and solved["solve_source"] == "IMU"
             ):
                 last_solve_time = time.time()  # TODO: solve_time is ambiguous because it's also used for IMU dead-reckoning
@@ -141,31 +143,10 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
                 # TODO: Is it necessary to set location?
                 # TODO: Altaz doesn't seem to be required for catalogs when in
                 #  EQ mode? Could be disabled in future when in EQ mode?
-                location = shared_state.location()
-                dt = shared_state.datetime()
-                if location:
-                    calc_utils.sf_utils.set_location(
-                        location.lat, location.lon, location.altitude
-                    )
-
-                # Set the roll so that the chart is displayed appropriately for the mount type
-                solved["Roll"] = get_roll_by_mount_type(
-                    solved["RA"], solved["Dec"], location, dt, mount_type
-                )
-
-                # Update remaining solved keys
-                # Calculate constellation for current position
-                solved["constellation"] = calc_utils.sf_utils.radec_to_constellation(
-                    solved["RA"], solved["Dec"]
-                )  # TODO: Can the outer brackets be omitted?
-
-                # Set Alt/Az because it's needed for the catalogs for the
-                # Alt/Az mount type. TODO: Can this be moved to the catalog?
-                if location and dt:
-                    solved["Alt"], solved["Az"] = calc_utils.sf_utils.radec_to_altaz(
-                        solved["RA"], solved["Dec"], dt
-                    )
-
+                update_solved_coords(solved, 
+                                     location=shared_state.location(), 
+                                     dt=shared_state.datetime(),
+                                     mount_type=mount_type)
                 # Push IMU update
                 shared_state.set_solution(solved)
                 shared_state.set_solve_state(True)
@@ -175,7 +156,6 @@ def integrator(shared_state, solver_queue, console_queue, log_queue, is_debug=Fa
 
 
 # ======== Wrapper and helper functions ===============================
-
 
 def update_plate_solve_and_imu(imu_dead_reckoning: ImuDeadReckoning, solved: dict):
     """
@@ -272,6 +252,36 @@ def update_imu(
                 solved["camera_center"]["Roll"],
             )
         )
+
+
+def update_solved_coords(solved, location, dt, mount_type):
+    """
+    Based on RA/Dec, update the following in dictionary 'solved':
+    solved["Alt"], solved["Az"], solved["Roll"], solved["constellation"]
+    """
+    if solved["RA"] is None or solved["Dec"] is None:
+        solved["constellation"] = None
+        solved["Alt"], solved["Az"] = None, None
+        solved["Roll"] = None
+        return
+
+    # Calculate constellation for current position
+    solved["constellation"] = calc_utils.sf_utils.radec_to_constellation(
+        solved["RA"], solved["Dec"]
+    )
+
+    if location and dt:
+        # Location needs to be set for Alt/Az and roll calculations
+        calc_utils.sf_utils.set_location(location.lat, location.lon, location.altitude)
+        # Set Alt/Az
+        solved["Alt"], solved["Az"] = calc_utils.sf_utils.radec_to_altaz(
+            solved["RA"], solved["Dec"], dt)
+        # Set the roll so that the chart is displayed appropriately for the mount type
+        solved["Roll"] = get_roll_by_mount_type(
+            solved["RA"], solved["Dec"], location, dt, mount_type)
+    else:
+        solved["Alt"], solved["Az"] = None, None
+        solved["Roll"] = None
 
 
 def set_cam2scope_alignment(imu_dead_reckoning: ImuDeadReckoning, solved: dict):


### PR DESCRIPTION
This PR fixes chart display with the *quaternion* version of the integrator.

Fixed by rotating the chart by `-parallactic_angle` rather than `roll`.

When `mount_type` is alt/az, it will correctly display the chart in horizontal coordinates. If the `mount_type` is equatorial, it will display the chart in equatorial coordinates (north-up in norther hemisphere and south-up in southern hemisphere). If location or time is not available from the GPS, the chart display will default to equatorial coordinates (north-up).

Sky tested (f53401a) 1 May 2026 in the northern hemisphere. 