### PR TITLE
fix: don't reject all objects when no constellation/type filter is selected

### DIFF
--- a/python/PiFinder/catalogs.py
+++ b/python/PiFinder/catalogs.py
@@ -223,9 +223,6 @@ class CatalogFilter:
             if obj.const not in self._constellations:
                 obj.last_filtered_result = False
                 return False
-        else:
-            obj.last_filtered_result = False
-            return False
 
         # check altitude
         if self._altitude != -1 and self.fast_aa:
@@ -259,9 +256,6 @@ class CatalogFilter:
             if obj.obj_type not in self._object_types:
                 obj.last_filtered_result = False
                 return False
-        else:
-            obj.last_filtered_result = False
-            return False
 
         # check observed
         if self._observed is not None and self._observed != "Any":


### PR DESCRIPTION
## Summary

`CatalogFilter.check_object()` had two `else` branches that returned `False` whenever `self._constellations` or `self._object_types` was empty. The effect was the opposite of what most users expect: with **no** constellation filter selected, **all** objects were rejected (instead of "no filter = pass all").

Drop both else branches so an empty filter set means "filter disabled".

## Files

- `python/PiFinder/catalogs.py` (-6 lines)

## Test plan

- [ ] Open object lists with no constellation filter — verify objects show up
- [ ] Open object lists with no object-type filter — verify objects show up
- [ ] Set a constellation/type filter and confirm filtering still works as before