### PR TITLE
fix: handle empty deduplicated object list in BallTree construction

### DIFF
--- a/python/PiFinder/nearby.py
+++ b/python/PiFinder/nearby.py
@@ -71,6 +71,10 @@ class ClosestObjectsFinder:
         Calculates a flat list of objects and the balltree for those objects
         """
         deduplicated_objects = deduplicate_objects(objects)
+        if not deduplicated_objects:
+            self._objects = np.array([])
+            self._objects_balltree = None
+            return
         object_radecs = np.array(
             [[np.deg2rad(x.ra), np.deg2rad(x.dec)] for x in deduplicated_objects]
         )


### PR DESCRIPTION
## Summary

`BallTree(np.array([]), ...)` raises `ValueError` on an empty input array. When `deduplicate_objects()` returned an empty list (no catalogs selected, all objects filtered out, etc.), `ClosestObjectsFinder.calculate_objects_balltree()` crashed.

Set the empty arrays and return early so callers see no nearby objects instead of an exception. `get_closest_objects()` already handles `self._objects_balltree is None` and returns `[]`, so callers stay consistent.

## Files

- \`python/PiFinder/nearby.py\` (+4 lines)

## Test plan

- [ ] Open a state where no catalogs are selected, then trigger a nearby-sort path — verify no exception
- [ ] Confirm normal nearby-sort behavior with at least one catalog selected