### PR TITLE
Add AX setup: contexts, ADRs, and grill-with-docs skill

### DIFF
--- a/.claude/skills/grill-with-docs/ADR-FORMAT.md
+++ b/.claude/skills/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/.claude/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/.claude/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,63 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Write an example dialogue.** A conversation between a dev and a domain expert that demonstrates how the terms interact naturally and clarifies boundaries between related concepts.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.claude/skills/grill-with-docs/SKILL.md
+++ b/.claude/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: grill-with-docs
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+---
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+</supporting-info>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,17 @@ Usual startup:
 python3.9 -m PiFinder.main -fh --camera debug --keyboard local -x
 ```
 
+## Reference Documentation
+
+Before working in an area of the codebase, check whether it has reference docs:
+
+- **`CONTEXT-MAP.md`** (repo root) — index of bounded contexts and how they relate. Start here for any cross-context question.
+- **`docs/ax/<area>/CONTEXT.md`** — canonical glossary for each context (Catalog, Positioning, SQM…). These define the project's vocabulary: what each domain term means, which words to avoid, and how related concepts compose. **Use these terms when reading, writing, and discussing code.**
+- **`docs/ax/<area>.md`** — architecture deep-dives (data flow, lifecycle, gotchas) alongside each CONTEXT.md.
+- **`docs/adr/NNNN-*.md`** — short architecture-decision records capturing the *why* behind non-obvious or hard-to-reverse choices.
+
+When a `CONTEXT.md` defines a term, prefer that term over synonyms in code comments, commit messages, and PR descriptions. If you encounter language in code or chat that conflicts with a CONTEXT.md, flag it.
+
 ## Architecture Overview
 
 **Multi-Process Design:** PiFinder uses a process-based architecture where each major subsystem runs in its own process, communicating via queues and shared state objects:

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,21 @@
+# Context Map
+
+PiFinder is a multi-process Raspberry Pi finder/plate-solver. These contexts each own a distinct slice of the runtime and have their own vocabulary.
+
+## Contexts
+
+- [Catalog](./docs/ax/catalog/CONTEXT.md) — loads, filters, searches astronomical catalogs (M, NGC, IC, WDS, planets, comets) for the UI.
+- [Positioning](./docs/ax/positioning/CONTEXT.md) — acquires telescope pointing via plate-solving and IMU dead-reckoning; publishes the canonical "where am I looking?" answer.
+- [SQM](./docs/ax/sqm/CONTEXT.md) — estimates sky brightness in mag/arcsec² from solved frames; also produces the noise-floor signal auto-exposure consumes.
+
+## Relationships
+
+- **Positioning → Catalog**: Catalog reads RA/Dec/Alt/Az from `shared_state.solution()` to compute visibility and "near me" lists.
+- **Positioning → SQM**: SQM is a side effect of every successful plate solve in the solver process; it reuses the tetra3 `matched_centroids` and the camera frame.
+- **SQM → Camera (auto-exposure)**: `shared_state.set_noise_floor()` feeds the SNR target used by auto-exposure in the camera process.
+- **Catalog ↔ Positioning**: Catalog supplies the `(RA, Dec)` target for the alignment flow that calibrates `solve_pixel` in Positioning.
+
+Companion architecture docs live next to each `CONTEXT.md`:
+- [`docs/ax/catalog.md`](./docs/ax/catalog.md)
+- [`docs/ax/positioning.md`](./docs/ax/positioning.md)
+- [`docs/ax/sqm.md`](./docs/ax/sqm.md)

--- a/docs/adr/0001-positioning-vocabulary.md
+++ b/docs/adr/0001-positioning-vocabulary.md
@@ -1,0 +1,10 @@
+# Positioning vocabulary: `pointing.<axis>.<state>`
+
+The positioning system tracks pointing as a 2 × 2 matrix — two **axes** (`camera`, `aligned`) and two **states** (`solve` from the latest plate-solve, `estimate` from IMU dead-reckoning forward) — accessed as `pointing.<axis>.<state>.<RA|Dec|Roll>`. In prose, bare "pointing" means `pointing.aligned.estimate`. The `(Y, X)` pixel produced by alignment is named `target_pixel` (displacing the legacy `solve_pixel`).
+
+`aligned` was chosen over `scope` because "scope" is heavily overloaded (telescope, eyepiece, finder, optical), while `aligned` carries the meaning that this axis is derived by taking the `camera` solve and applying the alignment offset — i.e. it names both the axis and the process that produces it.
+
+## Consequences
+
+- `PiFinder/types/positioning.py` field names `target_pixel` and `camera_center` will be renamed to `aligned` and `camera`; the legacy `solved` dict key `camera_solve` and the config key `solve_pixel` follow on the same rename pass.
+- The companion glossary lives at [`docs/ax/positioning/CONTEXT.md`](../ax/positioning/CONTEXT.md); cross-reference for current code-vs-language status during the migration.

--- a/docs/adr/0002-sqm-published-value-uncorrected.md
+++ b/docs/adr/0002-sqm-published-value-uncorrected.md
@@ -1,0 +1,9 @@
+# Publish raw SQM, not the altitude-corrected value
+
+`SQM.calculate()` returns both `sqm_final` (no extinction correction) and `sqm_altitude_corrected` (adds `0.28 · (airmass − 1)`). We publish `sqm_final` as `SQMState.value`; `sqm_altitude_corrected` is carried only in `details`. The 0.28 mag/airmass coefficient is an idealised V-band number, so under real atmospheric conditions the "corrected" value can deviate further from truth than the raw reading — an honest measurement is preferable to a confidently-wrong one. Users who need to compare across pointing altitudes can still read `sqm_altitude_corrected` from `details`.
+
+## Consequences
+
+- `shared_state.set_sqm(SQMState)` is **not** comparable across measurements taken at very different altitudes without consumer-side correction.
+- Changing the published value to the corrected number would invalidate prior calibration runs and break any comparisons baselined on `sqm_final`.
+- The glossary at [`docs/ax/sqm/CONTEXT.md`](../ax/sqm/CONTEXT.md) anchors the canonical meaning of bare "SQM" on this choice.

--- a/docs/ax/catalog.md
+++ b/docs/ax/catalog.md
@@ -1,0 +1,515 @@
+# The catalog system
+
+This document describes how PiFinder loads, organizes, filters, searches,
+and updates astronomical catalogs at runtime. The bulk of the system
+lives in `PiFinder/catalogs.py`, with supporting types in
+`PiFinder/catalog_base.py` and `PiFinder/composite_object.py`, and the
+on-disk SQLite layer in `PiFinder/db/objects_db.py`.
+
+A glossary of terms and data structures appears at the end. Definitions
+there are draft notes and should be reviewed.
+
+---
+
+## 1. The big picture
+
+At a high level:
+
+```
+   SQLite (astro_data/pifinder_objects.db)
+        │
+        ▼
+   CatalogBuilder.build()
+        │
+        ├── synchronous load:  priority catalogs  (M, NGC, IC)
+        │       │
+        │       └─► List[CompositeObject] ─► _get_catalogs() ─► Catalogs
+        │
+        ├── background thread: deferred catalogs (WDS, …)
+        │       │   via CatalogBackgroundLoader (batched, CPU-yielding)
+        │       └─► on_complete → catalogs.get_catalog_by_code().add_objects()
+        │                                                 └─► re-filter
+        │
+        ├── dynamic catalogs:  PlanetCatalog (TimerMixin, every ~5 min)
+        │                       CometCatalog (similar)
+        │
+        └─► Catalogs object (single instance shared across the app)
+                 │
+                 ├── CatalogFilter (one shared instance set on every catalog)
+                 ├── T9 / text search caches
+                 └── Iterates as List[Catalog], each holding List[CompositeObject]
+```
+
+The `Catalogs` instance is the runtime API for the rest of PiFinder
+(menus, charting, web). The integrator/solver layer doesn't touch
+catalogs directly — they live in the main UI process.
+
+---
+
+## 2. The data model
+
+### 2.1 `CompositeObject`
+
+`composite_object.CompositeObject` is the unit of everything the UI
+displays. It's a dataclass that merges three things:
+
+- A row from the SQLite `catalog_objects` table — `id`, `catalog_code`,
+  `sequence`, `description`.
+- The corresponding row from the `objects` table referenced by
+  `object_id` — `ra`, `dec`, `obj_type`, `const`, `size`,
+  `surface_brightness`, raw `mag` JSON.
+- Derived/auxiliary data — `names` (list of strings), `mag`
+  (`MagnitudeObject`), `mag_str` (display string), `logged` (looked up
+  in the observations DB), `last_filtered_time`/`last_filtered_result`
+  (used by the filter cache).
+
+Two `CompositeObject`s are equal iff their `object_id`s match. That
+means the same underlying object referenced by multiple catalogs (e.g.
+M 31 ≡ NGC 224) will hash identically; this matters for set membership
+but **not** for catalog iteration, which uses lists keyed by
+`(catalog_code, sequence)`.
+
+`display_name` returns `"PL <planet name>"` (capitalised) for planets,
+otherwise `"<catalog_code> <sequence>"` — e.g. `"NGC 7000"`.
+
+### 2.2 `MagnitudeObject`
+
+Every `CompositeObject.mag` is a `MagnitudeObject` wrapping a list of
+magnitudes (visual, photographic, combined-pair for doubles, etc.).
+
+- `filter_mag` — single float used by the filter. Computed as the mean
+  of all entries that parse as floats; defaults to
+  `UNKNOWN_MAG = 99` when nothing parses.
+- `calc_two_mag_representation()` — returns `"-"` if unknown, `"X.X"` if
+  one value, `"min/max"` for two-or-more, used as `mag_str` for display.
+- Serialised to/from JSON in the DB via `to_json` / `from_json`.
+
+### 2.3 `Names`
+
+`Names` (in `catalogs.py`) loads the common-names table once at startup
+and exposes:
+
+- `id_to_names: DefaultDict[int, List[str]]` — object_id → list of names.
+- `name_to_id` — reverse lookup (built by `ObjectsDatabase.get_name_to_object_id`).
+
+A `_sort_names()` hook exists for hierarchical sorting but is currently
+empty.
+
+### 2.4 `CatalogBase` and `Catalog`
+
+`catalog_base.CatalogBase` holds an internal `__objects: List` plus two
+position indices: `id_to_pos` and `sequence_to_pos`. Adding objects
+appends, then re-sorts (by `sequence` by default), then rebuilds the
+indices. `check_sequences()` asserts that no two objects in the catalog
+share a sequence number — that invariant is checked on every
+`add_object`/`add_objects` call.
+
+`catalogs.Catalog` extends `CatalogBase` with:
+
+- `catalog_filter` — pointer to the shared `CatalogFilter`.
+- `filtered_objects` / `filtered_objects_seq` — the post-filter views.
+- `get_status()` returning a `CatalogStatus(current, previous, data)`.
+- `is_selected()` — whether this catalog appears in
+  `catalog_filter.selected_catalogs`.
+
+External code is expected to read through `get_objects()` (returns a
+`ROArrayWrapper` — a read-only proxy that disallows assignment) or
+`get_filtered_objects()`.
+
+### 2.5 `Catalogs`
+
+A container that holds a `List[Catalog]` plus the singleton
+`CatalogFilter` and the T9 search cache. It exposes:
+
+- `filter_catalogs()` — runs `filter_objects()` on every catalog.
+- `set_catalog_filter(filter)` — installs one filter object on every
+  catalog so changes propagate uniformly.
+- `select_catalogs / select_all / select_no` — manipulate the selected
+  set on the shared filter.
+- `get_catalogs(only_selected=True)` / `get_codes(...)` /
+  `get_objects(...)` — collection accessors.
+- `get_catalog_by_code(code)` / `get_object(code, sequence)` — direct
+  lookup.
+- `search_by_text(s)` — substring match against all names (selected or
+  not, filtered or not).
+- `search_by_t9(digits)` — see §5.
+- `add(catalog)` / `remove(code)` / `set(catalogs)` — mutate the
+  collection and invalidate the T9 cache.
+- `is_loading()` — reports whether the background loader thread is
+  still alive (UI uses this to show a "still loading" indicator).
+- `__iter__` — yields only selected catalogs.
+
+---
+
+## 3. Building: `CatalogBuilder`
+
+`CatalogBuilder.build(shared_state, ui_queue=None)` is called once
+during startup (from the main process when initialising the catalog
+menu). It:
+
+1. Opens `ObjectsDatabase` and `ObservationsDatabase`.
+2. Loads all rows from `catalog_objects`, the keyed-by-id `objects`
+   dict, `Names`, and `catalogs_info` (descriptions + max_sequence per
+   catalog).
+3. Splits `catalog_objects` rows into two buckets based on
+   `catalog_code`:
+   - **priority** (`{"NGC", "IC", "M"}`) — loaded **synchronously** by
+     `_create_full_composite_object()`. About 13k objects.
+   - **deferred** (everything else, e.g. WDS) — handed to a
+     `CatalogBackgroundLoader`.
+4. Groups the loaded priority composites by `catalog_code` and creates
+   one `Catalog` per entry in `catalogs_info`, ending up with a
+   `Catalogs` instance even for catalogs that are currently empty (the
+   background loader will populate them later).
+5. Appends two dynamic catalogs: `PlanetCatalog` (`PL`) and, via local
+   import, `CometCatalog`.
+6. Asserts `check_catalogs_sequences(...)`.
+
+The reference to the background loader is also stashed on the
+`Catalogs` instance as `_background_loader` so `Catalogs.is_loading()`
+can introspect it.
+
+### 3.1 Priority vs. deferred — why
+
+Synchronously loading every catalog (including WDS, ~tens of thousands
+of double stars) blocks UI startup unacceptably. Splitting on
+"popular" catalogs (M, NGC, IC) yields a usable UI in a few hundred
+milliseconds; the rest stream in over the next several seconds while
+the user can already navigate.
+
+### 3.2 `CatalogBackgroundLoader`
+
+A standalone, testable helper (no Catalog/Catalogs references — just
+dicts, names, and the observations DB). Runs in a daemon thread:
+
+- `batch_size = 100` `CompositeObject`s per batch.
+- `yield_time = 0.05` s sleep between batches (gives CPU back to the
+  solver/UI).
+- Progress callback (`_on_loader_progress`) logs every 10k objects.
+- Completion callback (`_on_loader_complete`) groups loaded objects by
+  `catalog_code` and calls `catalog.add_objects(batch)` once per
+  catalog (much cheaper than per-object adds, since `add_objects`
+  rebuilds the position indices only at the end). It then re-runs
+  `catalog.filter_objects()` on each catalog that now has new content,
+  and finally pushes `"catalogs_fully_loaded"` onto `ui_queue` so the
+  main loop can refresh.
+- `stop()` sets a flag the worker checks per iteration and joins with a
+  1 s timeout — used during shutdown.
+
+---
+
+## 4. Filtering: `CatalogFilter`
+
+A single `CatalogFilter` is shared across all `Catalog`s via
+`Catalogs.set_catalog_filter(...)`. It maintains five filter parameters
+plus a selected-catalogs set:
+
+| Property | Type | Meaning |
+| --- | --- | --- |
+| `magnitude` | `float | None` | Maximum `filter_mag`. `None` disables. |
+| `object_types` | `list[str] | None` | Allowed obj_type values (e.g. `["Gal", "Neb"]`). Empty list **rejects everything**. |
+| `altitude` | `int` | Minimum altitude in degrees. `-1` disables. Requires GPS lock to compute. |
+| `observed` | `"Any" | "Yes" | "No"` | Match on `obj.logged`. |
+| `constellations` | `list[str]` | Required `const` values. Empty list **rejects everything**. |
+| `selected_catalogs` | `set[str]` | Which catalogs are "on" in the UI. |
+
+### 4.1 Dirty tracking
+
+Filtering is the hot path — every menu redraw asks for filtered objects.
+The filter therefore caches per-object decisions:
+
+- Every setter calls `mark_dirty()`, bumping `dirty_time = time.time()`.
+- `CompositeObject.last_filtered_time` and `.last_filtered_result` cache
+  the most recent decision for that object.
+- `apply_filter(obj)` short-circuits if `obj.last_filtered_time >
+  self.dirty_time` — i.e. the object was filtered after the last change.
+
+So if the filter has not changed since the last sweep, the second sweep
+is O(n) cache reads with no real predicate work.
+
+### 4.2 Altitude requires GPS
+
+`calc_fast_aa(shared_state)` builds a `FastAltAz` from the current
+location/datetime, *if* `shared_state.altaz_ready()`. When the alt-az
+calculator is missing, altitude is skipped (not rejected). This is why
+the altitude filter "stops working" without GPS — the predicate is
+simply not evaluated.
+
+### 4.3 Surprising "empty list = reject" behaviour
+
+For both `object_types` and `constellations`, an **empty list rejects
+every object**. Only `None` (or "Any" for observed) means "don't
+filter." This is intentional — empty constellation list means "the user
+unchecked everything." Callers should be careful when constructing
+filters programmatically.
+
+### 4.4 `load_from_config`
+
+`CatalogFilter.load_from_config(cfg)` pulls the same five parameters
+from `Config` under the `filter.*` namespace (`filter.magnitude`,
+`filter.object_types`, …, `filter.selected_catalogs`). This is how the
+filter is restored on app start.
+
+---
+
+## 5. Search
+
+### 5.1 Text search
+
+`Catalogs.search_by_text(s)` does a substring lower-case match against
+each name on each object. Returns a `List[CompositeObject]`. No indexing
+— it's O(n_names) per call but fine in practice.
+
+### 5.2 T9 (keypad) search
+
+PiFinder's hardware keypad uses a non-standard digit-to-letter mapping
+(`KEYPAD_DIGIT_TO_CHARS` at the top of `catalogs.py` — note `7→abc`,
+`1→tuv`, `3→'-+/`, etc.). `Catalogs.search_by_t9(digits)`:
+
+1. Translates every object name to its digit-form via a
+   `str.maketrans` table.
+2. Filters out characters that aren't valid T9 digits.
+3. Caches `(catalog_code, sequence) → list[digit_string]` in
+   `_t9_cache`, invalidated when catalogs are added/removed/replaced.
+4. Returns any object whose digit string contains the search pattern as
+   a substring (skipping objects whose digit string is shorter than the
+   query, since the substring couldn't match).
+
+The cache is rebuilt lazily by `_ensure_t9_cache(objs)` only if the
+dirty flag is set **or** the set of object keys has changed since the
+last rebuild — so dynamic catalogs (PL, comets) updating their
+positions don't trigger a rebuild as long as their key set is stable.
+
+---
+
+## 6. Dynamic catalogs
+
+### 6.1 `PlanetCatalog`
+
+A `Catalog` subclass that:
+
+- Uses `TimerMixin` to recompute positions on a background timer.
+- Has two delay regimes: `DEFAULT_DELAY = 307` s (have GPS lock) and
+  `WAITING_FOR_GPS_DELAY = 10` s (no lock yet). `time_delay_seconds`
+  picks based on `self.initialized`.
+- Reports state through `get_status()`: `NO_GPS` /
+  `CALCULATING` / `READY`, with a previous-state field for transition
+  detection by the UI.
+- On the first tick with a GPS-locked datetime, calls
+  `sf_utils.calc_planets(dt)` and creates a `CompositeObject` per
+  planet (skipping the Sun) with `catalog_code="PL"`,
+  `obj_type="Pla"`, and a single-name list. `VirtualIDManager`
+  assigns each object a negative `object_id` (the DB uses positive
+  ids; negative is the convention for in-memory-only objects).
+- Subsequent ticks update each existing `CompositeObject` in place —
+  new RA/Dec/mag/const — without recreating the catalog.
+
+### 6.2 `CometCatalog`
+
+Imported locally in `CatalogBuilder.build()` to avoid a circular
+import. Same general pattern: dynamic, status-aware, registered as a
+regular `Catalog` in the `Catalogs` collection.
+
+### 6.3 `TimerMixin`
+
+Provides `start_timer()` / `stop()` plus a `time_delay_seconds` that can
+be either an int or a callable. Each fire schedules itself again via
+`threading.Timer` and runs `do_timed_task` in a separate thread, so the
+catalog method does not run on the timer thread directly — useful
+because `do_timed_task` can take a noticeable amount of time
+(`sf_utils.calc_planets` is not cheap).
+
+### 6.4 `VirtualIDManager`
+
+Static helper that hands out monotonically decreasing `object_id`
+values for non-DB objects. Held under `virtual_id_lock` and persists
+the low watermark in `virtual_id_low`. Without this, two dynamic
+catalogs might mint identical negative IDs and break the
+`CompositeObject.__eq__/__hash__` contract.
+
+---
+
+## 7. Distribution
+
+The catalog system is consumed almost entirely inside the main UI
+process. Typical consumer patterns:
+
+- **Menu and chart screens** call `catalogs.get_objects(...)`,
+  `catalogs.get_catalog_by_code(...)`, `catalog.get_filtered_objects()`,
+  etc.
+- **CatalogDesignator** (`catalogs.py`, near the bottom) holds the
+  formatted input string for catalog-code selection — `"NGC----"`,
+  `"M-13"`, etc., respecting a per-catalog width derived from
+  `max_sequence`. It exposes `set_number`, `append_number`,
+  `increment_number`/`decrement_number`, and `has_number`.
+- **The filter UI** mutates `Catalogs.catalog_filter` via its
+  properties (which mark it dirty); the next call to
+  `Catalog.filter_objects()` re-runs the cached sweep.
+- **Background-loader completion** sends `"catalogs_fully_loaded"`
+  onto `ui_queue`, allowing the UI to refresh lists once the deferred
+  load finishes.
+- **The web server** uses the same `Catalogs` instance through the
+  shared object model, exposing object data through `/api/...` routes.
+
+There is no separate "catalog state" published on `shared_state`; the
+catalogs live in the main process and are shared with other processes
+only via the lower-level DB queries (`ObservationsDatabase` write-back
+of logged status, for example).
+
+---
+
+## 8. Lifecycle summary
+
+1. `CatalogBuilder.build()` constructs `Catalogs`, loads priority
+   catalogs, starts background loader, attaches `PlanetCatalog` and
+   `CometCatalog`.
+2. `CatalogFilter` is constructed and hooked in via
+   `set_catalog_filter`. `load_from_config(cfg)` restores user
+   preferences.
+3. Each UI refresh that needs filtered objects calls
+   `catalog.filter_objects()` — cheap thanks to the dirty-time cache.
+4. Periodic timers update `PlanetCatalog` / `CometCatalog` positions.
+5. Background loader, when it completes, batch-adds deferred objects to
+   their catalogs, triggers a re-filter, and signals the UI.
+6. On shutdown, `CatalogBackgroundLoader.stop()` and any
+   `TimerMixin.stop()` calls cancel their threads.
+
+---
+
+## 9. Glossary (draft — to be reviewed)
+
+> Working notes synthesised from the source. Should be reviewed for
+> correctness and refined before being treated as canonical.
+
+**Catalog code** — Short string identifier for a catalog, e.g. `"M"`,
+`"NGC"`, `"IC"`, `"WDS"`, `"PL"` (planets). Drives both DB queries and
+the UI designator.
+
+**Sequence** — Integer number of an object within its catalog (e.g. 13
+for M 13). Combined with catalog_code it uniquely identifies a catalog
+entry. Sequences must be unique inside a catalog — enforced by
+`CatalogBase.check_sequences()`.
+
+**Object ID (`object_id`)** — Primary key in the SQLite `objects`
+table. One physical object can be referenced by many catalog entries
+(e.g. M 31 and NGC 224 share an `object_id`). `CompositeObject`
+equality/hash is based on `object_id`.
+
+**Catalog object ID (`id`)** — Primary key in the SQLite
+`catalog_objects` table — i.e. the catalog-listing row, not the sky
+object.
+
+**Virtual ID** — Negative `object_id` assigned by `VirtualIDManager` to
+objects that don't come from the DB (planets, comets), so they still
+have unique hashable identifiers.
+
+**`CompositeObject`** — `composite_object.CompositeObject`. The
+runtime unit combining a catalog entry, its underlying object data,
+its common names, magnitude, and observation status. Used everywhere
+in the UI/web layers.
+
+**`MagnitudeObject`** — Wrapper around a list of magnitude values.
+Provides `filter_mag` (mean of parseable floats) for filtering and
+`calc_two_mag_representation()` for display. `UNKNOWN_MAG = 99`
+sentinel.
+
+**`Names`** — Lookup object for common-name maps:
+`id_to_names: object_id → list[name]` and the reverse `name_to_id`.
+Loaded once at startup from `ObjectsDatabase`.
+
+**`CatalogBase`** — Base class holding the object list plus
+`id_to_pos`/`sequence_to_pos` indices and the sequence-uniqueness
+invariant.
+
+**`Catalog`** — `CatalogBase` plus filtering: holds the shared
+`CatalogFilter`, the `filtered_objects` list, and `get_status()`.
+
+**`Catalogs`** — Collection of `Catalog`s. Owns the shared
+`CatalogFilter` and the T9 / text search caches; exposes the runtime
+API used by the UI.
+
+**`CatalogFilter`** — Filter parameters (`magnitude`, `object_types`,
+`altitude`, `observed`, `constellations`, `selected_catalogs`) plus
+the dirty-time cache. Setters call `mark_dirty()`.
+
+**Dirty time (`dirty_time` / `last_filtered_time`)** — Pair of epoch
+timestamps used to cache per-object filter decisions. An object is
+re-evaluated only when `obj.last_filtered_time < filter.dirty_time`.
+
+**Selected catalogs (`selected_catalogs`)** — Set of catalog codes the
+user has turned on in the UI. `Catalog.is_selected()` checks this set.
+
+**Priority catalogs / deferred catalogs** — In `CatalogBuilder`, the
+hard-coded `{"NGC", "IC", "M"}` set loaded synchronously vs.
+everything else loaded by `CatalogBackgroundLoader`.
+
+**`CatalogBackgroundLoader`** — Daemon thread that streams deferred
+catalog objects in batches of `batch_size = 100`, yielding the CPU
+between batches for `yield_time = 0.05` s. Calls `on_progress` for
+logging and `on_complete` to integrate the loaded objects.
+
+**`CatalogState` / `CatalogStatus`** — Enum
+(`READY` / `NO_GPS` / `DOWNLOADING` / `CALCULATING` / `ERROR`) and a
+NamedTuple `(current, previous, data)` used by the UI to react to
+catalog state transitions.
+
+**`TimerMixin`** — Composition helper providing periodic
+self-rescheduling timers. `time_delay_seconds` may be a callable for
+adaptive delays. `do_timed_task` is the catalog's update entry point;
+runs in its own thread, not on the timer thread.
+
+**`PlanetCatalog`** — Dynamic `Catalog` (`PL`) computed from skyfield
+via `sf_utils.calc_planets(dt)`. Adaptive update cadence:
+`WAITING_FOR_GPS_DELAY = 10` s pre-lock, `DEFAULT_DELAY = 307` s
+post-lock.
+
+**`CometCatalog`** — Comet equivalent of `PlanetCatalog`. Imported
+locally inside `CatalogBuilder.build()` to avoid a circular import.
+
+**`VirtualIDManager`** — Static manager that mints unique negative
+`object_id` values for non-DB catalog objects (planets, comets).
+Protected by `virtual_id_lock`.
+
+**`ROArrayWrapper`** — Read-only proxy returned from
+`CatalogBase.get_objects()` so that callers can iterate/index but not
+mutate the underlying list.
+
+**T9 search (`search_by_t9`)** — Substring search using the
+`KEYPAD_DIGIT_TO_CHARS` mapping to translate names to digit strings.
+Note the layout is non-conventional — `7→abc`, `1→tuv`, etc.
+Backed by `_t9_cache` keyed on `(catalog_code, sequence)`.
+
+**Text search (`search_by_text`)** — Lower-case substring match over
+all names in all catalogs (selected and unselected, filtered and
+unfiltered).
+
+**`CatalogDesignator`** — Holds the formatted input string for catalog
+selection, e.g. `"NGC----"` or `"M-13"`. Padding width is derived from
+each catalog's `max_sequence`.
+
+**`KEYPAD_DIGIT_TO_CHARS` / `LETTER_TO_DIGIT_MAP` / `translator`** —
+The keypad mapping table and its `str.maketrans` representation; the
+core of T9 search.
+
+**`logged`** — Boolean on `CompositeObject`, populated at build time
+from `ObservationsDatabase.check_logged(obj)`. Used by the `observed`
+filter and by UI badges.
+
+**`altaz_ready`** — `SharedStateObj` flag that says GPS+time are
+sufficient to compute Alt/Az. Gates `CatalogFilter.calc_fast_aa`.
+
+**`FastAltAz` / `fast_aa`** — A cached transformer constructed inside
+the filter for each filter pass; reused across all objects in that
+pass.
+
+**`ObjectsDatabase` / `ObservationsDatabase`** — SQLite wrappers in
+`PiFinder/db/`. Read-mostly catalog data lives in the former; the
+latter records user observations and answers `check_logged`.
+
+**`catalogs_fully_loaded`** — String token pushed onto `ui_queue` by
+the background loader when deferred loading completes. The UI watches
+for it to refresh lists.
+
+**`ui_queue`** — Queue from the main loop, passed into
+`CatalogBuilder.build()` so the loader can signal completion without
+holding a UI reference.

--- a/docs/ax/catalog/CONTEXT.md
+++ b/docs/ax/catalog/CONTEXT.md
@@ -1,0 +1,198 @@
+# Catalog
+
+The Catalog context owns runtime loading, filtering, searching and display of astronomical catalogs (Messier, NGC, IC, WDS, planets, comets…) for the UI and web layers. Catalog state lives in the main UI process; other processes only see catalog content indirectly through the shared `objects.db` and `observations.db`.
+
+> Companion architecture doc: [`../catalog.md`](../catalog.md).
+
+## Language
+
+### Identity
+
+**Catalog code**:
+Short string identifier for a catalog as a whole — `"M"`, `"NGC"`, `"IC"`, `"WDS"`, `"PL"` (planets). Drives DB queries and the UI designator.
+_Avoid_: catalog name, catalog id, prefix.
+
+**Sequence**:
+Integer position of an object inside one catalog (e.g. `13` for M 13). Must be unique within a catalog (enforced by `CatalogBase.check_sequences()`).
+_Avoid_: number, index, ordinal.
+
+**Object ID** (`object_id`):
+Primary key in the SQLite `objects` table — i.e. the **sky object**'s id. The same sky object may appear in multiple catalog listings and they all share one `object_id` (e.g. M 31 ≡ NGC 224). `CompositeObject` equality/hash is keyed on this.
+_Avoid_: object key, db id.
+
+**Catalog object ID** (`id`):
+Primary key in the `catalog_objects` table — the **catalog listing**'s id, distinct from `object_id`. Rarely used outside DB code.
+_Avoid_: row id, catalog row.
+
+**Sky object**:
+A row in the `objects` SQLite table — the physical thing in the sky. One sky object can be listed in many catalogs.
+_Avoid_: object (without "sky" qualifier, "object" means `CompositeObject`), DSO row.
+
+**Catalog listing**:
+A row in the `catalog_objects` SQLite table — how a sky object appears in one particular catalog (catalog_code + sequence + description). One sky object can have many catalog listings.
+_Avoid_: catalog object (sounds like `CompositeObject`), entry, catalog row.
+
+**Virtual ID**:
+Negative `object_id` minted by `VirtualIDManager` for in-memory-only catalog objects (planets, comets) so they still hash uniquely.
+_Avoid_: synthetic id, fake id.
+
+**Designator**:
+The user-facing formatted string for a catalog entry — `"NGC 7000"`, `"M 13"`, `"PL Mars"`. Managed by `CatalogDesignator`; per-catalog width comes from `max_sequence`.
+_Avoid_: label, name (a "name" is a common name like "Andromeda").
+
+### Domain objects
+
+**CompositeObject**:
+The runtime unit displayed in the UI: a catalog listing merged with its underlying sky object, common names, magnitude, and `logged` flag. Built once and held by reference across catalogs. The bare word "object" in prose means a `CompositeObject`.
+_Avoid_: object record, catalog row, entry.
+
+**MagnitudeObject**:
+Wrapper around a list of magnitude values. Exposes `filter_mag` (mean of parseable floats) for filtering and `calc_two_mag_representation()` for the `"min/max"` display string. `UNKNOWN_MAG = 99` is the sentinel.
+_Avoid_: magnitude, mag (those are the underlying floats).
+
+**Names**:
+The common-name lookup: `id_to_names: object_id → list[str]` and the reverse `name_to_id`. Loaded once at startup.
+_Avoid_: aliases, labels.
+
+**Catalog** (the class):
+A `CatalogBase` (object list + sequence/id indices) plus filtering: holds the shared `CatalogFilter`, the `filtered_objects` view, and `get_status()`.
+_Avoid_: catalog object, catalog instance — use `Catalog` when the class is meant.
+
+**Catalogs** (the catalog collection):
+The container of `Catalog`s. Owns the singleton `CatalogFilter` and the T9/text search caches; this is the runtime API used by the UI and web. In prose, say "the catalog collection"; reserve `Catalogs` (code-style) for the type itself.
+_Avoid_: catalog list, catalog set, the catalogs object.
+
+### Filtering
+
+**CatalogFilter**:
+Single shared filter installed on every `Catalog`. Holds five filter parameters plus the enabled-catalogs set; every setter calls `mark_dirty()`.
+_Avoid_: filter, criteria — "the filter" is fine in prose but the type name is `CatalogFilter`.
+
+**Enabled catalog**:
+A catalog whose code is in `CatalogFilter.selected_catalogs` — i.e. the user has turned it on in the UI. `Catalog.is_selected()` checks membership; iterating `Catalogs` yields enabled catalogs only.
+_Avoid_: selected catalog (the code identifier says `selected_catalogs`, but in prose we reserve "selected" for the displayed object — see below), active catalog.
+
+> Note: the field is named `selected_catalogs` in code (`catalogs.py:182`, menu structure, config key `filter.selected_catalogs`). The prose term is "enabled" — keep the existing identifier names but say "enabled" in docs and conversation.
+
+**Filtered objects**:
+The post-filter view returned by `Catalog.get_filtered_objects()`. Distinct from enabling: filtering operates inside a catalog; enabling picks whole catalogs in/out.
+_Avoid_: matching objects, visible objects.
+
+**Selected object**:
+The single `CompositeObject` currently being viewed in `UIObjectDetails` (info + push-to guidance). Not a property of a catalog — it's a UI cursor.
+_Avoid_: current object, active object, target object.
+
+**Logged**:
+Technical: the object has a row in the observations DB log table. The `CompositeObject.logged` bool is populated at build time from `ObservationsDatabase.check_logged(obj)`. Use this term when talking about table membership / DB queries / the field itself.
+_Avoid_: observed (that's the user-facing twin — see below).
+
+**Observed**:
+User-facing: "I've seen this object." Surfaces as the `CatalogFilter.observed` parameter (`"Yes" | "No" | "Any"`) and in UI copy. The predicate test reads `obj.logged`, so the two terms refer to the same underlying state — they're deliberately split into a technical term (`logged`) and a colloquial one (`observed`).
+_Avoid_: logged (when speaking to users or in UI copy), seen.
+
+**Dirty time** (`dirty_time` / `last_filtered_time`):
+Pair of epoch timestamps that drive the per-object filter cache. An object is re-evaluated only when `obj.last_filtered_time < filter.dirty_time`.
+_Avoid_: invalidation, cache key.
+
+**Empty-list rejection**:
+For `object_types` and `constellations`, an empty list rejects every object; only `None` (or `"Any"` for `observed`) means "don't filter on this dimension." Flagged here because it surprises callers.
+_Avoid_: empty filter, no filter.
+
+### Loading
+
+**Priority catalogs**:
+The hard-coded set `{"NGC", "IC", "M"}` loaded synchronously during `CatalogBuilder.build()` so the UI is usable in a few hundred ms.
+_Avoid_: core catalogs, default catalogs.
+
+**Deferred catalogs**:
+Everything else (e.g. WDS) — loaded in a daemon thread by `CatalogBackgroundLoader` after the UI is up.
+_Avoid_: background catalogs, lazy catalogs.
+
+**Populated**:
+A catalog has at least one `CompositeObject` in its `get_objects()` list. Priority catalogs are populated by the end of `build()`; deferred catalogs become populated at the moment `_on_loader_complete` runs (all deferred catalogs flip together — intentional, so the UI gets one `"catalogs_fully_loaded"` notification rather than a stream).
+_Avoid_: loaded (without qualifier), ready.
+
+**Fully loaded**:
+The background loader thread has exited — `Catalogs.is_loading()` returns False. For deferred catalogs this coincides with becoming populated; for priority catalogs there is a window where they're populated but the system isn't fully loaded yet.
+_Avoid_: loaded (without qualifier), done.
+
+**CatalogBackgroundLoader**:
+Daemon thread that streams deferred catalog objects in batches of 100 with a 0.05 s CPU-yield between batches; signals completion to the UI by pushing `"catalogs_fully_loaded"` on `ui_queue`.
+_Avoid_: background loader, async loader.
+
+**`catalogs_fully_loaded`**:
+The literal string token pushed onto `ui_queue` once deferred loading completes. The UI watches for it to refresh lists.
+_Avoid_: load-done event, ready signal.
+
+### Dynamic catalogs
+
+**Dynamic catalog**:
+A `Catalog` whose objects are computed at runtime rather than loaded from `objects.db`. Currently `PlanetCatalog` and `CometCatalog`.
+_Avoid_: live catalog, computed catalog.
+
+**PlanetCatalog**:
+The `"PL"` catalog. Recomputes planet positions on a `TimerMixin` schedule using `sf_utils.calc_planets(dt)`. Adaptive delay: 10 s pre-GPS-lock, 307 s after.
+_Avoid_: planets, ephemeris (those are more general).
+
+**CometCatalog**:
+Comet equivalent of `PlanetCatalog`. Imported locally inside `CatalogBuilder.build()` to break a circular import.
+_Avoid_: comets.
+
+**TimerMixin**:
+Composition helper providing self-rescheduling periodic timers. `time_delay_seconds` may be a callable for adaptive delays. Updates run in their own thread, not on the timer thread.
+_Avoid_: scheduler, ticker.
+
+**Catalog status** (`CatalogStatus`):
+NamedTuple `(current, previous, data)` exposing the lifecycle state of a (typically dynamic) catalog. Current values: `READY`, `NO_GPS`, `DOWNLOADING`, `CALCULATING`, `ERROR`.
+_Avoid_: catalog state (the enum is `CatalogState`; the wrapper is `CatalogStatus`).
+
+### Search
+
+**Text search** (`search_by_text`):
+Lower-case substring match against every name in every catalog. Selection and filter state are ignored.
+_Avoid_: name search, full-text search.
+
+**T9 search** (`search_by_t9`):
+Substring search after translating names to PiFinder's non-standard keypad-digit form (`KEYPAD_DIGIT_TO_CHARS` — `7→abc`, `1→tuv`, …). Backed by `_t9_cache` keyed on `(catalog_code, sequence)`.
+_Avoid_: keypad search, digit search (use T9 search for the public concept).
+
+### UI helpers
+
+**CatalogDesignator**:
+Holds the formatted input string the user edits during catalog-code selection (`"NGC----"`, `"M-13"`). Width derives from each catalog's `max_sequence`.
+_Avoid_: input buffer, designator input.
+
+**ROArrayWrapper**:
+Read-only proxy returned from `CatalogBase.get_objects()`. Iterable and indexable, not mutable.
+_Avoid_: readonly list, immutable view.
+
+### Boundary terms
+
+**`shared_state`** is referenced by Catalog but **owned by Positioning**. See [Positioning](../positioning/CONTEXT.md).
+
+**`logged`** on `CompositeObject` is set at build time from `ObservationsDatabase.check_logged(obj)`; the observations DB is read-only from the Catalog's perspective.
+
+**`altaz_ready` / `FastAltAz`** come from the Positioning context — Catalog uses them only to gate the altitude filter.
+
+## Flagged ambiguities
+
+- **"Catalog"** — refers either to the class `Catalog` (one M, NGC, etc.) or the collection `Catalogs`. In prose, prefer "the catalog collection" for the `Catalogs` instance and "a catalog" for one of them; write `Catalogs` / `Catalog` in code-style when the type itself is meant.
+- **"Object"** — bare word means `CompositeObject`. For the DB layers force a qualifier: **"sky object"** = `objects` row (the physical thing; one per real-world target), **"catalog listing"** = `catalog_objects` row (one per appearance of a sky object in a catalog). M 31 is one sky object with multiple catalog listings ("M 31" and "NGC 224"), all surfaced as separate `CompositeObject`s but sharing an `object_id`.
+- **"Selected"** has two valid meanings — keep them apart:
+  - **Selected object** = the single object currently displayed in `UIObjectDetails`. UI-cursor concept.
+  - The catalog-level concept used to be called "selected catalogs" in code and is still named that way (`CatalogFilter.selected_catalogs`, `Catalog.is_selected()`). In **prose** we now say "enabled catalog" to avoid confusion with the selected object. Don't rename the code identifiers — just the words you use to talk about them.
+- **"Filtered"** vs **"enabled"** — filtered is per-object inside a catalog; enabled is whole-catalog in/out. They compose: a filtered-out object can live in an enabled catalog.
+
+## Example dialogue
+
+> **Dev:** I want to show only galaxies the user has seen in the M and NGC catalogs.
+>
+> **Domain:** So you'll **enable** M and NGC (`selected_catalogs = {"M", "NGC"}` in code), set `object_types = ["Gal"]`, and `observed = "Yes"`. Iterating the `Catalogs` collection yields just those two enabled `Catalog`s, and `get_filtered_objects()` on each gives you the galaxies with `logged=True`.
+>
+> **Dev:** And when the user opens NGC 7000 from the list?
+>
+> **Domain:** That makes NGC 7000 the **selected object** — the one `UIObjectDetails` is showing. Selecting an object doesn't change which catalogs are enabled or which objects are filtered in; it's an independent UI cursor.
+>
+> **Dev:** What if no galaxies are logged yet?
+>
+> **Domain:** Then `filtered_objects` is empty — which is fine. Watch out though: if you bound the type list to a UI list and the user unchecks everything, you'll send `object_types=[]`, which **rejects everything**. Only `None` means "don't filter on type."

--- a/docs/ax/positioning.md
+++ b/docs/ax/positioning.md
@@ -1,0 +1,435 @@
+# Positioning in PiFinder
+
+This document describes how PiFinder acquires, integrates, and distributes
+position data (where the telescope is currently pointed). It focuses on the
+two processes that produce the canonical "where am I pointing?" answer:
+
+- `PiFinder/solver.py` — runs plate-solving on camera frames.
+- `PiFinder/integrator.py` — fuses plate-solves with IMU dead-reckoning
+  and publishes the result to the rest of the system.
+
+A glossary of terms and data structures appears at the end. Definitions
+there are draft notes and should be reviewed.
+
+---
+
+## 1. Process layout
+
+The two positioning processes are spawned from `main.py` alongside the
+camera, IMU, GPS, web, and UI processes. They communicate through:
+
+- `shared_state` — a `SharedStateObj` proxy backed by a multiprocessing
+  manager. Used for camera frames, IMU samples, GPS/time, configuration,
+  and the published pointing solution.
+- `solver_queue` — a one-way `multiprocessing.Queue` from solver to
+  integrator carrying the most recent `solved` dictionary.
+- `align_command_queue` / `align_result_queue` — used by the alignment
+  flow to request a plate-solve targeted at a particular RA/Dec and
+  return the resulting pixel coordinates.
+- `camera_image` — a shared PIL image of the latest captured frame.
+
+```
+   Camera ──► camera_image ──┐
+                             │
+                       ┌───► Solver ──► solver_queue ──► Integrator ──► shared_state.set_solution()
+                       │                                       ▲
+   IMU ──► shared_state.imu() ─────────────────────────────────┘
+
+   shared_state.solution() is read by: UI, web server, position server (SkySafari), catalogs.
+```
+
+---
+
+## 2. The `solved` dictionary
+
+Both processes operate on a `solved` dict initialized by
+`solver.get_initialized_solved_dict()`. This dict is the unit of
+information that travels through `solver_queue` and is eventually stored
+via `shared_state.set_solution()`. Its key fields are:
+
+| Field | Meaning |
+| --- | --- |
+| `RA`, `Dec`, `Roll` | Current pointing in degrees. After a successful plate-solve these are the coordinates **at the target pixel** (not the camera center). The integrator may overwrite these with IMU dead-reckoned values. |
+| `camera_solve.RA/Dec/Roll` | Pointing at the **camera center** from the most recent plate-solve. Never updated by the IMU. Used as the anchor for dead-reckoning. |
+| `imu_quat` | The IMU quaternion sampled at the moment the camera exposure ended. Used as the IMU reference at the time of the last plate-solve. |
+| `Alt`, `Az` | Topocentric altitude/azimuth, computed by the integrator from RA/Dec, GPS location, and current time. |
+| `solve_source` | `"CAM"`, `"CAM_FAILED"`, or `"IMU"` — what produced the current RA/Dec. |
+| `solve_time` | Wall-clock time the current solution was produced. |
+| `cam_solve_time` | Wall-clock time of the most recent **camera** solve. |
+| `last_solve_attempt` | The `exposure_end` of the most recently processed image. Used to skip frames the solver has already seen. |
+| `last_solve_success` | The `exposure_end` of the most recent **successful** plate-solve. |
+| `Matches`, `RMSE` | Diagnostics from tetra3: matched star count and residual. Used by auto-exposure even when the solve fails. |
+| `constellation` | Three-letter constellation containing RA/Dec, filled by the integrator. |
+
+The same dict shape is shared between the two processes, which makes the
+integrator's job mostly merging and annotating, not transforming.
+
+---
+
+## 3. Acquisition: `solver.py`
+
+The solver process owns one tight loop:
+
+1. **Drain `align_command_queue`.** Three commands are handled:
+   - `align_on_radec` — store an `align_ra`/`align_dec` target; subsequent
+     plate-solves will pass `target_sky_coord` to tetra3 so we can read
+     back the pixel where that sky coordinate lands.
+   - `align_cancel` — clear the alignment target.
+   - `reload_sqm_calibration` — rebuild the `SQMCalculator` (camera
+     calibration may have changed).
+2. **Rate-limit the loop** with `state_utils.sleep_for_framerate`.
+3. **Fetch the latest frame metadata** from `shared_state.last_image_metadata()`.
+   If `exposure_end` is older than `solved["last_solve_attempt"]`, the
+   image is stale and the loop continues.
+4. **Extract centroids.** The solver prefers `PFCedarDetectClient` (a
+   subclass of `cedar_detect_client.CedarDetectClient` that talks to the
+   `cedar-detect-server` over gRPC on port 50551, using POSIX shared
+   memory when possible). On any gRPC failure, raises `CedarConnectionError`
+   and falls back to `tetra3.get_centroids_from_image`.
+5. **Solve with tetra3.** `t3.solve_from_centroids(...)` is called with:
+   - the image dims `(512, 512)`,
+   - `fov_estimate=12.0`, `fov_max_error=4.0`,
+   - `target_pixel=shared_state.solve_pixel()` so tetra3 also reports the
+     RA/Dec at the user's chosen pixel,
+   - optional `target_sky_coord` when alignment is active.
+6. **On success**, copy the camera-center coordinates into
+   `solved["camera_solve"]`, then **replace** `solved["RA"/"Dec"]` with
+   the `RA_target`/`Dec_target` values that correspond to the target
+   pixel. Attach the `imu_quat` from `last_image_metadata["imu"]["quat"]`
+   if available. Set `solve_time`, `cam_solve_time`, `last_solve_success`.
+7. **SQM update.** When the solve produced `matched_centroids`,
+   `update_sqm()` runs `SQMCalculator.calculate` on the same frame and
+   stores the result (plus the noise-floor) into `shared_state`. SQM is
+   gated to once every `SQM_CALCULATION_INTERVAL_SECONDS` (5 s).
+8. **Handle alignment hits.** If a target_sky_coord was active and tetra3
+   returned `x_target`/`y_target`, the pixel coordinates are pushed back
+   on `align_result_queue` as `["aligned", (y, x)]`.
+9. **Failures** clear `RA`/`Dec`/`Matches` but **still push** the dict to
+   `solver_queue`. This is required so the integrator (and downstream
+   auto-exposure) can react to repeated failed solves.
+
+The solver only knows about the camera. It never reads or updates the
+IMU directly — it only forwards the `imu_quat` that the camera process
+already stamped onto the frame.
+
+---
+
+## 4. Integration: `integrator.py`
+
+The integrator's job is to produce a continuous pointing estimate even
+when plate-solves are sparse or fail. It runs another tight loop.
+
+### 4.1 State held across iterations
+
+- `solved` — the current published-style dict.
+- `last_image_solve` — a deep copy of the most recent **successful**
+  plate-solve. Used as the anchor for IMU dead-reckoning and as the
+  recovery state after failed solves.
+- `imu_dead_reckoning` — an `ImuDeadReckoning` instance constructed with
+  the configured `screen_direction`. This object holds the
+  camera-to-IMU transform learned from the latest plate-solve.
+- `last_solve_time` — the `solve_time` of the most recent push to shared
+  state, used to suppress duplicates.
+
+### 4.2 Per-iteration flow
+
+1. **Try to read one solve** from `solver_queue` (non-blocking).
+2. **If a camera solve arrived:**
+   - Seed `solved` from `last_image_solve` (not from `shared_state`,
+     which may contain accumulated IMU drift).
+   - Copy `Matches`, `RMSE`, `last_solve_attempt`, `last_solve_success`
+     unconditionally so auto-exposure sees them even on failure.
+   - If `RA is not None`: merge the entire dict, mark
+     `solve_source = "CAM"`, deep-copy into `last_image_solve`, call
+     `update_plate_solve_and_imu()` to teach `ImuDeadReckoning` the new
+     camera-to-IMU alignment, and set `pointing_updated = True`.
+   - If the solve failed: mark `solve_source = "CAM_FAILED"`, blank the
+     constellation, and push immediately so consumers see `Matches=0`.
+3. **If no camera solve was applied and `ImuDeadReckoning.is_initialized()`:**
+   read `shared_state.imu()` and call `update_imu()`. That function:
+   - Compares the new IMU quaternion against `last_image_solve["imu_quat"]`.
+   - If the angular delta is below `IMU_MOVED_ANG_THRESHOLD` (0.06°),
+     does nothing (we have not actually moved).
+   - Otherwise calls `imu_dead_reckoning.predict(q_x2imu)` to get a fresh
+     `RaDecRoll`, writes it into `solved["RA"/"Dec"/"Roll"]`, sets
+     `solve_time = time.time()` and `solve_source = "IMU"`.
+4. **Annotate and publish.** When pointing was updated and `solve_time`
+   advanced past `last_solve_time`:
+   - Fill `constellation` from `calc_utils.sf_utils.radec_to_constellation`.
+   - Compute `Alt`, `Az` from RA/Dec + GPS location + current datetime.
+     (Marked TODO: not strictly needed in EQ mode.)
+   - Call `shared_state.set_solution(solved)` and
+     `shared_state.set_solve_state(True)`.
+
+### 4.3 Why the integrator copies from `last_image_solve` instead of `shared_state`
+
+`shared_state.solution()` is the IMU-tracked pointing, which drifts
+between camera solves. If the integrator used it as the base for each
+new camera solve, drift would be folded into successive plate-solves'
+metadata. Using the deep-copied `last_image_solve` keeps each new solve
+anchored to known-good camera data and resets the IMU dead-reckoning
+chain.
+
+---
+
+## 5. Camera-to-telescope alignment
+
+The plate-solver knows where the **camera** is pointing. What the user
+cares about is where the **eyepiece** is pointing. Those two
+sight-lines are not the same — the finder camera is offset from the
+optical axis of the main scope. The job of the alignment subsystem is
+to learn one number: which pixel in the 512×512 camera image
+corresponds to the center of the eyepiece view. That pixel is called
+the **solve pixel**, stored in `shared_state` as `solve_pixel` and
+persisted in `Config` under `"solve_pixel"`. Default `(256, 256)`
+(image center) means "no offset known yet."
+
+### 5.1 How `solve_pixel` is used during normal operation
+
+`solve_pixel` is read **on every solve**, not just during alignment:
+
+```python
+solution = t3.solve_from_centroids(
+    ...,
+    target_pixel=shared_state.solve_pixel(),
+    ...,
+)
+```
+
+tetra3, given `target_pixel`, returns both the RA/Dec at the camera
+center **and** the RA/Dec at that pixel as `RA_target`/`Dec_target`.
+The solver then:
+
+1. Copies the camera-center RA/Dec into `solved["camera_solve"]`
+   (preserved for IMU dead-reckoning — the IMU calibration is anchored
+   to the camera's optical axis, not the eyepiece).
+2. **Overwrites** `solved["RA"/"Dec"]` with `RA_target`/`Dec_target`.
+
+That overwrite is what makes `solved["RA"/"Dec"]` reflect the eyepiece
+direction. Every downstream consumer (UI, web, SkySafari) sees the
+eyepiece pointing, never the camera pointing.
+
+### 5.2 The alignment flow (round trip)
+
+1. **User picks a known target** in the catalog UI (e.g. a bright
+   star), and centers it in the eyepiece. They trigger "align on this."
+2. **`ui/align.py::align_on_radec(...)`** is the orchestrator. It:
+   - Drains any stale messages from `align_result_queue`.
+   - Posts `["align_on_radec", ra, dec]` on `align_command_queue`.
+   - Polls `align_result_queue` for up to 2 s. On timeout it posts
+     `["align_cancel", ra, dec]` and reports "Align Timeout."
+3. **`solver.py`** picks up the command at the top of its loop, stores
+   `align_ra` / `align_dec`, and on the next plate-solve passes
+   `target_sky_coord=[[align_ra, align_dec]]` to tetra3. tetra3 then
+   reports `x_target` / `y_target` — the pixel where that sky
+   coordinate lands in the current frame.
+4. **Solver pushes the result back** on `align_result_queue` as
+   `["aligned", (y_target, x_target)]` and clears `align_ra`/`align_dec`
+   so subsequent solves go back to normal.
+5. **`align_on_radec`** receives the pixel and commits it:
+   ```python
+   shared_state.set_solve_pixel(target_pixel)
+   config_object.set_option("solve_pixel", target_pixel)
+   ```
+   `shared_state` makes it effective immediately; `Config` makes it
+   survive a restart.
+
+### 5.3 Coordinate conventions and reset
+
+- `solve_pixel` is stored as `(Y, X)` in camera-image space (512×512).
+- `shared_state.solve_pixel(screen_space=True)` returns `(X, Y)`
+  rescaled to display space (128×128 = camera/4) for UI overlays
+  (`ui/preview.py` draws the reticle at this point).
+- Resetting alignment in the UI calls
+  `shared_state.set_solve_pixel((256, 256))` and writes the same value
+  to `Config` — i.e. recenter the eyepiece pixel on the image center.
+
+### 5.4 Why alignment doesn't disturb IMU tracking
+
+The IMU is rigidly attached to the camera, not the eyepiece. The
+camera-to-IMU transform learned by `ImuDeadReckoning.solve(pointing, q_x2imu)`
+must therefore be expressed in terms of the **camera center**, which
+is why the integrator passes `solved["camera_solve"]` (not
+`solved["RA"/"Dec"]`) into `update_plate_solve_and_imu()`. Changing
+`solve_pixel` shifts the published `solved["RA"/"Dec"]` but leaves
+`camera_solve` untouched, so the IMU model is unaffected.
+
+---
+
+## 6. Distribution
+
+Once `shared_state.set_solution(solved)` is called, downstream consumers
+read the dict by polling `shared_state.solution()`:
+
+- **UI** (`PiFinder/ui/*`) — chart, telrad, catalog pages.
+- **Web server** (`PiFinder/server.py`) — `/api/current-selection`,
+  status table, SkySafari proxy pages.
+- **Position server** (`PiFinder/pos_server.py`) — serves the LX200-style
+  telescope protocol to SkySafari and other planetarium apps.
+- **Catalogs** — use RA/Dec (and `Alt`/`Az` when available) to compute
+  visibility and "near me" lists.
+
+`shared_state.set_solve_state(bool)` is a separate, lighter signal that
+tells consumers whether a current solution exists (used by the UI to
+show the "no solve" indicator).
+
+---
+
+## 7. Timing and freshness rules
+
+A few subtle rules worth knowing when modifying either file:
+
+- The solver uses `exposure_end` (from camera metadata) — not wall
+  clock — to decide whether a frame is new. This means re-injected frames
+  with old timestamps are correctly skipped.
+- The integrator deduplicates pushes by comparing `solve_time` to its
+  local `last_solve_time`. IMU updates therefore must advance
+  `solve_time` to be published.
+- `IMU_MOVED_ANG_THRESHOLD` (0.06°) is the deadband below which IMU
+  motion is ignored. Setting it too low publishes noise; too high adds
+  visible lag when slewing.
+- On **every** solve attempt, success or failure, the solver pushes a
+  dict onto `solver_queue`. Auto-exposure depends on `Matches` being
+  updated whether or not the plate-solve succeeded.
+
+---
+
+## 8. Glossary (draft — to be reviewed)
+
+> These definitions are working notes synthesized from the source. They
+> should be reviewed for correctness and refined before being treated as
+> canonical.
+
+**Plate solve** — The process of identifying which patch of sky an image
+shows by matching detected star centroids against a catalog of star
+patterns. PiFinder uses [tetra3](https://github.com/esa/tetra3).
+
+**Centroid** — A sub-pixel `(y, x)` coordinate of a star-like point
+source detected in the image. Produced either by `cedar-detect-server`
+(preferred) or by `tetra3.get_centroids_from_image` (fallback).
+
+**Cedar / cedar-detect** — A separate gRPC service (`cedar-detect-server`)
+running on `127.0.0.1:50551` that performs fast star detection. PiFinder
+talks to it via `PFCedarDetectClient`, optionally using POSIX shared
+memory for zero-copy image transfer.
+
+**Tetra3** — The plate-solving library; bundled under
+`python/PiFinder/tetra3/`. Database used:
+`tetra3/data/default_database.npz`.
+
+**`solved` dict** — The canonical position record passed from the solver
+to the integrator and into shared state. Shape is defined by
+`get_initialized_solved_dict()` in `solver.py`.
+
+**`camera_solve`** — Sub-dict inside `solved` holding the RA/Dec/Roll at
+the **camera center** from the last plate-solve. Distinct from the
+top-level `RA`/`Dec`/`Roll`, which refer to the **target pixel** and may
+be updated by the IMU.
+
+**Target pixel / solve pixel** — A user-configurable image pixel where
+the eyepiece/finder reticle is aligned. tetra3 is asked to report the
+sky coordinate at this pixel via the `target_pixel` argument; the
+resulting RA/Dec is what the user actually sees as their pointing.
+
+**IMU (Inertial Measurement Unit)** — The BNO055 sensor that supplies
+orientation. Samples are produced by the IMU process and read by the
+integrator via `shared_state.imu()`.
+
+**IMU quaternion (`q_x2imu` / `imu_quat`)** — A unit quaternion
+expressing the IMU's current orientation in its world frame. PiFinder
+uses scalar-first convention via the `numpy-quaternion` package.
+The naming `q_x2imu` (in `ImuDeadReckoning`) denotes a transform from
+some reference frame `x` to the IMU frame.
+
+**Dead reckoning (`ImuDeadReckoning`)** — Given (a) a known pointing at
+the moment of the last successful plate-solve and (b) the IMU quaternion
+at that same moment, project the current IMU quaternion forward to a
+new RA/Dec/Roll. Defined in
+`PiFinder/pointing_model/imu_dead_reckoning.py`.
+
+**`RaDecRoll`** — Coordinate dataclass defined in
+`PiFinder/types/coordinates.py`. Constructed with `deg=True` from degree
+values; `.get(deg=True)` returns a `(RA, Dec, Roll)` tuple in degrees.
+
+**`solve_source`** — String tag on the published solution:
+- `"CAM"` — pointing came from a fresh plate-solve.
+- `"CAM_FAILED"` — most recent plate-solve attempt failed; position may
+  be from an earlier solve or IMU.
+- `"IMU"` — pointing came from IMU dead-reckoning since the last solve.
+
+**`Matches` / `RMSE`** — Tetra3 plate-solve diagnostics. `Matches` is the
+count of matched stars; `RMSE` is the residual in pixels. Surfaced via
+the `solved` dict and consumed by auto-exposure.
+
+**`last_solve_attempt` / `last_solve_success`** — Timestamps (as the
+camera's `exposure_end` value, not wall clock) of, respectively, the
+most recent frame the solver tried to solve and the most recent frame
+it succeeded on.
+
+**`shared_state` / `SharedStateObj`** — The multiprocessing-manager
+proxy that lets every PiFinder process read and write shared
+configuration, IMU samples, GPS fixes, the latest image, and the
+published pointing solution.
+
+**Screen direction** — Configuration field (`screen_direction`) that
+tells `ImuDeadReckoning` how the display/IMU is physically mounted
+relative to the optical axis. Used to bake in the right axis
+conventions when initializing dead-reckoning.
+
+**SQM (Sky Quality Meter)** — A measurement of sky brightness in
+magnitudes per square arcsecond, computed by `PiFinder/sqm.py` from
+matched stars. Calculated opportunistically inside the solver loop
+(every `SQM_CALCULATION_INTERVAL_SECONDS`, default 5 s) and published
+via `shared_state.set_sqm()`.
+
+**Noise floor** — A per-image ADU level derived during SQM calculation
+and stored via `shared_state.set_noise_floor`. Consumed by auto-exposure
+(SNR-based) in the camera process.
+
+**Camera-to-telescope alignment** — The process of learning which
+pixel in the camera image corresponds to the center of the eyepiece
+view. The user centers a known sky target in the eyepiece, and the
+solver reports back the pixel coordinate where that target lands in
+the camera frame. That pixel is stored as `solve_pixel` in
+`shared_state` and persisted to `Config`. From then on, every
+plate-solve asks tetra3 for the RA/Dec at that pixel, and publishes
+it as the pointing — so `solved["RA"/"Dec"]` reflects the eyepiece,
+not the camera center.
+
+**`solve_pixel`** — `(Y, X)` pixel in 512×512 camera image space
+representing the calibrated eyepiece-center location. Default
+`(256, 256)` means no alignment offset. Read on every plate-solve as
+the `target_pixel` argument to tetra3. Updated by
+`shared_state.set_solve_pixel(...)` and persisted via
+`Config.set_option("solve_pixel", ...)`. Accessible in screen space
+(128×128, X/Y) via `shared_state.solve_pixel(screen_space=True)` for
+UI reticle overlays.
+
+**`align_ra` / `align_dec`** — Local state in the solver process that
+holds the user's chosen sky coordinate during an alignment request.
+Non-zero values cause the next plate-solve to pass `target_sky_coord`
+to tetra3 and return the pixel where that coordinate lands. Cleared
+back to zero once the result is posted.
+
+**`align_on_radec` / `align_cancel`** — Command strings on
+`align_command_queue`. `align_on_radec` carries `(ra, dec)` and
+arms alignment; `align_cancel` clears it (sent by the UI on timeout
+or user cancel).
+
+**`["aligned", (y, x)]`** — Response message on `align_result_queue`
+carrying the pixel coordinates of the alignment target. Consumed by
+`ui/align.py::align_on_radec()`.
+
+**`solver_queue`** — Multiprocessing queue, solver → integrator. Carries
+the `solved` dict on every attempt, success or failure.
+
+**`align_command_queue` / `align_result_queue`** — Queues that carry
+alignment commands into the solver and pixel results back out.
+
+**`solve_state`** — Boolean flag set on `shared_state` indicating
+whether a current pointing solution exists; separate from the
+`solved` dict for cheap UI polling.
+
+**IMU_MOVED_ANG_THRESHOLD** — Deadband (0.06°, 1.05 mrad) below which
+IMU motion is treated as noise and no dead-reckoning update is
+published.

--- a/docs/ax/positioning/CONTEXT.md
+++ b/docs/ax/positioning/CONTEXT.md
@@ -1,0 +1,210 @@
+# Positioning
+
+The Positioning context produces and publishes the canonical "where is the telescope pointed?" answer. Plate-solving (`solver.py`) and IMU dead-reckoning (`integrator.py`) cooperate to feed `shared_state.set_solution()`; every other process (UI, web, position server, catalogs) reads through `shared_state`.
+
+> Companion architecture doc: [`../positioning.md`](../positioning.md).
+
+## Language
+
+### Core record
+
+**`PointingEstimate`**:
+The canonical "where are we pointing?" record. Replaces the legacy `solved` dict. Travels through `solver_queue` and `shared_state.set_solution()`. Holds two `PointingPair`s (current and last-solve), the IMU anchor, Alt/Az, source/timing fields, `SolveDiagnostics`, and `AlignmentResult`. Defined in `PiFinder/types/positioning.py`.
+_Avoid_: solved dict (legacy; still in use during migration but being replaced), pointing dict, solution record.
+
+> Migration note: the dataclass coexists with the legacy `solved` dict. `to_legacy_dict()` / `from_legacy_dict()` bridge them so consumers move incrementally. In prose, prefer the new vocabulary even when reading older code paths.
+
+**`solved` dict** (legacy):
+The pre-dataclass position record (`get_initialized_solved_dict()`). Being replaced by `PointingEstimate`. Use only when describing the legacy code path or the wire-compatible bridge format.
+_Avoid_: pointing dict — say "the legacy `solved` dict" when this is what you mean.
+
+**`solve_source`** / **`SolveSource`**:
+Tag on the record recording who produced the current pointing. New `SolveSource` enum: `CAMERA` (`"CAM"`), `CAMERA_FAILED` (`"CAM_FAILED"`), `IMU`. Enum inherits `str` so legacy string equality still works.
+_Avoid_: origin, source.
+
+**`solve_state`**:
+Boolean flag on `shared_state` indicating whether *any* current pointing solution exists. Separate from the `PointingEstimate` so the UI can poll cheaply.
+_Avoid_: is_solved, has_pointing.
+
+### Coordinates: the 2 × 2 matrix
+
+The positioning system tracks **two axes** (the camera optical axis, and the aligned eyepiece direction), each in **two states** (the latest plate-solve value, and the current IMU-progressed estimate). The canonical access shape is `pointing.<axis>.<state>.<RA|Dec|Roll>`:
+
+|                  | **`solve`** — plate-solve truth | **`estimate`** — current (may be IMU-progressed) |
+|------------------|----------------------------------|----------------------------------------------------|
+| **`camera`** — optical axis  | `pointing.camera.solve`  | `pointing.camera.estimate`   |
+| **`aligned`** — eyepiece direction | `pointing.aligned.solve` | `pointing.aligned.estimate` |
+
+> The code currently uses `target_pixel` / `camera_center` field names (see `PiFinder/types/positioning.py`); the canonical *language* is `aligned` / `camera`, and the dataclass will be renamed to match. Use the new names in prose and review; let the rename land separately. The same applies to `last_solve` (legacy field name) vs the `solve` column above.
+
+**Camera axis** (`camera`):
+The pointing at the camera's optical centre. The IMU dead-reckoning anchor is `pointing.camera.solve` paired with `last_solve_imu`. Never `aligned.*` — the IMU is rigidly attached to the camera, not the eyepiece.
+_Avoid_: camera_center (legacy field name), optical axis pointing, image center.
+
+**Aligned axis** (`aligned`):
+The pointing at the calibrated eyepiece centre — i.e. RA/Dec at the **target pixel** (see below). What every downstream consumer ultimately reads.
+_Avoid_: eyepiece pointing (fine in user-facing copy; in dev prose say "aligned"), target_pixel (that name is now reserved for the image-space pixel coordinate, not the RA/Dec — see below).
+
+**Solve state** (`solve`):
+The value produced by the latest plate-solve. Never touched by the IMU. `pointing.camera.solve` is the truth reference for IMU anchoring; `pointing.aligned.solve` is the truth reference for diagnostics and recovery.
+_Avoid_: last_solve (legacy field name), truth, raw.
+
+**Estimate state** (`estimate`):
+The current value, equal to `solve` immediately after a plate-solve and progressed forward by IMU dead-reckoning between solves. This is what consumers read.
+_Avoid_: current, IMU pointing (the IMU only progresses the estimate; saying "IMU pointing" obscures that it's still anchored on a plate-solve).
+
+**Pointing** (`Pointing`):
+The unit triple `(RA, Dec, Roll)` in degrees. The leaf type at every cell of the matrix. Bridge to radians via `Pointing.as_radecroll()`.
+_Avoid_: pointing (lower-case, unqualified) — that means `pointing.aligned.estimate`. See below.
+
+**`pointing`** (the dataclass field):
+The top-level container on `PointingEstimate`. Holds the four cells of the matrix. Lower-case `pointing` in prose (no code-style markup) means `pointing.aligned.estimate`; capitalised / code-style `pointing.x` means the field itself.
+_Avoid_: confusion with the prose word — context disambiguates by markup.
+
+**Pointing** (lower-case, unqualified, in prose):
+`pointing.aligned.estimate`. The aligned (eyepiece) direction as currently estimated. The default answer to "where is the telescope pointed?".
+_Avoid_: scope direction, telescope direction (fine in user-facing copy; in dev prose say "pointing").
+
+**Target pixel** (`target_pixel`):
+The `(Y, X)` pixel in 512×512 camera-image space where the eyepiece centre is calibrated by the alignment system. This is the (x, y) coordinate the alignment flow produces. Currently persisted as `Config["solve_pixel"]` and `shared_state.solve_pixel()`; the code rename to `target_pixel` follows the language rename. Default `(256, 256)` means no offset known. Passed to tetra3 as its `target_pixel` argument on every solve.
+_Avoid_: solve_pixel (legacy name; pending rename), reticle pixel, aligned pixel (the *axis* is called aligned; the *pixel* is called target).
+
+> Three names, three concepts, no overlap:
+> - **Target pixel** = `(Y, X)` image-space coordinate from alignment (the *pixel*).
+> - **Aligned** = the RA/Dec direction *at* the target pixel (the *axis*).
+> - **`pointing.aligned.estimate`** = the current IMU-progressed value of that direction (the *value the user sees*).
+
+**`RaDecRoll`**:
+Radian-based, quaternion-aware coordinate dataclass in `PiFinder/types/coordinates.py`. Used by `ImuDeadReckoning`. `Pointing.as_radecroll()` bridges from degrees → radians.
+_Avoid_: coords, position tuple.
+
+### Acquisition
+
+**Plate solve**:
+Identifying which patch of sky an image shows by matching detected star centroids against a star-pattern catalog. PiFinder uses [tetra3](https://github.com/esa/tetra3).
+_Avoid_: astrometric solve, blind solve.
+
+**Centroid**:
+Sub-pixel `(y, x)` coordinate of a star-like point source. Produced by `PFCedarDetectClient` (preferred) or `tetra3.get_centroids_from_image` (fallback).
+_Avoid_: star pixel, point source.
+
+**Matched centroid**:
+A centroid that tetra3 was able to identify against a known star. `solution["matched_centroids"]` is required before SQM runs.
+_Avoid_: identified star, recognized centroid.
+
+**Cedar / cedar-detect**:
+The separate gRPC service (`cedar-detect-server`, default `127.0.0.1:50551`) that does fast star detection. PiFinder talks to it via `PFCedarDetectClient`, optionally with POSIX shared-memory zero-copy.
+_Avoid_: detector, star detector.
+
+**Tetra3**:
+The plate-solving library bundled under `python/PiFinder/tetra3/`. Uses `tetra3/data/default_database.npz`.
+_Avoid_: solver (that name is overloaded — see below).
+
+**Solver** (the process):
+The PiFinder process owning `solver.py`. It drives the plate-solve loop and is the sole runtime caller of `SQM.calculate()`.
+_Avoid_: tetra3 (the library is one thing the solver process uses; they are not synonyms).
+
+### Diagnostics
+
+**`Matches`**:
+Count of stars tetra3 matched in the most recent solve attempt. Published on every attempt (success or failure) because auto-exposure depends on it.
+_Avoid_: matched stars, hit count.
+
+**`RMSE`**:
+Tetra3 residual in pixels for the most recent solve. Diagnostic only.
+_Avoid_: error, residual.
+
+**`last_solve_attempt`**:
+The `exposure_end` (camera-stamped timestamp) of the most recent frame the solver tried to solve. Used to skip frames it has already seen.
+_Avoid_: last_try, last_solve_time (different field).
+
+**`last_solve_success`**:
+The `exposure_end` of the most recent **successful** plate-solve.
+_Avoid_: last_ok.
+
+### Integration
+
+**Integrator** (the process):
+The process that fuses fresh plate-solves with IMU samples and publishes the result. Single owner of the `solve`-state values (`pointing.camera.solve`, `pointing.aligned.solve`) and the `ImuDeadReckoning` instance.
+_Avoid_: fuser, merger.
+
+**Last image solve** (legacy `last_image_solve`):
+The integrator's deep copy of the most recent **successful** plate-solve, used as the IMU anchor and recovery base. In the new model this is just the `solve` state on `pointing.camera` and `pointing.aligned` (plus `last_solve_imu`); the legacy `last_image_solve` dict goes away with the dataclass migration.
+_Avoid_: last_solve (this is the *state* name in the new model, not a field), last_solution.
+
+**Dead reckoning** (`ImuDeadReckoning`):
+Given a known pointing at the moment of the last plate-solve and the IMU quaternion at that moment, project the current IMU quaternion forward to a fresh `RaDecRoll`. Lives in `PiFinder/pointing_model/imu_dead_reckoning.py`.
+_Avoid_: IMU tracking, prediction.
+
+**IMU**:
+The BNO055 sensor that supplies orientation. Sampled by the IMU process; read by the integrator via `shared_state.imu()`.
+_Avoid_: gyro, sensor.
+
+**IMU quaternion** (`imu_quat`, `q_x2imu`):
+Unit quaternion (scalar-first) describing the IMU's orientation in its world frame. The name `q_x2imu` reads as "transform from frame `x` to IMU frame."
+_Avoid_: orientation, quaternion (qualify it).
+
+**`IMU_MOVED_ANG_THRESHOLD`**:
+Deadband (0.06° ≈ 1.05 mrad) below which IMU motion is treated as noise and no dead-reckoning update is published.
+_Avoid_: jitter threshold, IMU noise.
+
+**Screen direction** (`screen_direction`):
+Configuration field that tells `ImuDeadReckoning` how the display/IMU is physically mounted relative to the optical axis. Used to bake in axis conventions on initialisation.
+_Avoid_: orientation, mount direction.
+
+### Alignment
+
+**Camera-to-telescope alignment**:
+The process of learning which camera pixel coincides with the centre of the eyepiece view. Outcome: an updated **target pixel**. From then on, every solve reports RA/Dec at that pixel as `pointing.aligned`.
+_Avoid_: telescope alignment, eyepiece alignment, scope alignment.
+
+**Alignment target** (`align_ra` / `align_dec`):
+Local state in the solver process holding the user's chosen sky coordinate while an alignment request is pending. Cleared once the result is posted.
+_Avoid_: aim target.
+
+**`align_on_radec`**:
+Command on `align_command_queue` carrying `(ra, dec)` that arms alignment. Cleared by the matching `align_cancel` (timeout/user cancel).
+_Avoid_: align command, request alignment.
+
+**`["aligned", (y, x)]`**:
+Response on `align_result_queue` carrying the pixel coordinates where the alignment target lands in the current frame.
+_Avoid_: align result, pixel result.
+
+### Queues & shared state
+
+**`shared_state`** (`SharedStateObj`):
+Multiprocessing-manager proxy carrying configuration, IMU samples, GPS fixes, the latest image, the published `solved` dict, and the SQM/noise-floor state. Read by every process.
+_Avoid_: state, global state.
+
+**`solver_queue`**:
+One-way `multiprocessing.Queue`, solver → integrator. Carries the `solved` dict on every attempt, success or failure.
+_Avoid_: solve queue, pointing queue.
+
+**`align_command_queue` / `align_result_queue`**:
+Pair of queues running alignment commands into the solver and pixel results back to the UI.
+_Avoid_: align queue (singular — there are two).
+
+### Boundary terms
+
+- **SQM** is computed inside the solver process but is a separate context — see [SQM](../sqm/CONTEXT.md).
+- **`shared_state.solution()`** is consumed by Catalog to compute visibility — see [Catalog](../catalog/CONTEXT.md).
+- **GPS / time** are owned by the GPS process; Positioning is a consumer.
+
+## Flagged ambiguities
+
+- **"Pointing"** (unqualified, lower-case in prose) — means `pointing.aligned.estimate`. The eyepiece direction as currently estimated. Always qualify when you mean any of the other three cells in the 2 × 2 matrix.
+- **"`pointing`"** (the dataclass field) vs **"pointing"** (the prose word) — disambiguated by capitalisation / code-style. `PointingEstimate.pointing` is the top-level container holding the four cells; bare "pointing" in prose means `pointing.aligned.estimate`.
+- **"Solver"** — the PiFinder *process*. The plate-solving *library* is "tetra3". Don't conflate.
+- **"Target pixel"** vs the **`aligned`** axis — the *pixel* is `(Y, X)` in image space, produced by alignment; the *axis* is the RA/Dec direction at that pixel. Don't say "target pixel" when you mean the direction; don't say "aligned" when you mean the pixel.
+- **"Solution"** — be specific: `shared_state.solution()` returns the latest published `PointingEstimate`. The latest plate-solve values are the `solve` state inside; the current values consumers see are the `estimate` state.
+- **Legacy code field names** — `target_pixel` and `camera_center` still exist in `PiFinder/types/positioning.py` and the legacy `solved` dict (`camera_solve`). The canonical *language* is `aligned` / `camera` / `solve` / `estimate`; treat the field names as a code rename pending.
+
+## Example dialogue
+
+> **Dev:** During alignment, why does the published RA/Dec not jump?
+>
+> **Domain:** Alignment only changes the **target pixel** (the `(Y, X)` coordinate). It doesn't touch `pointing.camera` in either state, so the IMU model — anchored on `pointing.camera.solve` plus `last_solve_imu` — is untouched. The next plate-solve computes a fresh `pointing.aligned.solve` at the new target pixel; the integrator then promotes it to `pointing.aligned.estimate` for downstream consumers.
+>
+> **Dev:** What if the solve fails right after alignment?
+>
+> **Domain:** The solver pushes a `PointingEstimate` with `solve_source=CAMERA_FAILED`. The `solve`-state cells (`pointing.camera.solve`, `pointing.aligned.solve`) and `last_solve_imu` are preserved, so the integrator keeps producing `pointing.aligned.estimate` from IMU dead-reckoning. Auto-exposure still sees `diagnostics.Matches=0`, which is why we push on every attempt — success or failure.

--- a/docs/ax/sqm.md
+++ b/docs/ax/sqm.md
@@ -1,0 +1,393 @@
+# Sky Quality Meter (SQM) in PiFinder
+
+This document describes how PiFinder estimates sky brightness in
+magnitudes per square arcsecond, and how the same machinery produces a
+secondary "noise floor" value that auto-exposure consumes.
+
+It focuses on the runtime path that executes during normal solving:
+
+- `PiFinder/sqm/sqm.py` — the `SQM` calculator (photometry + extinction).
+- `PiFinder/sqm/noise_floor.py` — the `NoiseFloorEstimator` (camera physics + adaptive measurement).
+- `PiFinder/sqm/camera_profiles.py` — per-sensor noise constants.
+- `PiFinder/solver.py` — the only runtime caller of `SQM.calculate()`.
+
+The UI side (`ui/sqm.py`, `ui/sqm_calibration.py`, `ui/sqm_correction.py`)
+is summarized at the end. A draft glossary appears at the very bottom.
+
+---
+
+## 1. Process layout
+
+SQM is computed inside the **solver process** as a side effect of every
+successful plate solve. It does not run anywhere else during normal
+operation. The UI process only reads cached results.
+
+```
+   Camera ──► camera_image ──► Solver ──► SQM.calculate() (≤ once / 5 s)
+                                    │
+                                    ├──► shared_state.set_sqm(SQMState)
+                                    ├──► shared_state.set_sqm_details(dict)
+                                    └──► shared_state.set_noise_floor(float)
+
+   shared_state.sqm()         ──► UI sqm.py
+   shared_state.noise_floor() ──► camera_interface ──► auto_exposure (SNR target)
+```
+
+A second SQM call site lives inside the **calibration wizard**
+(`ui/sqm_calibration.py`), which captures dedicated sky/dark frames and
+runs `SQM.calculate()` against each. That code path is only active while
+the user is on the calibration screen.
+
+---
+
+## 2. Data shapes
+
+### 2.1 `SQMState` (`state.py:144`)
+
+The published per-solve result. Lives in `SharedStateObj`:
+
+| Field | Meaning |
+| --- | --- |
+| `value` | Sky brightness in mag/arcsec². Default `20.15` (typical dark sky). |
+| `source` | `"None"`, `"Calculated"`, `"Manual"`, etc. |
+| `last_update` | ISO-8601 timestamp of last calculation, or `None`. |
+
+`shared_state.sqm()` returns this dataclass; `shared_state.set_sqm(...)`
+replaces it. Two related setters live alongside:
+
+- `set_sqm_details(dict)` — the diagnostic dict from `SQM.calculate()`
+  (with the bulky per-star arrays stripped — see `solver.py:121`).
+- `set_noise_floor(float)` — the latest ADU floor; consumed by
+  auto-exposure (see §6).
+
+### 2.2 `SQM.calculate()` return value
+
+`(sqm_value, details)`:
+
+- `sqm_value: Optional[float]` — magnitudes per arcsec² after photometric
+  reduction. `None` if the solve had no matched stars, the FOV field was
+  missing, or the background was unphysical.
+- `details: dict` — diagnostics. The solver filters out
+  `star_centroids`, `star_mags`, `star_fluxes`, `star_local_backgrounds`,
+  and `star_mzeros` (the large per-star arrays) before publishing the
+  rest via `set_sqm_details`. Keys retained include `mzero`, `mzero_std`,
+  `background_per_pixel`, `pedestal`, `noise_floor_details`,
+  `sqm_uncorrected`, `extinction_for_altitude`, `sqm_altitude_corrected`,
+  and the aperture/annulus parameters used.
+
+### 2.3 `CameraProfile` (`sqm/camera_profiles.py`)
+
+Per-sensor noise constants used by `NoiseFloorEstimator`:
+
+| Field | Meaning |
+| --- | --- |
+| `read_noise_adu` | Sensor read noise [ADU], constant w.r.t. exposure. |
+| `dark_current_rate` | Thermal dark current rate [ADU/s] at ~20 °C. |
+| `bias_offset` | Electronic pedestal [ADU]. Subtracted as part of pedestal. |
+| `format`, `raw_size`, `analog_gain`, `bit_depth`, `crop_*`, `rotation_90` | Hardware config used by the camera process. |
+| `typical_sky_background` | mag/arcsec² used as a sanity bound. |
+
+Profiles are looked up by camera type (e.g. `imx296_processed`). Saved
+calibration in `~/PiFinder_data/sqm_calibration_<camera_type>.json`
+overrides `bias_offset`, `read_noise_adu`, and `dark_current_rate` when
+loaded by `NoiseFloorEstimator.load_calibration()`.
+
+---
+
+## 3. The acquisition path: `solver.py`
+
+The solver process owns the only steady-state caller. Two functions
+matter:
+
+### 3.1 `create_sqm_calculator(shared_state)`
+
+Constructs an `SQM(camera_type=<camera>_processed)` once at process
+startup, and again when an `align_command_queue` command of
+`["reload_sqm_calibration"]` arrives — used by the calibration wizard
+after it writes a new calibration JSON.
+
+### 3.2 `update_sqm(...)`
+
+Called from the solver loop on every successful tetra3 solve that
+produced `matched_centroids` (see `solver.py:446`). The function:
+
+1. **Reads `shared_state.sqm()`** and compares `last_update` to wall clock.
+2. **Gates on `SQM_CALCULATION_INTERVAL_SECONDS` (5.0 s)** — if the last
+   update is younger than 5 s, returns immediately. This is the single
+   knob that bounds SQM cost from the solver's per-frame loop. (The
+   solver loop itself is `~30 Hz` via `sleep_for_framerate`, so SQM
+   fires at most once every ~150 solver iterations.)
+3. **Calls `sqm_calculator.calculate(...)`** with:
+   - `centroids` — all detected centroids (kept for compatibility; unused).
+   - `solution` — the tetra3 solve dict (`FOV`, `matched_centroids`,
+     `matched_stars` required).
+   - `image_processed` — the 8-bit ISP-processed frame as a numpy array.
+   - `exposure_sec`, `altitude_deg` — for noise scaling and extinction.
+4. **Publishes results to `shared_state`** — `set_noise_floor`,
+   `set_sqm_details` (filtered), and `set_sqm(SQMState(...))`.
+
+Errors from `calculate()` are caught and logged; the solver loop is not
+interrupted.
+
+---
+
+## 4. The math: `SQM.calculate()`
+
+`SQM.calculate()` is a single pass over the matched stars. The full
+formula it implements (from the class docstring) is:
+
+```
+For each matched star:
+    local_bg = median(annulus pixels around star)
+    star_flux = aperture_sum - local_bg × aperture_area
+mzero = flux-weighted mean over stars of (catalog_mag + 2.5 · log10(star_flux))
+sky_bg = median(all local_bg measurements)
+SQM = mzero - 2.5 · log10((sky_bg - pedestal) / arcsec²/pixel) + extinction
+```
+
+Per-frame steps in order (see code paths in `sqm/sqm.py:315`):
+
+1. **Field parameters** — `_calc_field_parameters(fov_degrees)` precomputes
+   `arcsec_squared_per_pixel` from FOV and the fixed 512 × 512 frame size.
+2. **Optional overlap exclusion** — `_detect_aperture_overlaps` is
+   `O(N²)` in matched stars. **Disabled by default** (`correct_overlaps=False`).
+3. **Noise floor estimation** — `NoiseFloorEstimator.estimate_noise_floor`
+   runs a 5th-percentile measurement on the whole image, smoothed over
+   the last 20 calls (see §5).
+4. **Per-star photometry** — `_measure_star_flux_with_local_background`
+   iterates over matched centroids. For each: extract a 2*outer_radius+1
+   patch, build aperture and annulus masks via `np.ogrid`, take
+   `np.median` of annulus pixels for local background, sum aperture
+   pixels above background, exclude saturated stars (pixel ≥ 250 ADU
+   anywhere in aperture). Returns `(star_fluxes, local_backgrounds,
+   n_saturated)`. **This is the dominant per-call cost** — see §7.
+5. **Sky background** — `np.median(local_backgrounds)` minus pedestal,
+   clamped to ≥ 1.0 ADU.
+6. **Photometric zero point** — `_calculate_mzero` does flux-weighted
+   mean of per-star zero points; stars with non-positive flux are dropped.
+7. **Magnitude conversion** — `sqm_uncorrected = mzero - 2.5 ·
+   log10(background_flux_density)`.
+8. **Extinction correction** — `_atmospheric_extinction(altitude_deg)`
+   adds `0.28 · (airmass − 1)` using the Pickering (2002) airmass
+   formula. The "main" `sqm_final` returned is **without** this
+   correction; `sqm_altitude_corrected` is included in `details`.
+9. **Diagnostics dict** — large; the solver filters out per-star arrays
+   before publishing.
+
+Default aperture parameters from the solver call site:
+`aperture_radius=5`, `annulus_inner_radius=6`, `annulus_outer_radius=14`,
+`saturation_threshold=250`, `correct_overlaps=False`.
+
+---
+
+## 5. Noise floor estimation: `NoiseFloorEstimator`
+
+Lives in `sqm/noise_floor.py` and is owned by the `SQM` instance.
+
+`estimate_noise_floor(image, exposure_sec, percentile=5.0)` per call:
+
+1. **Measure** — `np.percentile(image, 5.0)` of the full frame.
+   Appended to a 20-deep `deque` (`dark_pixel_history`).
+2. **Theoretical floor** — `bias_offset + read_noise + dark_current_rate · exposure_sec`.
+3. **Smooth** — once history ≥ 5, use `np.median` of the deque as the
+   measurement; otherwise the raw current measurement.
+4. **Choose conservative** — `min(measured, theoretical)`, but if the
+   measurement is below `bias_offset` (physically impossible) fall back
+   to theoretical. Floor is clamped to ≥ `bias_offset`.
+5. **Validate** — `_validate_estimate` checks the floor isn't above 80 %
+   of image median (would imply no stars detected) and isn't above
+   `bias_offset + 20 · read_noise_adu`.
+6. **Optional zero-second sample request** — every
+   `zero_sec_interval` (300 s default) a flag is set in the details
+   dict so the camera process can capture a 0-second exposure for
+   recalibration. The hook is `update_with_zero_sec_sample()`. (Whether
+   the camera process honors the flag is outside the SQM module.)
+
+Per-frame cost is one full-frame percentile + one full-frame median for
+the validity check + small deque ops. On a 512×512 8-bit frame this is
+small but not zero — see §7.
+
+---
+
+## 6. Distribution
+
+`shared_state.set_sqm(SQMState)` is read by `UISQM.update()`
+(`ui/sqm.py:77`), which renders the latest value on the SQM screen.
+`UISQM` does **not** call `SQM.calculate()` — it only reads cached state
+and runs its own `sleep_for_framerate(shared_state)` (~30 Hz).
+
+`shared_state.set_noise_floor(float)` is read by the camera process
+(`camera_interface.py:252`) and forwarded to
+`auto_exposure.SNR_target_offset(noise_floor=...)` (`auto_exposure.py:728`)
+to set the minimum acceptable background for SNR-based exposure control.
+
+---
+
+## 7. Cost characterization (where the time goes)
+
+Driven entirely by the per-star loop in
+`_measure_star_flux_with_local_background`. For each matched star
+(typically 10–60 from tetra3):
+
+- A `(2·14+1)² = 841`-pixel patch is sliced from the image.
+- `np.ogrid` builds y/x grids on the patch coords (not pixel-indexed).
+- Two boolean masks (aperture, annulus) at ~841 pixels each.
+- `np.median(annulus_pixels)`, `np.max(aperture_pixels)`, `np.sum(...)`.
+
+The work is Python-loop-bound (one `for cy, cx in centroids` iteration
+per star, with several small numpy calls inside). Numpy call overhead
+on tiny arrays dominates the wall-clock cost. With 30 matched stars and
+the default 5/6/14 radii, a single `calculate()` typically lands in the
+**tens of milliseconds** on Pi-class hardware. Multiplying through the
+5-second interval gate gives a steady-state average load of well under
+1 % of one core in the solver process.
+
+This call **does not** block the UI process (a separate process), but
+the underlying single-core Pi will schedule them on the same CPU, so a
+heavy `calculate()` can transiently steal cycles from the UI loop. See
+the profiling harness for empirical numbers on a given host.
+
+---
+
+## 8. Calibration flows
+
+### 8.1 Persistent file
+
+`~/PiFinder_data/sqm_calibration_<camera_type>.json` — JSON dict with
+`bias_offset`, `read_noise`, `dark_current_rate`, `camera_type`,
+`timestamp`. Loaded by `NoiseFloorEstimator.__init__` via
+`load_calibration()`; written by `save_calibration()` and by the
+calibration wizard.
+
+### 8.2 The calibration UI (`ui/sqm_calibration.py`)
+
+A multi-step wizard (`CalibrationState`) that:
+
+1. Captures a series of **dark frames** at increasing exposures to
+   measure `bias_offset`, `read_noise_adu`, and `dark_current_rate`.
+2. Captures **sky frames** and runs `SQM.calculate()` on each
+   (`sqm_calibration.py:816`) to validate the result.
+3. Writes the calibration JSON.
+4. Sends `["reload_sqm_calibration"]` on `align_command_queue` so the
+   solver process picks up the new constants without restart.
+
+The wizard uses several `time.sleep()` calls (e.g. `sqm_calibration.py:127`)
+to wait for camera state changes; those affect the wizard screen only.
+
+### 8.3 Correction UI (`ui/sqm_correction.py`)
+
+Allows a user-supplied offset to apply to the measured SQM. Stores the
+offset; does not trigger recalculation.
+
+---
+
+## 9. Timing and gating rules
+
+A few invariants worth knowing when modifying the SQM path:
+
+- **One calculation per ~5 s.** Driven by
+  `SQM_CALCULATION_INTERVAL_SECONDS` and the `last_update` check in
+  `update_sqm`. Lowering this constant proportionally increases solver
+  CPU.
+- **No SQM on a failed solve.** The solver only enters the SQM block if
+  `"matched_centroids" in solution` (`solver.py:439`). Failed solves do
+  not advance the SQM clock.
+- **Centroid format.** `matched_centroids` are already in `(y, x)`
+  order; `SQM.calculate()` does not swap them. Don't re-swap upstream.
+- **Image format.** `image_processed` must be 8-bit (uint8). The
+  saturation threshold of 250 assumes 8-bit dynamic range.
+- **FOV must be present** in `solution` or `calculate()` returns
+  `(None, {})` and the solver clock is *not* advanced (next solve will
+  retry).
+- **Noise floor smoothing** needs ≥ 5 calls (~25 s wall clock at the
+  default interval) before the rolling median takes over from the raw
+  per-call percentile. Until then, the floor estimate is jumpy.
+
+---
+
+## 10. Glossary (draft — to be reviewed)
+
+> These definitions are working notes synthesized from the source. They
+> should be reviewed for correctness and refined before being treated as
+> canonical.
+
+**SQM (Sky Quality Meter)** — Sky brightness in magnitudes per square
+arcsecond. Higher values are darker skies. The PiFinder measurement is a
+photometric reduction from a single plate-solved frame; it is not a
+hardware SQM-LE-style sensor reading.
+
+**`mag/arcsec²`** — Astronomical surface brightness unit. Typical dark
+sky is 21–22; suburban is 18–19; bright city is 16–17.
+
+**Photometric zero point (`mzero`)** — The conversion constant between
+ADU and apparent magnitude for the current frame:
+`mag = mzero − 2.5 · log10(flux_ADU)`. Computed from matched stars of
+known catalog magnitude.
+
+**Pedestal** — The fixed electronic offset added to every pixel by the
+sensor and ISP, before any real signal. PiFinder estimates this as
+`bias_offset + dark_current_contribution` and subtracts it from the
+measured sky background.
+
+**Bias offset** — The sensor's quiescent ADU value (zero exposure, no
+signal). Comes from `CameraProfile.bias_offset`, refinable via
+calibration JSON or zero-second samples.
+
+**Read noise** — Random per-pixel noise introduced by the ADC. Constant
+w.r.t. exposure. Stored as `CameraProfile.read_noise_adu`.
+
+**Dark current** — Thermal electrons per second per pixel. Scaled by
+`exposure_sec` to a per-frame dark contribution. Stored as
+`CameraProfile.dark_current_rate` (ADU/s at ~20 °C).
+
+**Aperture** — Circular pixel region around a star centroid where flux
+is summed. Default radius 5 px.
+
+**Annulus** — Ring around each star (default inner 6 px, outer 14 px)
+used to measure *local* sky background. Local annuli (vs a single global
+sky measurement) handle uneven backgrounds and gradient illumination.
+
+**Saturation threshold** — Pixel value above which a star's aperture is
+considered saturated and the star is excluded from the `mzero` average.
+Default 250 ADU (for 8-bit processed images).
+
+**Noise floor** — The ADU level below which we treat values as
+"empty sky + sensor noise" rather than real signal. Used as the lower
+bound for sky background and as a target for SNR-based auto-exposure.
+
+**`NoiseFloorEstimator`** — Class that fuses a per-frame measurement
+(`np.percentile` of darkest pixels) with a physics-based theoretical
+floor (`bias_offset + read_noise + dark_current_rate · exposure_sec`),
+choosing the more conservative value and smoothing with a 20-deep
+history.
+
+**Airmass** — Path length through the atmosphere relative to zenith.
+Computed by Pickering (2002):
+`airmass(h) = 1 / sin(h + 244 / (165 + 47 · h^1.1))` with `h` in
+degrees. More accurate than `1/sin(h)` near the horizon.
+
+**Extinction** — Magnitudes of atmospheric attenuation per unit
+airmass. PiFinder uses 0.28 mag/airmass (V-band) and reports two SQM
+numbers: a raw `sqm_final` with no extinction correction, and an
+`sqm_altitude_corrected` that adds `0.28 · (airmass − 1)` so
+measurements at different altitudes can be compared.
+
+**Zero-second sample** — A 0-s exposure used to directly measure
+`bias_offset` and `read_noise_adu` without any sky signal or dark
+current. `NoiseFloorEstimator` periodically flags
+`request_zero_sec_sample=True` in its details so the camera process
+can capture one.
+
+**`SQM_CALCULATION_INTERVAL_SECONDS`** — The minimum wall-clock interval
+between SQM calculations in the solver loop. Default 5.0 s
+(`solver.py:34`).
+
+**`reload_sqm_calibration`** — A command string posted on
+`align_command_queue` by the calibration wizard. Causes the solver to
+rebuild its `SQMCalculator` instance, picking up freshly-saved
+calibration JSON.
+
+**Per-star arrays in `details`** — `star_centroids`, `star_mags`,
+`star_fluxes`, `star_local_backgrounds`, `star_mzeros`. Returned by
+`SQM.calculate()` for diagnostics but **stripped** before publishing
+via `set_sqm_details` to avoid bloating shared-state proxy traffic.

--- a/docs/ax/sqm/CONTEXT.md
+++ b/docs/ax/sqm/CONTEXT.md
@@ -1,0 +1,174 @@
+# SQM (Sky Quality Meter)
+
+The SQM context estimates sky brightness in magnitudes per square arcsecond from solved camera frames, and produces a "noise floor" ADU level that auto-exposure consumes. Lives entirely in the solver process at runtime; the UI is read-only.
+
+> Companion architecture doc: [`../sqm.md`](../sqm.md).
+
+## Language
+
+### Measurements
+
+**SQM**:
+The PiFinder sky-brightness measurement, in magnitudes per square arcsecond. A photometric reduction from a single plate-solved frame, not a hardware-meter reading. Higher values mean darker skies.
+_Avoid_: sky brightness number, mag-arcsec (qualify with the dataclass when relevant).
+
+**`SQMState`**:
+The published dataclass carrying the latest measurement (`value`, `source`, `last_update`). Lives in `SharedStateObj`; read by the SQM UI.
+_Avoid_: SQM value (that's the float inside), sqm reading.
+
+**`sqm_final`** (a.k.a. raw SQM):
+The SQM number returned from `SQM.calculate()` **without** the altitude extinction correction. **Intentionally** the published value (`SQMState.value`) — the 0.28 mag/airmass coefficient is an idealised V-band number, so a `sqm_altitude_corrected` that's wrong in the wrong direction is worse than an honest raw reading. Bare "SQM" means this.
+_Avoid_: corrected SQM (it's the uncorrected one).
+
+**`sqm_altitude_corrected`**:
+The SQM number after adding `0.28 · (airmass − 1)`. Carried in `details`, never in `SQMState.value`. Useful for comparing measurements taken at different pointing altitudes, but only as accurate as the idealised extinction coefficient — see `sqm_final` for the rationale that this is not the primary value.
+_Avoid_: extinction-corrected (be explicit about altitude), corrected SQM (ambiguous).
+
+**`mag/arcsec²`**:
+The astronomical surface-brightness unit. Reference scale: 21–22 dark, 18–19 suburban, 16–17 bright city.
+_Avoid_: mpsas (in code).
+
+### Photometry
+
+**Aperture**:
+Circular pixel region around a star centroid where flux is summed. Default radius 5 px.
+_Avoid_: star window, ROI.
+
+**Annulus**:
+Ring around each star (default inner 6 px, outer 14 px) used to measure the *local* sky background. Per-star local annuli — not a single global sky measurement.
+_Avoid_: background ring, sky ring.
+
+**Photometric zero point** (`mzero`):
+Per-frame conversion constant between ADU flux and apparent magnitude: `mag = mzero − 2.5 · log10(flux_ADU)`. Flux-weighted mean over the matched stars.
+_Avoid_: zero-point, calibration constant.
+
+**Saturation threshold**:
+Pixel value above which a star's aperture is excluded from `mzero`. Default 250 ADU (assumes 8-bit processed frames).
+_Avoid_: clipping threshold, max pixel.
+
+**Per-star arrays**:
+The bulky diagnostic arrays `star_centroids`, `star_mags`, `star_fluxes`, `star_local_backgrounds`, `star_mzeros` returned in `details` by `SQM.calculate()`. **Stripped** before `shared_state.set_sqm_details()` to keep proxy traffic small.
+_Avoid_: star data, debug arrays.
+
+### Atmospheric correction
+
+**Airmass**:
+Atmospheric path length relative to zenith, via Pickering (2002): `airmass(h) = 1 / sin(h + 244 / (165 + 47·h^1.1))` with `h` in degrees. More accurate near the horizon than `1/sin(h)`.
+_Avoid_: secant z, optical depth.
+
+**Extinction**:
+Atmospheric attenuation per unit airmass. PiFinder uses 0.28 mag/airmass (V-band). Reported via `extinction_for_altitude` and folded into `sqm_altitude_corrected`.
+_Avoid_: atmospheric loss.
+
+### Noise model
+
+**Bias offset**:
+The **static** component of the pedestal: sensor quiescent ADU value at zero exposure, no signal. Constant per sensor; doesn't scale with exposure time. From `CameraProfile.bias_offset`; refinable via calibration JSON or zero-second samples.
+_Avoid_: bias, pedestal (pedestal includes more than just the bias — see below).
+
+**Pedestal**:
+The **exposure-dependent total** subtracted from the measured sky background: `bias_offset + dark_current_contribution`. Grows with exposure because dark current does. Use this when you want "the floor under sky signal at this exposure"; use `bias_offset` when you want "the DC offset before any signal."
+_Avoid_: offset (overloaded), bias offset (it's a *component* of pedestal, not a synonym).
+
+> Worked example: at `bias_offset = 20 ADU`, `dark_current_rate = 0.5 ADU/s`, `exposure_sec = 1`: pedestal = `20 + 0.5 · 1 = 20.5 ADU`. At `exposure_sec = 10`: pedestal = `20 + 0.5 · 10 = 25 ADU`. Bias offset stays 20 in both cases.
+
+**Read noise**:
+Random per-pixel noise from the ADC. Constant w.r.t. exposure. `CameraProfile.read_noise_adu`.
+_Avoid_: ADC noise.
+
+**Dark current**:
+Thermal electrons per second per pixel. `CameraProfile.dark_current_rate` (ADU/s at ~20 °C). Scaled by `exposure_sec` to a per-frame contribution.
+_Avoid_: thermal noise (it isn't noise — it's signal).
+
+**Noise floor**:
+The **published** ADU value (`shared_state.set_noise_floor()`) below which we treat pixel values as "empty sky + sensor noise" rather than real signal. Lower bound for sky background; auto-exposure's SNR target. When someone says "the noise floor" without qualifier, this is what they mean — never one of the intermediate quantities inside `NoiseFloorEstimator`.
+_Avoid_: dark level, baseline, raw noise floor (use a qualifier — see below).
+
+**Measured noise floor**:
+Intermediate inside `NoiseFloorEstimator`: `np.percentile(image, 5.0)` of the current frame. Use the qualifier when this is what you mean — the bare "noise floor" refers to the published value.
+
+**Smoothed noise floor**:
+Intermediate: `np.median(dark_pixel_history)` once history ≥ 5 samples. Replaces the raw measurement once enough history has accumulated.
+
+**Theoretical noise floor**:
+Intermediate: `bias_offset + read_noise + dark_current_rate · exposure_sec`. Physics-based prediction, no image involved.
+
+**Conservative noise floor**:
+Intermediate: `min(smoothed_measurement, theoretical)` clamped to `≥ bias_offset`. The pre-validation candidate that becomes the published noise floor once `_validate_estimate` passes.
+
+**`NoiseFloorEstimator`**:
+The class that fuses a per-frame 5th-percentile measurement with a physics-based theoretical floor (`bias_offset + read_noise + dark_current_rate · exposure_sec`), choosing the more conservative value and smoothing with a 20-deep history.
+_Avoid_: floor estimator, noise estimator.
+
+**`CameraProfile`**:
+Per-sensor record holding noise constants (`read_noise_adu`, `dark_current_rate`, `bias_offset`) plus hardware config (`format`, `raw_size`, `analog_gain`, …). Looked up by camera type (e.g. `imx296_processed`).
+_Avoid_: sensor profile, camera config.
+
+### Calibration
+
+**Calibration JSON**:
+Persistent calibration file at `~/PiFinder_data/sqm_calibration_<camera_type>.json` holding `bias_offset`, `read_noise`, `dark_current_rate`, `camera_type`, `timestamp`. Overrides the matching `CameraProfile` fields.
+_Avoid_: cal file, sqm config.
+
+**Zero-second sample**:
+A single 0-second exposure used to measure `bias_offset` and `read_noise_adu` directly (no sky signal, no dark current). `NoiseFloorEstimator` periodically sets `request_zero_sec_sample=True` in `details` so the camera process can capture one. Runtime concept.
+_Avoid_: dark frame (astrophotography sense — see ambiguities), zero sample.
+
+**Dark sequence**:
+A *series* of frames captured by the calibration wizard at increasing exposures. Used to fit `dark_signal = bias_offset + read_noise + dark_current_rate · exposure_sec` and extract those three constants. Wizard concept, multi-frame, multi-exposure. The frames are **not** stacked into a master dark — only the fitted constants are kept.
+_Avoid_: dark frames (the astrophotography sense expects a master output; that's not what this produces), dark stack (stacking implies combining into one master, which doesn't happen here), darks.
+
+**Sky frame**:
+Capture-time term in the calibration wizard for the on-sky frames used to validate the resulting SQM number.
+_Avoid_: light frame.
+
+**Calibration wizard**:
+The UI flow in `ui/sqm_calibration.py` that captures the dark sequence and sky frames, fits the three noise constants, writes the calibration JSON, and sends `["reload_sqm_calibration"]` on `align_command_queue` so the solver rebuilds its `SQMCalculator`.
+_Avoid_: setup wizard.
+
+### Distribution
+
+**`shared_state.set_sqm(SQMState)`**:
+The publication call. Read by `UISQM.update()` on the SQM screen. UI does not call `SQM.calculate()`.
+_Avoid_: publish SQM, push SQM.
+
+**`shared_state.set_sqm_details(dict)`**:
+Publishes the diagnostic dict (with per-star arrays stripped). Consumed by the UI for advanced views and by the calibration wizard.
+_Avoid_: set details.
+
+**`shared_state.set_noise_floor(float)`**:
+Publishes the latest noise floor. Read by the camera process and forwarded into `auto_exposure.SNR_target_offset(noise_floor=...)`.
+_Avoid_: set floor.
+
+### Timing
+
+**`SQM_CALCULATION_INTERVAL_SECONDS`**:
+Minimum wall-clock interval between SQM calculations in the solver loop. Default 5.0 s — the single knob bounding SQM cost.
+_Avoid_: SQM interval, cadence.
+
+**`reload_sqm_calibration`**:
+The literal command string posted on `align_command_queue` by the calibration wizard. Causes the solver to rebuild its `SQMCalculator` from the freshest calibration JSON.
+_Avoid_: refresh calibration, reload sqm.
+
+### Boundary terms
+
+- **`align_command_queue`** is owned by [Positioning](../positioning/CONTEXT.md); SQM uses it only to receive `reload_sqm_calibration`.
+- **Matched centroids / FOV** come from tetra3 via the solver (Positioning); SQM is a downstream consumer of every successful solve.
+- **`shared_state`** is part of the system-wide shared state — defined in Positioning.
+
+## Flagged ambiguities
+
+- **"Noise floor"** (bare) — the *published* ADU value (`shared_state.set_noise_floor()`). For the intermediates inside `NoiseFloorEstimator`, force a qualifier: **measured**, **smoothed**, **theoretical**, **conservative**. Bare "noise floor" never means an intermediate.
+- **"Dark frame" (astrophotography sense)** is NOT used here. In astrophotography, a "dark frame" is one lens-capped exposure (often combined into a master dark) — readers may import that mental model. PiFinder has two distinct concepts instead: **dark sequence** (multi-frame, multi-exposure, wizard-time, used to fit noise constants — never stacked into a master), and **zero-second sample** (single 0-s exposure, runtime, refreshes `bias_offset` / `read_noise_adu`). Don't say "dark frame".
+- **"SQM"** — without qualifier means the published `SQMState.value` (i.e. `sqm_final`, no extinction correction). The altitude-corrected number is `sqm_altitude_corrected` in details.
+- **"Pedestal"** vs **"bias offset"** — pedestal is the exposure-dependent total (`bias_offset + dark_current_contribution`); bias offset is the static zero-exposure component. **Bias offset ⊆ pedestal**. They are not synonyms.
+
+## Example dialogue
+
+> **Dev:** Why is SQM not updating right after a solve?
+>
+> **Domain:** Solver only enters the SQM block on solves that produced `matched_centroids`, and even then only once per `SQM_CALCULATION_INTERVAL_SECONDS` (5 s default). If `FOV` is missing or background is unphysical, `calculate()` returns `(None, {})` and the clock isn't advanced — next solve retries.
+>
+> **Dev:** What does the camera process care about?
+>
+> **Domain:** Just the noise floor. `set_noise_floor()` is the only line of communication. Auto-exposure uses it as the SNR floor — change SQM's interval gate and that auto-exposure signal changes cadence too.

--- a/python/PiFinder/types/positioning.py
+++ b/python/PiFinder/types/positioning.py
@@ -1,0 +1,638 @@
+"""
+Proposed dataclasses for the solving / integration flow.
+
+PROPOSAL ONLY — nothing in this module is referenced by existing code yet.
+The goal is to replace the loose dicts and tagged-list messages that
+travel between camera → solver → integrator → shared_state with named,
+type-checked structures.
+
+Dicts these types replace
+-------------------------
+
+1. The ``solved`` dict built by ``solver.get_initialized_solved_dict()``
+   and merged with tetra3's ``solution`` return value.
+   →  :class:`PointingEstimate`, which holds two
+      :class:`PointingPair`\\ s — the published current pair
+      (target-pixel + camera-center, possibly IMU-estimated) and the
+      last actual plate-solve pair (never IMU-touched) — plus
+      :class:`SolveDiagnostics` and :class:`AlignmentResult`.
+
+2. The ``last_image_metadata`` dict stamped by the camera process and
+   read by the solver via ``shared_state.last_image_metadata()``.
+   →  :class:`CameraFrameMetadata`
+
+3. The ``imu_data`` dict produced by ``imu_pi.py`` and read via
+   ``shared_state.imu()``.
+   →  :class:`ImuSample`
+
+4. The tagged-list messages on the alignment queues.
+   →  :class:`AlignOnRaDec`, :class:`AlignCancel`,
+      :class:`ReloadSqmCalibration`, :class:`AlignedResult`
+   →  Union aliases :data:`SolverCommand`, :data:`AlignResponse`
+
+Design notes
+------------
+
+* All equatorial RA/Dec/Roll triples are represented by a single
+  :class:`Pointing` dataclass. The same type is used for the
+  target-pixel pointing (which the IMU may update) and the
+  camera-center pointing (``camera_solve``, which the IMU never
+  touches); the distinction is made by the field name on
+  :class:`PointingEstimate`, not by a separate type.
+
+* Field names that already exist as keys in the legacy dicts are
+  preserved verbatim (including non-PEP-8 capitalisation like
+  ``Matches`` / ``RMSE`` / ``RA``) to minimise churn during
+  migration and to match the keys tetra3 returns in its
+  ``solution`` dict.
+
+* Angles remain in degrees here — the existing ``solved`` dict is in
+  degrees end-to-end, and changing that is a separate refactor. For
+  the radian-based, quaternion-aware form used by
+  :class:`ImuDeadReckoning`, see
+  :class:`PiFinder.types.coordinates.RaDecRoll`; bridge via
+  :meth:`Pointing.as_radecroll`.
+
+* All structures must remain picklable so they can ride on
+  ``multiprocessing.Queue`` and ``SharedStateObj`` proxies.
+  ``numpy.quaternion`` already pickles, dataclasses pickle by default,
+  and we avoid lambdas/closures in defaults.
+
+* ``to_legacy_dict()`` / ``from_legacy_dict()`` helpers are included
+  on :class:`PointingEstimate` so consumers and shared-state setters
+  can be migrated incrementally (write the dataclass, read either
+  form).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, Tuple, Union
+
+import quaternion
+
+from PiFinder.types.coordinates import RaDecRoll
+
+
+# =====================================================================
+# Enums
+# =====================================================================
+
+
+class SolveSource(str, Enum):
+    """Replaces the free-form ``solved["solve_source"]`` string.
+
+    Inherits from ``str`` so existing equality checks against literals
+    (``solved["solve_source"] == "CAM"``) keep working during migration.
+    """
+
+    CAMERA = "CAM"
+    CAMERA_FAILED = "CAM_FAILED"
+    IMU = "IMU"
+
+
+# =====================================================================
+# The core triple: one Pointing dataclass used everywhere
+# =====================================================================
+
+
+@dataclass
+class Pointing:
+    """A single equatorial pointing direction: RA, Dec, Roll in **degrees**.
+
+    Used everywhere RA/Dec/Roll appears in the solving/integration flow:
+
+    * :attr:`PointingEstimate.pointing` — the published pointing at
+      the target pixel (eyepiece direction; may be IMU-updated).
+    * :attr:`PointingEstimate.camera_solve` — the pointing at the
+      camera center from the most recent plate-solve (never
+      IMU-updated; anchor for dead-reckoning).
+
+    All three fields are required: a ``Pointing`` instance is always a
+    fully-defined direction. The "no pointing yet" state is expressed
+    by ``Optional[Pointing]`` on the containing record (see
+    :attr:`PointingEstimate.pointing`), not by nullable fields here.
+
+    For the radian-based, quaternion-aware form used by
+    :class:`ImuDeadReckoning`, bridge via :meth:`as_radecroll`.
+    """
+
+    RA: float
+    Dec: float
+    Roll: float
+
+    def as_radecroll(self) -> RaDecRoll:
+        """Return a :class:`RaDecRoll` (radians internally)."""
+        return RaDecRoll(self.RA, self.Dec, self.Roll, deg=True)
+
+    def to_dict(self) -> dict:
+        """Legacy dict shape: ``{"RA": ..., "Dec": ..., "Roll": ...}``."""
+        return {"RA": self.RA, "Dec": self.Dec, "Roll": self.Roll}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Pointing":
+        """Strict inverse of :meth:`to_dict`. Raises ``KeyError`` if any
+        of ``RA`` / ``Dec`` / ``Roll`` is missing. For the partially-
+        populated dicts seen during migration, gate the call at the
+        :class:`PointingEstimate` level instead."""
+        return cls(RA=d["RA"], Dec=d["Dec"], Roll=d["Roll"])
+
+
+# =====================================================================
+# Helpers
+# =====================================================================
+
+
+def _pointing_from_legacy(d: dict) -> Optional[Pointing]:
+    """Build a :class:`Pointing` from a legacy-shaped dict if all three
+    of RA/Dec/Roll are populated; otherwise ``None``. Used by the
+    :meth:`PointingEstimate.from_legacy_dict` migration shim where
+    partially-populated dicts are expected."""
+    ra, dec, roll = d.get("RA"), d.get("Dec"), d.get("Roll")
+    if ra is None or dec is None or roll is None:
+        return None
+    return Pointing(RA=ra, Dec=dec, Roll=roll)
+
+
+# =====================================================================
+# PointingPair — target pixel + camera center, produced together
+# =====================================================================
+
+
+@dataclass
+class PointingPair:
+    """A pair of equatorial pointings that are produced together by a
+    single procedure: the eyepiece direction (target pixel) and the
+    camera-axis direction (camera center).
+
+    * On a plate-solve, tetra3 reports the camera-center RA/Dec from
+      the matched stars and the target-pixel RA/Dec from the
+      configured ``target_pixel``; both are returned by the same call.
+    * On an IMU dead-reckoning update (planned), the same
+      ``ImuDeadReckoning`` instance projects both pointings forward
+      from the IMU quaternion; they advance in lock-step.
+
+    Both fields are required: a ``PointingPair`` instance is always
+    fully-defined. The "not produced yet" state is expressed by
+    ``Optional[PointingPair]`` on the containing record (see
+    :class:`PointingEstimate`).
+
+    When no alignment offset is calibrated, ``target_pixel`` and
+    ``camera_center`` may be identical; once :data:`solve_pixel`
+    diverges from the image center, they differ.
+    """
+
+    target_pixel: Pointing
+    camera_center: Pointing
+
+
+# =====================================================================
+# Other nested records inside PointingEstimate
+# =====================================================================
+
+
+@dataclass
+class SolveDiagnostics:
+    """Plate-solver diagnostics carried alongside the pointing.
+    Forwarded from tetra3's ``solution`` dict.
+
+    Replaces the loose ``Matches`` / ``RMSE`` / ``T_solve`` / ``FOV`` /
+    ``Prob`` / ``T_extract`` keys that today get merged onto ``solved``
+    via ``solved |= solution``.
+
+    ``Matches`` defaults to 0 (not ``None``) because auto-exposure reads
+    it on every solve, including failures, and expects an int.
+    """
+
+    Matches: int = 0
+    RMSE: Optional[float] = None
+    Prob: Optional[float] = None
+    FOV: Optional[float] = None
+    T_solve: Optional[float] = None
+    T_extract: Optional[float] = None
+
+
+@dataclass
+class AlignmentResult:
+    """Pixel where the alignment target landed in the camera frame.
+
+    Replaces ``solved["x_target"]`` / ``solved["y_target"]``, which
+    today are populated when ``target_sky_coord`` was passed to tetra3
+    and then cleared after the solver posts ``["aligned", (y, x)]``.
+    """
+
+    x_target: Optional[float] = None
+    y_target: Optional[float] = None
+
+    def is_set(self) -> bool:
+        return self.x_target is not None and self.y_target is not None
+
+    def as_pixel_yx(self) -> Optional[Tuple[float, float]]:
+        """Return ``(y, x)`` in camera image space, matching the existing
+        ``align_result_queue`` message convention."""
+        if not self.is_set():
+            return None
+        return (self.y_target, self.x_target)
+
+
+# =====================================================================
+# The big one: replaces the `solved` dict
+# =====================================================================
+
+
+@dataclass
+class PointingEstimate:
+    """Canonical 'where are we pointing?' record.
+
+    Replaces the dict returned by
+    ``solver.get_initialized_solved_dict()`` and travels through
+    ``solver_queue`` and ``shared_state.set_solution()``.
+
+    Naming follows the existing TODO at the top of ``integrator.py``
+    (``solved -> pointing_estimate``).
+
+    Pointing semantics
+    ------------------
+    Four pointings are tracked, organised as two
+    :class:`PointingPair`\\ s:
+
+    * :attr:`pointing` — the **published, current** pair. Both
+      ``target_pixel`` and ``camera_center`` are produced fresh on a
+      plate-solve and then advanced together by IMU dead-reckoning
+      between solves. This is the pair downstream consumers (UI,
+      web, SkySafari) should read.
+    * :attr:`last_solve` — the **last actual plate-solve** pair.
+      Never touched by the IMU. Its ``camera_center`` is the anchor
+      passed to :meth:`ImuDeadReckoning.solve`; its ``target_pixel``
+      is the truth-value reference for diagnostics, drift checks,
+      and recovery paths.
+
+    On a successful plate-solve both fields are set to the same
+    :class:`PointingPair`. On an IMU dead-reckoning update only
+    :attr:`pointing` advances; :attr:`last_solve` stays anchored at
+    the most recent camera-derived truth.
+
+    :attr:`Alt` / :attr:`Az` are topocentric, derived in the
+    integrator from ``pointing.target_pixel`` + GPS + datetime.
+
+    Timing fields use ``time.time()`` for ``solve_time`` and
+    ``cam_solve_time``, but ``last_solve_attempt`` and
+    ``last_solve_success`` use the camera frame's ``exposure_end``
+    (not wall clock) so the solver can dedupe stale frames precisely.
+    """
+
+    # --- Published pair (target pixel + camera center; may be IMU-estimated) ---
+    # ``None`` until the first successful solve. Once set, both
+    # pointings inside the pair are fully populated.
+    pointing: Optional[PointingPair] = None
+
+    # --- Last actual plate-solve (never IMU-touched) ---
+    # Anchor for IMU dead-reckoning. Survives failed solves so the
+    # IMU still has a reference point.
+    last_solve: Optional[PointingPair] = None
+
+    # --- IMU reference at the time of the last plate-solved frame ---
+    # Paired with :attr:`last_solve`: this is the IMU quaternion that
+    # was stamped on the frame that produced that plate-solve, and
+    # together they form the anchor for IMU dead-reckoning.
+    last_solve_imu: Optional[quaternion.quaternion] = None
+
+    # --- Derived horizontal coords ---
+    Alt: Optional[float] = None
+    Az: Optional[float] = None
+
+    # --- Source and timing ---
+    solve_source: Optional[SolveSource] = None
+    solve_time: Optional[float] = None
+    cam_solve_time: float = 0.0
+    last_solve_attempt: float = 0.0
+    last_solve_success: Optional[float] = None
+
+    # --- Annotation ---
+    constellation: Optional[str] = None
+
+    # --- Sub-records ---
+    diagnostics: SolveDiagnostics = field(default_factory=SolveDiagnostics)
+    alignment: AlignmentResult = field(default_factory=AlignmentResult)
+
+    # ----------------------------------------------------------------
+    # Convenience predicates
+    # ----------------------------------------------------------------
+
+    def has_pointing(self) -> bool:
+        """True if a published pointing exists (regardless of source)."""
+        return self.pointing is not None
+
+    def is_camera_solve(self) -> bool:
+        return self.solve_source == SolveSource.CAMERA
+
+    def is_imu_solve(self) -> bool:
+        return self.solve_source == SolveSource.IMU
+
+    # ----------------------------------------------------------------
+    # Compatibility shim — emit the legacy dict shape so existing
+    # consumers (web/UI/SkySafari) can be migrated incrementally.
+    # ----------------------------------------------------------------
+
+    def to_legacy_dict(self) -> dict:
+        """Render this estimate in the legacy ``solved`` dict shape so
+        consumers that still expect a dict keep working during the
+        rollout."""
+        empty_pointing = {"RA": None, "Dec": None, "Roll": None}
+        # Legacy mapping:
+        #   solved["RA"/"Dec"/"Roll"]   ← pointing.target_pixel (current)
+        #   solved["camera_solve"]      ← last_solve.camera_center
+        #                                 (the never-IMU-touched anchor)
+        target = self.pointing.target_pixel if self.pointing else None
+        anchor = self.last_solve.camera_center if self.last_solve else None
+        d: dict = {
+            "RA": target.RA if target else None,
+            "Dec": target.Dec if target else None,
+            "Roll": target.Roll if target else None,
+            "camera_solve": anchor.to_dict() if anchor else dict(empty_pointing),
+            "imu_quat": self.last_solve_imu,
+            "Alt": self.Alt,
+            "Az": self.Az,
+            "solve_source": (self.solve_source.value if self.solve_source else None),
+            "solve_time": self.solve_time,
+            "cam_solve_time": self.cam_solve_time,
+            "last_solve_attempt": self.last_solve_attempt,
+            "last_solve_success": self.last_solve_success,
+            "constellation": self.constellation,
+            "Matches": self.diagnostics.Matches,
+        }
+        # Optional diagnostic fields are only included when set, to
+        # match how tetra3 merges its solution into `solved`.
+        for k in ("RMSE", "Prob", "FOV", "T_solve", "T_extract"):
+            v = getattr(self.diagnostics, k)
+            if v is not None:
+                d[k] = v
+        if self.alignment.x_target is not None:
+            d["x_target"] = self.alignment.x_target
+            d["y_target"] = self.alignment.y_target
+        return d
+
+    @classmethod
+    def from_legacy_dict(cls, d: dict) -> "PointingEstimate":
+        """Inverse of :meth:`to_legacy_dict`. Tolerant of missing keys
+        so it can absorb partially-built dicts during migration.
+
+        Note this conversion is lossy: the legacy dict carries the
+        current target-pixel direction and the last-solve camera-center
+        direction, but not the current camera-center direction or the
+        last-solve target-pixel direction. On migration we reconstruct
+        a :class:`PointingPair` for :attr:`pointing` by reusing the
+        legacy camera_solve as the camera_center side, and use the
+        same pair for :attr:`last_solve`. New producers will populate
+        both pairs natively."""
+        source_str = d.get("solve_source")
+        target = _pointing_from_legacy(d)
+        anchor = _pointing_from_legacy(d.get("camera_solve") or {})
+        pair: Optional[PointingPair] = None
+        if target is not None and anchor is not None:
+            pair = PointingPair(target_pixel=target, camera_center=anchor)
+        return cls(
+            pointing=pair,
+            last_solve=pair,
+            last_solve_imu=d.get("imu_quat"),
+            Alt=d.get("Alt"),
+            Az=d.get("Az"),
+            solve_source=SolveSource(source_str) if source_str else None,
+            solve_time=d.get("solve_time"),
+            cam_solve_time=d.get("cam_solve_time", 0.0),
+            last_solve_attempt=d.get("last_solve_attempt", 0.0),
+            last_solve_success=d.get("last_solve_success"),
+            constellation=d.get("constellation"),
+            diagnostics=SolveDiagnostics(
+                Matches=d.get("Matches", 0),
+                RMSE=d.get("RMSE"),
+                Prob=d.get("Prob"),
+                FOV=d.get("FOV"),
+                T_solve=d.get("T_solve"),
+                T_extract=d.get("T_extract"),
+            ),
+            alignment=AlignmentResult(
+                x_target=d.get("x_target"),
+                y_target=d.get("y_target"),
+            ),
+        )
+
+
+# =====================================================================
+# IMU sample — replaces shared_state.imu() dict
+# =====================================================================
+
+
+@dataclass
+class ImuSample:
+    """Single IMU orientation reading.
+
+    Replaces the ``imu_data`` dict in ``imu_pi.py`` (keys: ``moving``,
+    ``move_start``, ``move_end``, ``quat``, ``status``). The
+    ``move_start`` / ``move_end`` fields are flagged ``# TODO: Remove``
+    in the source — leaving them here for now so this is a strict
+    superset of today's shape; they can be dropped in a follow-up.
+
+    ``quat`` is scalar-first ``(w, x, y, z)``, as produced by
+    ``quaternion.from_float_array(imu.avg_quat)``.
+    """
+
+    quat: quaternion.quaternion
+    status: int = 0  # 3 == fully calibrated (BNO055)
+    moving: bool = False
+    move_start: Optional[float] = None  # TODO: remove (unused)
+    move_end: Optional[float] = None  # TODO: remove (unused)
+
+    def is_calibrated(self) -> bool:
+        return self.status == 3
+
+
+# =====================================================================
+# Camera frame metadata — replaces shared_state.last_image_metadata()
+# =====================================================================
+
+
+@dataclass
+class CameraFrameMetadata:
+    """Metadata stamped by the camera process when an exposure finishes.
+
+    Replaces the ``image_metadata`` dict built in
+    ``camera_interface.py`` and read by the solver via
+    ``shared_state.last_image_metadata()``.
+
+    ``exposure_time`` is in **microseconds** (matching the existing
+    convention); convert with ``exposure_time / 1_000_000`` for
+    seconds (the solver already does this for SQM).
+
+    ``imu_delta`` is the angular delta between IMU quaternions sampled
+    at the start and end of the exposure, in **degrees**. The solver's
+    fast-path uses this to reject blurry frames captured while moving.
+    """
+
+    exposure_start: float
+    exposure_end: float
+    exposure_time: int  # microseconds
+    gain: float = 1.0
+    imu: Optional[ImuSample] = None
+    imu_delta: float = 0.0  # degrees
+
+
+# =====================================================================
+# Queue messages
+# =====================================================================
+#
+# Today these are tagged lists like ["align_on_radec", ra, dec] /
+# ["aligned", (y, x)]. Receivers dispatch on the leading string.
+# Dataclasses + isinstance() dispatch give the same ergonomics with
+# proper field names and type checking.
+
+
+@dataclass
+class AlignOnRaDec:
+    """Arm the solver: next solve should pass ``target_sky_coord``
+    to tetra3 and return the pixel coordinate for (ra, dec).
+    Degrees.
+
+    Distinct from :class:`Pointing` because alignment supplies only
+    RA/Dec — no Roll — and the semantics are "target sought," not
+    "where we are pointing."
+    """
+
+    ra: float
+    dec: float
+
+
+@dataclass
+class AlignCancel:
+    """Clear any pending alignment target in the solver."""
+
+    pass
+
+
+@dataclass
+class ReloadSqmCalibration:
+    """Tell the solver to rebuild its :class:`SQMCalculator` (the
+    camera calibration profile may have changed)."""
+
+    pass
+
+
+SolverCommand = Union[AlignOnRaDec, AlignCancel, ReloadSqmCalibration]
+"""Anything that can travel on ``align_command_queue`` (note the queue
+also carries non-alignment commands today, hence the broader name)."""
+
+
+@dataclass
+class AlignedResult:
+    """Reply on ``align_result_queue`` carrying the pixel where the
+    alignment target landed.
+
+    Field order matches the existing ``(y, x)`` tuple convention used
+    by ``ui/align.py`` and stored as ``solve_pixel``.
+    """
+
+    y_target: float
+    x_target: float
+
+    def as_solve_pixel(self) -> Tuple[float, float]:
+        """Return ``(y, x)`` — the order used by ``solve_pixel`` in
+        ``shared_state`` and persisted in ``Config``."""
+        return (self.y_target, self.x_target)
+
+
+# A failure / cancellation response would extend this union in future.
+AlignResponse = Union[AlignedResult]
+
+
+# =====================================================================
+# Convenience: the tetra3 raw return is also a dict, but it isn't our
+# code to retype. We document the merge boundary here so consumers can
+# see what flows in.
+# =====================================================================
+
+
+def merge_tetra3_solution(
+    estimate: PointingEstimate,
+    solution: dict,
+    imu_sample: Optional[ImuSample],
+) -> PointingEstimate:
+    """Reference implementation of how a tetra3 ``solution`` dict
+    should be folded into a :class:`PointingEstimate`. This mirrors
+    the existing ``solved |= solution`` step in ``solver.py``, plus
+    the camera-vs-target-pixel swap.
+
+    Not wired up — illustrative only. Lives here so the proposed
+    dataclasses have a clear seam against the upstream library that
+    still returns dicts.
+    """
+    estimate.diagnostics = SolveDiagnostics(
+        Matches=solution.get("Matches", 0),
+        RMSE=solution.get("RMSE"),
+        Prob=solution.get("Prob"),
+        FOV=solution.get("FOV"),
+        T_solve=solution.get("T_solve"),
+        T_extract=solution.get("T_extract"),
+    )
+
+    if solution.get("RA") is None:
+        # Failed solve — clear the current pointing, but preserve
+        # last_solve as the IMU anchor / recovery reference.
+        estimate.pointing = None
+        return estimate
+
+    # On a successful tetra3 solve, RA / Dec / Roll are all populated.
+    # Use direct indexing so a missing field surfaces loudly rather
+    # than silently producing a half-defined pointing.
+    camera_center = Pointing(
+        RA=solution["RA"],
+        Dec=solution["Dec"],
+        Roll=solution["Roll"],
+    )
+    target_pixel = Pointing(
+        RA=solution.get("RA_target", solution["RA"]),
+        Dec=solution.get("Dec_target", solution["Dec"]),
+        Roll=solution["Roll"],
+    )
+    pair = PointingPair(target_pixel=target_pixel, camera_center=camera_center)
+
+    # Fresh plate-solve: both fields point at the same pair.
+    # Subsequent IMU updates will advance ``pointing`` while leaving
+    # ``last_solve`` anchored at this snapshot.
+    estimate.pointing = pair
+    estimate.last_solve = pair
+
+    # Alignment pixel (only present when target_sky_coord was set)
+    estimate.alignment = AlignmentResult(
+        x_target=solution.get("x_target"),
+        y_target=solution.get("y_target"),
+    )
+
+    # IMU anchor for the dead-reckoner
+    if imu_sample is not None:
+        estimate.last_solve_imu = imu_sample.quat
+
+    return estimate
+
+
+# =====================================================================
+# Exports
+# =====================================================================
+
+__all__ = [
+    "AlignCancel",
+    "AlignOnRaDec",
+    "AlignResponse",
+    "AlignedResult",
+    "AlignmentResult",
+    "CameraFrameMetadata",
+    "ImuSample",
+    "Pointing",
+    "PointingEstimate",
+    "PointingPair",
+    "ReloadSqmCalibration",
+    "SolveDiagnostics",
+    "SolveSource",
+    "SolverCommand",
+    "merge_tetra3_solution",
+]

--- a/python/PiFinder/types/positioning.py
+++ b/python/PiFinder/types/positioning.py
@@ -6,16 +6,31 @@ The goal is to replace the loose dicts and tagged-list messages that
 travel between camera → solver → integrator → shared_state with named,
 type-checked structures.
 
+Vocabulary
+----------
+
+These types implement the canonical Positioning vocabulary
+(see ``docs/ax/positioning/CONTEXT.md`` and
+``docs/adr/0001-positioning-vocabulary.md``).
+
+* Two **axes**: ``camera`` (optical axis) and ``aligned`` (eyepiece
+  direction, calibrated via the **target pixel**).
+* Two **states** per axis: ``solve`` (latest plate-solve value;
+  never IMU-touched) and ``estimate`` (current value, equal to ``solve``
+  immediately after a plate-solve and advanced by IMU dead-reckoning
+  between solves).
+* Canonical access shape: ``pointing.<axis>.<state>.<RA|Dec|Roll>`` —
+  e.g. ``pointing.aligned.estimate.RA``.
+* Bare "pointing" in prose means ``pointing.aligned.estimate``.
+
 Dicts these types replace
 -------------------------
 
 1. The ``solved`` dict built by ``solver.get_initialized_solved_dict()``
    and merged with tetra3's ``solution`` return value.
-   →  :class:`PointingEstimate`, which holds two
-      :class:`PointingPair`\\ s — the published current pair
-      (target-pixel + camera-center, possibly IMU-estimated) and the
-      last actual plate-solve pair (never IMU-touched) — plus
-      :class:`SolveDiagnostics` and :class:`AlignmentResult`.
+   →  :class:`PointingEstimate`, whose :attr:`pointing` field holds a
+      :class:`PointingMatrix` with the four cells of the 2 × 2 matrix,
+      plus :class:`SolveDiagnostics` and :class:`AlignmentResult`.
 
 2. The ``last_image_metadata`` dict stamped by the camera process and
    read by the solver via ``shared_state.last_image_metadata()``.
@@ -34,17 +49,14 @@ Design notes
 ------------
 
 * All equatorial RA/Dec/Roll triples are represented by a single
-  :class:`Pointing` dataclass. The same type is used for the
-  target-pixel pointing (which the IMU may update) and the
-  camera-center pointing (``camera_solve``, which the IMU never
-  touches); the distinction is made by the field name on
-  :class:`PointingEstimate`, not by a separate type.
+  :class:`Pointing` dataclass. The same type is used for every cell of
+  the 2 × 2 matrix; the cell is identified by its position
+  (``pointing.<axis>.<state>``), not by a separate type.
 
 * Field names that already exist as keys in the legacy dicts are
   preserved verbatim (including non-PEP-8 capitalisation like
-  ``Matches`` / ``RMSE`` / ``RA``) to minimise churn during
-  migration and to match the keys tetra3 returns in its
-  ``solution`` dict.
+  ``Matches`` / ``RMSE`` / ``RA``) to minimise churn during migration
+  and to match the keys tetra3 returns in its ``solution`` dict.
 
 * Angles remain in degrees here — the existing ``solved`` dict is in
   degrees end-to-end, and changing that is a separate refactor. For
@@ -93,7 +105,7 @@ class SolveSource(str, Enum):
 
 
 # =====================================================================
-# The core triple: one Pointing dataclass used everywhere
+# The leaf triple: one Pointing dataclass per cell of the matrix
 # =====================================================================
 
 
@@ -101,18 +113,21 @@ class SolveSource(str, Enum):
 class Pointing:
     """A single equatorial pointing direction: RA, Dec, Roll in **degrees**.
 
-    Used everywhere RA/Dec/Roll appears in the solving/integration flow:
+    Used at every leaf of the pointing matrix:
 
-    * :attr:`PointingEstimate.pointing` — the published pointing at
-      the target pixel (eyepiece direction; may be IMU-updated).
-    * :attr:`PointingEstimate.camera_solve` — the pointing at the
-      camera center from the most recent plate-solve (never
-      IMU-updated; anchor for dead-reckoning).
+    * ``pointing.camera.solve`` — camera-axis RA/Dec/Roll from the
+      latest plate-solve.
+    * ``pointing.camera.estimate`` — current camera-axis value
+      (may be IMU-progressed).
+    * ``pointing.aligned.solve`` — aligned-axis (eyepiece) RA/Dec/Roll
+      from the latest plate-solve.
+    * ``pointing.aligned.estimate`` — current aligned-axis value;
+      this is what bare "pointing" means in prose, and what every
+      downstream consumer ultimately reads.
 
     All three fields are required: a ``Pointing`` instance is always a
-    fully-defined direction. The "no pointing yet" state is expressed
-    by ``Optional[Pointing]`` on the containing record (see
-    :attr:`PointingEstimate.pointing`), not by nullable fields here.
+    fully-defined direction. The "no value yet" state is expressed by
+    ``Optional[Pointing]`` on the containing :class:`PointingAxis`.
 
     For the radian-based, quaternion-aware form used by
     :class:`ImuDeadReckoning`, bridge via :meth:`as_radecroll`.
@@ -156,35 +171,58 @@ def _pointing_from_legacy(d: dict) -> Optional[Pointing]:
 
 
 # =====================================================================
-# PointingPair — target pixel + camera center, produced together
+# PointingAxis — one axis, both states
 # =====================================================================
 
 
 @dataclass
-class PointingPair:
-    """A pair of equatorial pointings that are produced together by a
-    single procedure: the eyepiece direction (target pixel) and the
-    camera-axis direction (camera center).
+class PointingAxis:
+    """One axis of pointing, tracked across both states.
 
-    * On a plate-solve, tetra3 reports the camera-center RA/Dec from
-      the matched stars and the target-pixel RA/Dec from the
-      configured ``target_pixel``; both are returned by the same call.
-    * On an IMU dead-reckoning update (planned), the same
-      ``ImuDeadReckoning`` instance projects both pointings forward
-      from the IMU quaternion; they advance in lock-step.
+    Holds the two values for a single axis (``camera`` or ``aligned``):
 
-    Both fields are required: a ``PointingPair`` instance is always
-    fully-defined. The "not produced yet" state is expressed by
-    ``Optional[PointingPair]`` on the containing record (see
-    :class:`PointingEstimate`).
+    * :attr:`solve` — RA/Dec/Roll from the latest plate-solve.
+      ``None`` until the first successful solve. Never IMU-touched
+      once set.
+    * :attr:`estimate` — the current value. Equal to ``solve``
+      immediately after a plate-solve; may be IMU-progressed between
+      solves. This is what downstream consumers should read.
 
-    When no alignment offset is calibrated, ``target_pixel`` and
-    ``camera_center`` may be identical; once :data:`solve_pixel`
-    diverges from the image center, they differ.
+    Both fields are ``Optional[Pointing]`` because a fresh
+    :class:`PointingEstimate` may exist before any solve has happened.
     """
 
-    target_pixel: Pointing
-    camera_center: Pointing
+    solve: Optional[Pointing] = None
+    estimate: Optional[Pointing] = None
+
+
+# =====================================================================
+# PointingMatrix — both axes, both states (the 2 × 2 matrix)
+# =====================================================================
+
+
+@dataclass
+class PointingMatrix:
+    """The 2 × 2 matrix of pointings.
+
+    Two axes (``camera`` for the optical-axis direction, ``aligned``
+    for the eyepiece-aligned direction), each as a :class:`PointingAxis`
+    holding ``solve`` and ``estimate`` values. Canonical access shape
+    is ``<matrix>.<axis>.<state>.<RA|Dec|Roll>``.
+
+    On a successful plate-solve, both axes' ``solve`` and ``estimate``
+    are populated together: ``camera.{solve,estimate}`` from tetra3's
+    matched-stars solution, and ``aligned.{solve,estimate}`` from the
+    target-pixel solution. Between solves, the IMU advances only the
+    ``estimate`` cells; the ``solve`` cells stay anchored at the last
+    plate-solve.
+
+    When no alignment offset is calibrated (target pixel at image
+    center), :attr:`aligned` may equal :attr:`camera`.
+    """
+
+    camera: PointingAxis = field(default_factory=PointingAxis)
+    aligned: PointingAxis = field(default_factory=PointingAxis)
 
 
 # =====================================================================
@@ -217,9 +255,15 @@ class SolveDiagnostics:
 class AlignmentResult:
     """Pixel where the alignment target landed in the camera frame.
 
+    In the canonical vocabulary this **is** the target pixel — the
+    ``(Y, X)`` image-space coordinate produced by the alignment system.
     Replaces ``solved["x_target"]`` / ``solved["y_target"]``, which
     today are populated when ``target_sky_coord`` was passed to tetra3
     and then cleared after the solver posts ``["aligned", (y, x)]``.
+
+    Field names ``x_target`` / ``y_target`` are kept to match the
+    tetra3 ``solution`` dict keys; use :meth:`target_pixel` to retrieve
+    the canonical ``(Y, X)`` tuple.
     """
 
     x_target: Optional[float] = None
@@ -228,10 +272,11 @@ class AlignmentResult:
     def is_set(self) -> bool:
         return self.x_target is not None and self.y_target is not None
 
-    def as_pixel_yx(self) -> Optional[Tuple[float, float]]:
-        """Return ``(y, x)`` in camera image space, matching the existing
-        ``align_result_queue`` message convention."""
-        if not self.is_set():
+    def target_pixel(self) -> Optional[Tuple[float, float]]:
+        """Return the target pixel as ``(Y, X)`` in camera image space,
+        matching the convention used by alignment queue messages and
+        the persisted target-pixel config value."""
+        if self.x_target is None or self.y_target is None:
             return None
         return (self.y_target, self.x_target)
 
@@ -254,27 +299,19 @@ class PointingEstimate:
 
     Pointing semantics
     ------------------
-    Four pointings are tracked, organised as two
-    :class:`PointingPair`\\ s:
+    The pointing matrix is :attr:`pointing`, a :class:`PointingMatrix`
+    holding the four cells of the 2 × 2 matrix
+    (``camera``/``aligned`` × ``solve``/``estimate``). Canonical access
+    is ``estimate.pointing.<axis>.<state>.<RA|Dec|Roll>``; downstream
+    consumers (UI, web, SkySafari) read ``pointing.aligned.estimate``.
 
-    * :attr:`pointing` — the **published, current** pair. Both
-      ``target_pixel`` and ``camera_center`` are produced fresh on a
-      plate-solve and then advanced together by IMU dead-reckoning
-      between solves. This is the pair downstream consumers (UI,
-      web, SkySafari) should read.
-    * :attr:`last_solve` — the **last actual plate-solve** pair.
-      Never touched by the IMU. Its ``camera_center`` is the anchor
-      passed to :meth:`ImuDeadReckoning.solve`; its ``target_pixel``
-      is the truth-value reference for diagnostics, drift checks,
-      and recovery paths.
+    The IMU anchor used for dead-reckoning is the pair of
+    ``pointing.camera.solve`` (camera-axis truth) and :attr:`imu_anchor`
+    (the IMU quaternion sampled at the same frame). Together these are
+    the input to :meth:`ImuDeadReckoning.solve`.
 
-    On a successful plate-solve both fields are set to the same
-    :class:`PointingPair`. On an IMU dead-reckoning update only
-    :attr:`pointing` advances; :attr:`last_solve` stays anchored at
-    the most recent camera-derived truth.
-
-    :attr:`Alt` / :attr:`Az` are topocentric, derived in the
-    integrator from ``pointing.target_pixel`` + GPS + datetime.
+    :attr:`Alt` / :attr:`Az` are topocentric, derived in the integrator
+    from ``pointing.aligned.estimate`` + GPS + datetime.
 
     Timing fields use ``time.time()`` for ``solve_time`` and
     ``cam_solve_time``, but ``last_solve_attempt`` and
@@ -282,21 +319,17 @@ class PointingEstimate:
     (not wall clock) so the solver can dedupe stale frames precisely.
     """
 
-    # --- Published pair (target pixel + camera center; may be IMU-estimated) ---
-    # ``None`` until the first successful solve. Once set, both
-    # pointings inside the pair are fully populated.
-    pointing: Optional[PointingPair] = None
+    # --- The 2 × 2 pointing matrix ---
+    # Fresh default has all four cells = None. Populated by the solver
+    # on a successful plate-solve; advanced on the estimate side by the
+    # integrator's IMU dead-reckoning.
+    pointing: PointingMatrix = field(default_factory=PointingMatrix)
 
-    # --- Last actual plate-solve (never IMU-touched) ---
-    # Anchor for IMU dead-reckoning. Survives failed solves so the
-    # IMU still has a reference point.
-    last_solve: Optional[PointingPair] = None
-
-    # --- IMU reference at the time of the last plate-solved frame ---
-    # Paired with :attr:`last_solve`: this is the IMU quaternion that
-    # was stamped on the frame that produced that plate-solve, and
-    # together they form the anchor for IMU dead-reckoning.
-    last_solve_imu: Optional[quaternion.quaternion] = None
+    # --- IMU anchor ---
+    # The IMU quaternion sampled on the frame that produced the current
+    # ``pointing.<axis>.solve`` cells. Paired with
+    # ``pointing.camera.solve`` to seed IMU dead-reckoning.
+    imu_anchor: Optional[quaternion.quaternion] = None
 
     # --- Derived horizontal coords ---
     Alt: Optional[float] = None
@@ -321,8 +354,9 @@ class PointingEstimate:
     # ----------------------------------------------------------------
 
     def has_pointing(self) -> bool:
-        """True if a published pointing exists (regardless of source)."""
-        return self.pointing is not None
+        """True if a published pointing exists — i.e.
+        ``pointing.aligned.estimate`` is populated."""
+        return self.pointing.aligned.estimate is not None
 
     def is_camera_solve(self) -> bool:
         return self.solve_source == SolveSource.CAMERA
@@ -338,20 +372,23 @@ class PointingEstimate:
     def to_legacy_dict(self) -> dict:
         """Render this estimate in the legacy ``solved`` dict shape so
         consumers that still expect a dict keep working during the
-        rollout."""
+        rollout.
+
+        Legacy mapping:
+          solved["RA"/"Dec"/"Roll"]   ← pointing.aligned.estimate
+                                        (the published current pointing)
+          solved["camera_solve"]      ← pointing.camera.solve
+                                        (the never-IMU-touched anchor)
+        """
         empty_pointing = {"RA": None, "Dec": None, "Roll": None}
-        # Legacy mapping:
-        #   solved["RA"/"Dec"/"Roll"]   ← pointing.target_pixel (current)
-        #   solved["camera_solve"]      ← last_solve.camera_center
-        #                                 (the never-IMU-touched anchor)
-        target = self.pointing.target_pixel if self.pointing else None
-        anchor = self.last_solve.camera_center if self.last_solve else None
+        target = self.pointing.aligned.estimate
+        anchor = self.pointing.camera.solve
         d: dict = {
             "RA": target.RA if target else None,
             "Dec": target.Dec if target else None,
             "Roll": target.Roll if target else None,
             "camera_solve": anchor.to_dict() if anchor else dict(empty_pointing),
-            "imu_quat": self.last_solve_imu,
+            "imu_quat": self.imu_anchor,
             "Alt": self.Alt,
             "Az": self.Az,
             "solve_source": (self.solve_source.value if self.solve_source else None),
@@ -378,24 +415,24 @@ class PointingEstimate:
         """Inverse of :meth:`to_legacy_dict`. Tolerant of missing keys
         so it can absorb partially-built dicts during migration.
 
-        Note this conversion is lossy: the legacy dict carries the
-        current target-pixel direction and the last-solve camera-center
-        direction, but not the current camera-center direction or the
-        last-solve target-pixel direction. On migration we reconstruct
-        a :class:`PointingPair` for :attr:`pointing` by reusing the
-        legacy camera_solve as the camera_center side, and use the
-        same pair for :attr:`last_solve`. New producers will populate
-        both pairs natively."""
+        Note this conversion is lossy: the legacy dict carries only the
+        published aligned-axis direction and the camera-axis solve
+        anchor. The aligned-axis ``solve`` and the camera-axis
+        ``estimate`` cells are reconstructed by sharing values
+        (aligned.solve = aligned.estimate; camera.estimate =
+        camera.solve), which is correct at solve time but loses any
+        IMU drift the camera axis might independently track. New
+        producers populate all four cells natively.
+        """
         source_str = d.get("solve_source")
-        target = _pointing_from_legacy(d)
-        anchor = _pointing_from_legacy(d.get("camera_solve") or {})
-        pair: Optional[PointingPair] = None
-        if target is not None and anchor is not None:
-            pair = PointingPair(target_pixel=target, camera_center=anchor)
+        aligned_value = _pointing_from_legacy(d)
+        camera_value = _pointing_from_legacy(d.get("camera_solve") or {})
         return cls(
-            pointing=pair,
-            last_solve=pair,
-            last_solve_imu=d.get("imu_quat"),
+            pointing=PointingMatrix(
+                camera=PointingAxis(solve=camera_value, estimate=camera_value),
+                aligned=PointingAxis(solve=aligned_value, estimate=aligned_value),
+            ),
+            imu_anchor=d.get("imu_quat"),
             Alt=d.get("Alt"),
             Az=d.get("Az"),
             solve_source=SolveSource(source_str) if source_str else None,
@@ -529,15 +566,15 @@ class AlignedResult:
     alignment target landed.
 
     Field order matches the existing ``(y, x)`` tuple convention used
-    by ``ui/align.py`` and stored as ``solve_pixel``.
+    by ``ui/align.py`` and persisted as the target pixel.
     """
 
     y_target: float
     x_target: float
 
-    def as_solve_pixel(self) -> Tuple[float, float]:
-        """Return ``(y, x)`` — the order used by ``solve_pixel`` in
-        ``shared_state`` and persisted in ``Config``."""
+    def as_target_pixel(self) -> Tuple[float, float]:
+        """Return ``(y, x)`` — the order used by the target pixel
+        on ``shared_state`` and persisted in ``Config``."""
         return (self.y_target, self.x_target)
 
 
@@ -560,7 +597,7 @@ def merge_tetra3_solution(
     """Reference implementation of how a tetra3 ``solution`` dict
     should be folded into a :class:`PointingEstimate`. This mirrors
     the existing ``solved |= solution`` step in ``solver.py``, plus
-    the camera-vs-target-pixel swap.
+    the camera-vs-aligned-axis swap.
 
     Not wired up — illustrative only. Lives here so the proposed
     dataclasses have a clear seam against the upstream library that
@@ -576,31 +613,34 @@ def merge_tetra3_solution(
     )
 
     if solution.get("RA") is None:
-        # Failed solve — clear the current pointing, but preserve
-        # last_solve as the IMU anchor / recovery reference.
-        estimate.pointing = None
+        # Failed solve — clear the current estimate cells, but preserve
+        # the solve cells and ``imu_anchor`` so the integrator still has
+        # an anchor for IMU dead-reckoning.
+        estimate.pointing.camera.estimate = None
+        estimate.pointing.aligned.estimate = None
         return estimate
 
     # On a successful tetra3 solve, RA / Dec / Roll are all populated.
     # Use direct indexing so a missing field surfaces loudly rather
     # than silently producing a half-defined pointing.
-    camera_center = Pointing(
+    camera_value = Pointing(
         RA=solution["RA"],
         Dec=solution["Dec"],
         Roll=solution["Roll"],
     )
-    target_pixel = Pointing(
+    aligned_value = Pointing(
         RA=solution.get("RA_target", solution["RA"]),
         Dec=solution.get("Dec_target", solution["Dec"]),
         Roll=solution["Roll"],
     )
-    pair = PointingPair(target_pixel=target_pixel, camera_center=camera_center)
 
-    # Fresh plate-solve: both fields point at the same pair.
-    # Subsequent IMU updates will advance ``pointing`` while leaving
-    # ``last_solve`` anchored at this snapshot.
-    estimate.pointing = pair
-    estimate.last_solve = pair
+    # Fresh plate-solve: both states equal each cell's value. The IMU
+    # will then advance only the ``estimate`` cells from here on, while
+    # the ``solve`` cells stay anchored at this snapshot.
+    estimate.pointing.camera.solve = camera_value
+    estimate.pointing.camera.estimate = camera_value
+    estimate.pointing.aligned.solve = aligned_value
+    estimate.pointing.aligned.estimate = aligned_value
 
     # Alignment pixel (only present when target_sky_coord was set)
     estimate.alignment = AlignmentResult(
@@ -610,7 +650,7 @@ def merge_tetra3_solution(
 
     # IMU anchor for the dead-reckoner
     if imu_sample is not None:
-        estimate.last_solve_imu = imu_sample.quat
+        estimate.imu_anchor = imu_sample.quat
 
     return estimate
 
@@ -628,8 +668,9 @@ __all__ = [
     "CameraFrameMetadata",
     "ImuSample",
     "Pointing",
+    "PointingAxis",
     "PointingEstimate",
-    "PointingPair",
+    "PointingMatrix",
     "ReloadSqmCalibration",
     "SolveDiagnostics",
     "SolveSource",


### PR DESCRIPTION
## Summary

Establishes a bounded-context vocabulary for the **Catalog**, **Positioning**, and **SQM** subsystems so future work shares the same language. Produced via a `grill-with-docs` session over the existing `docs/ax/*.md` draft glossaries.

* **`CONTEXT-MAP.md`** indexes the three contexts and how they relate.
* **`docs/ax/<area>/CONTEXT.md`** — canonical glossary per area, with flagged ambiguities and an example dialogue. Companion architecture deep-dives live as `docs/ax/<area>.md`.
* **`docs/adr/0001-positioning-vocabulary.md`** — locks in the `pointing.<axis>.<state>.<RA|Dec|Roll>` shape, the choice of `aligned` over `scope`, and `target_pixel` as the (Y, X) image-space coordinate. The code rename will land against the proposal dataclasses in `python/PiFinder/types/positioning.py`.
* **`docs/adr/0002-sqm-published-value-uncorrected.md`** — captures the intentional choice to publish raw `sqm_final` rather than the idealised altitude-corrected number.
* **`.claude/skills/grill-with-docs/`** — the skill that produced the contexts, included so the session can be re-run as the vocabulary evolves.
* **`CLAUDE.md`** — points future agents at the new reference docs.

Key vocabulary decisions baked in:

- **Catalog**: `enabled` (catalog) vs `selected` (object), `sky object` vs `catalog listing` vs `CompositeObject`, `populated` vs `fully loaded`, `logged` (technical) vs `observed` (user-facing).
- **Positioning**: 2 × 2 matrix `pointing.{camera,aligned}.{solve,estimate}`; bare "pointing" = `pointing.aligned.estimate`.
- **SQM**: `dark sequence` (multi-frame wizard concept) vs `zero-second sample` (single-frame runtime), `bias_offset` ⊆ `pedestal`, "noise floor" reserved for the published value.


## Prototype dataclasses
* Includes proposed dataclasses to be used for an upcoming refactor as it's the file is referenced in the context.  These dataclasses are subject to change in a future refactoring PR

## Test plan

- [ ] Skim `CONTEXT-MAP.md` and confirm relationships are accurate
- [ ] Walk each `docs/ax/<area>/CONTEXT.md` and confirm terms match how you'd describe them to a new contributor
- [ ] Confirm both ADRs reflect intentional choices, not accidents
- [ ] Verify `python/PiFinder/types/positioning.py` is the proposal-dataclass file you intended to ship in this PR (it can be split out if not)
- [ ] Check the `CLAUDE.md` Reference Documentation section is wired to land before Architecture Overview
- [ ] Sanity-check that no unrelated files (gerbers, kicad backups) snuck in

🤖 Generated with [Claude Code](https://claude.com/claude-code)