### PR TITLE
fix: clear camera_center/camera_solve on failed solves

### DIFF
--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -378,6 +378,12 @@ def solver(
                         solved["RA"] = None
                         solved["Dec"] = None
                         solved["Matches"] = 0
+                        solved["camera_center"]["RA"] = None
+                        solved["camera_center"]["Dec"] = None
+                        solved["camera_center"]["Roll"] = None
+                        solved["camera_solve"]["RA"] = None
+                        solved["camera_solve"]["Dec"] = None
+                        solved["camera_solve"]["Roll"] = None
                         solution = {}
 
                         if len(centroids) == 0:


### PR DESCRIPTION
## Summary
The clear-on-failure block in `solver()` resets `solved["RA"]/Dec/Matches` but leaves `camera_center` and `camera_solve` pinned to the last successful solve across every failure path (no-centroids, pattern-match failure, exception).

## Why this matters
- **Integrator-side downstream is unaffected today:** `integrator.py:96` only merges new position data when `RA is not None`, and the integrator's `solved` starts from `copy.deepcopy(last_image_solve)` on each iteration. UI consumers also gate on `solve_state()`.
- **But `solved` from the solver's perspective leaks stale `camera_center`** to anything that records or reads it directly — e.g. telemetry recording on downstream branches, where it produces "plateau" artifacts: bit-identical RA/Dec/Roll samples stamped at fresh timestamps after the last successful solve.

The fix completes the intent already documented in the existing comment at this site:
```
# Clear solve results which indicate solve as failed
# (otherwise old values persist)
```

## Change
Six lines added inside the existing clearing block, same indent, same style. No deletions, no behavior changes for any current downstream consumer.

```python
solved["camera_center"]["RA"] = None
solved["camera_center"]["Dec"] = None
solved["camera_center"]["Roll"] = None
solved["camera_solve"]["RA"] = None
solved["camera_solve"]["Dec"] = None
solved["camera_solve"]["Roll"] = None
```

`Alt`/`Az` on `camera_center` are intentionally left alone — those are owned by the integrator, not the solver, and the success path doesn't touch them either.

## Test plan
- [x] Run existing smoke/unit tests: `nox -s smoke_tests unit_tests`
- [ ] Manual check on a session with intentionally bad seeing: confirm that on failed-solve frames `camera_center` is `None` rather than the previous good value.