### PR TITLE
Headless remote-control mode + pifinder-remote skill

### DIFF
--- a/.claude/skills/pifinder-remote/SKILL.md
+++ b/.claude/skills/pifinder-remote/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: pifinder-remote
+description: >-
+  Run the PiFinder app headlessly and drive it like a user — launch it with no
+  pygame window or physical display, send keypad presses to navigate menus,
+  capture the 128x128 screen as a PNG, read live state (plate solve, location,
+  IMU, SQM), and stop it cleanly. Use this whenever you need to actually
+  operate or observe the running PiFinder UI rather than just read its code:
+  "launch/start/run PiFinder", "navigate to <menu/screen>", "take a screenshot
+  of PiFinder", "press UP/DOWN/SQUARE", "what's on the PiFinder screen", "what
+  is it solving / where is it pointing", "check the UI shows X", "reproduce
+  this UI bug", "drive the PiFinder interface", or "stop/shut down PiFinder".
+  Also use it to verify UI-affecting changes by running the app and looking at
+  the screen.
+---
+
+# Driving PiFinder headlessly
+
+PiFinder normally renders to a physical OLED/LCD (or a pygame emulator window)
+and is driven by a hardware keypad. This skill runs it in a **headless** mode —
+no pygame, no SDL window, no hardware — while still rendering every frame, and
+drives it entirely over PiFinder's HTTP API. That lets you launch the app,
+navigate its menus, see exactly what's on screen, read its live state, and shut
+it down, all from the command line.
+
+Everything goes through one helper: **`scripts/pf_remote.py`** (Python standard
+library only — runs under any `python3`; it finds and uses the PiFinder venv
+itself when launching). Run `python3 <skill>/scripts/pf_remote.py -h` for the
+full command list.
+
+## The loop
+
+```bash
+S=.claude/skills/pifinder-remote/scripts/pf_remote.py   # adjust path as needed
+
+python3 $S launch            # start cedar + headless PiFinder, wait for the API
+python3 $S screen -o /tmp/pf.png   # capture the current 128x128 screen as PNG
+python3 $S key DOWN DOWN RIGHT     # send keypad presses, in order
+python3 $S status            # aggregated live state as JSON
+python3 $S stop              # graceful shutdown, then guaranteed teardown
+```
+
+After `launch` succeeds, the other commands find the running instance (URL +
+PIDs) from a small state file in the temp dir — you don't need to pass the URL.
+**Read the PNG that `screen` writes** (use the Read tool on the path it prints)
+to see the UI; that is how you "look at" PiFinder.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `launch` | Starts `cedar-detect-server` then PiFinder headless (`-fh --camera debug --keyboard none --display headless -x`), in its own process group, and waits until `/api/status` answers. Records state for the other commands. |
+| `screen [-o PATH]` | Saves `GET /api/screen` (the live 128×128 display) as a PNG and prints the path. |
+| `key BTN [BTN ...]` | POSTs each button to `/api/key` in order (default 0.4s apart, `--delay` to change). |
+| `status` / `solution` / `location` | Pretty-prints `GET /api/status` / `/api/solution` / `/api/location`. |
+| `get PATH` | GETs any other endpoint, e.g. `get /api/imu`, `get /api/sqm`. |
+| `stop` | Best-effort graceful `/api/stop`, then escalates to SIGTERM/SIGKILL on the process group so nothing is orphaned. |
+| `kill` | Skips the graceful step; force-kills the recorded process groups (recovery). |
+| `logs [-n N]` | Tails the captured PiFinder and cedar startup logs (first place to look if `launch` fails). |
+| `ready` | Polls until the API answers; useful after a manual launch. |
+
+## Keypad buttons
+
+PiFinder has a small keypad. Pass these names to `key` (case-sensitive), or a
+raw integer keycode:
+
+- Directions / actions: `UP` `DOWN` `LEFT` `RIGHT` `PLUS` `MINUS` `SQUARE`
+- Long press (held): `LNG_LEFT` `LNG_UP` `LNG_DOWN` `LNG_RIGHT` `LNG_SQUARE`
+- Alt (function) variants: `ALT_UP` `ALT_DOWN` `ALT_LEFT` `ALT_RIGHT` `ALT_PLUS` `ALT_MINUS` `ALT_SQUARE` `ALT_0`
+- Number keys: pass the digit as an integer, e.g. `key 1 2 3`
+
+Navigation model: `RIGHT` (or `SQUARE`) generally drills into the highlighted
+item, `LEFT` goes back, `UP`/`DOWN` move the selection, `LNG_LEFT` returns to
+the top menu. After any input, take a fresh `screen` to confirm what happened —
+the screen is the ground truth, menu order changes between versions.
+
+## How it works (and why stop is built this way)
+
+- **Headless rendering.** The launch passes `--display headless`, which selects
+  the in-memory `DisplayHeadless` driver (`python/PiFinder/displays.py`, backed
+  by `luma.core.device.dummy`). The UI render loop already calls
+  `shared_state.set_screen()` beside every hardware draw, so the current frame
+  is always available at `GET /api/screen` regardless of display driver. No
+  pygame/SDL/X is needed.
+- **Input.** `--keyboard none` runs a no-op keyboard process; `POST /api/key`
+  injects into the same `keyboard_queue` the main loop reads, so menu
+  navigation behaves exactly as with the real keypad.
+- **Solving works headless.** With `--camera debug`, PiFinder cycles through
+  sample frames and `cedar-detect-server` + the solver produce real plate
+  solves, so `status`/`solution` return live RA/Dec/constellation.
+- **Stopping is deliberately two-stage.** PiFinder is multi-process; its workers
+  run bare `while True` loops, aren't daemonized, and don't watch a stop flag.
+  Clean shutdown depends on `SIGINT` reaching the whole process group at once
+  (what a terminal Ctrl-C does). `POST /api/stop` does that from inside the app,
+  which reliably stops the worker processes — but the main process can still
+  hang in its teardown (a multiprocessing-manager shutdown race). So `launch`
+  starts PiFinder in its **own session/process group, isolated from the
+  launcher**, and `stop` escalates with `SIGTERM`→`SIGKILL` on that group after
+  a short grace period. `stop` returns as soon as the process is actually gone.
+  This guarantees no orphaned processes even when the graceful path stalls.
+
+## When startup fails
+
+`launch` waits up to `--timeout` seconds (default 90) for the API. The **first**
+launch in a fresh checkout rebuilds the catalog cache (~90s, one time); later
+launches come up in a few seconds. If it times out:
+
+1. `python3 $S logs` — read the PiFinder/cedar startup logs.
+2. Confirm the venv exists (`python/venv` or `python/.venv`) and the object DB
+   is present (`astro_data/pifinder_objects.db`).
+3. The API binds port 80 when it can, else 8080; `launch` probes both and
+   records the winner. Pass `--base-url http://host:port` to override.
+4. If a previous run left something behind, `python3 $S kill` clears it.
+
+## Notes
+
+- Repo location is auto-detected (this skill lives under the repo). Override
+  with `--repo /path/to/PiFinder` or the `PIFINDER_REPO` env var.
+- This skill requires two small pieces of in-repo support that ship with it:
+  the `headless` display driver and the `POST /api/stop` endpoint
+  (`python/PiFinder/api_extensions.py`). They're already in this branch.
+- The screen is 128×128 and rendered mostly in the red channel (PiFinder's
+  night-vision palette); that's expected, not a rendering bug.

--- a/.claude/skills/pifinder-remote/scripts/pf_remote.py
+++ b/.claude/skills/pifinder-remote/scripts/pf_remote.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""pf_remote.py — launch and drive a headless PiFinder over its HTTP API.
+
+This is the single entry point for the pifinder-remote skill. It needs only the
+Python standard library, so it runs under any python3 (it does not need to be
+the PiFinder venv interpreter — it locates and uses that itself when launching).
+
+Subcommands
+-----------
+  launch     Start cedar-detect-server + a headless PiFinder, wait until the
+             web API answers, and record PIDs/process-groups to a state file.
+  ready      Poll until the API answers (or time out).
+  screen     Fetch GET /api/screen and save the 128x128 PNG.
+  key        POST one or more buttons to /api/key, in order, with a small delay.
+  status     GET /api/status (aggregated state) and print it.
+  solution   GET /api/solution (plate-solve result) and print it.
+  location   GET /api/location and print it.
+  get        GET an arbitrary /api/* path and print the body.
+  stop       Graceful shutdown via POST /api/stop, then escalate to
+             SIGTERM/SIGKILL on the process group if anything lingers, and
+             stop cedar-detect-server too.
+  kill       Skip the graceful step; force-kill the recorded process groups.
+  logs       Print the tail of the PiFinder / cedar log files.
+
+Why a process group, not just a PID
+------------------------------------
+PiFinder is multi-process. Its children run bare ``while True`` loops, are not
+daemonized, and do not watch a stop flag — the only thing that brings them down
+cleanly is SIGINT delivered to the whole group at once (what a terminal Ctrl-C
+does). ``launch`` therefore starts PiFinder in its own session
+(``start_new_session=True``) so the whole tree shares one process group that is
+isolated from this launcher. ``/api/stop`` signals that group from the inside;
+``stop`` here escalates from the outside if a child still stalls. See
+SKILL.md for the full rationale.
+"""
+
+import argparse
+import json
+import os
+import platform
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+STATE_PATH = Path(tempfile.gettempdir()) / "pf_remote_state.json"
+LOG_DIR = Path(tempfile.gettempdir())
+PIFINDER_LOG = LOG_DIR / "pf_remote_pifinder.log"
+CEDAR_LOG = LOG_DIR / "pf_remote_cedar.log"
+
+DEFAULT_PORT = 8080
+CEDAR_PORT = 50551
+
+
+# ─────────────────────────── discovery ───────────────────────────
+
+
+def find_repo(explicit=None):
+    """Locate the PiFinder repo root (the dir holding python/PiFinder/main.py)."""
+    candidates = []
+    if explicit:
+        candidates.append(Path(explicit))
+    if os.environ.get("PIFINDER_REPO"):
+        candidates.append(Path(os.environ["PIFINDER_REPO"]))
+    # This skill is project-scoped, so the repo root is normally a few levels up
+    # from the script. Also walk up from the script and the cwd as a fallback.
+    here = Path(__file__).resolve()
+    candidates.extend(here.parents)
+    candidates.extend(Path.cwd().resolve().parents)
+    candidates.append(Path.cwd().resolve())
+    seen = set()
+    for c in candidates:
+        c = c.resolve()
+        if c in seen:
+            continue
+        seen.add(c)
+        if (c / "python" / "PiFinder" / "main.py").exists():
+            return c
+    raise SystemExit(
+        "Could not find the PiFinder repo (no python/PiFinder/main.py). "
+        "Pass --repo /path/to/PiFinder or set PIFINDER_REPO."
+    )
+
+
+def find_python(repo):
+    """Return the PiFinder venv interpreter if present, else this interpreter."""
+    for rel in (
+        "python/venv/bin/python",
+        "python/.venv/bin/python",
+        ".venv/bin/python",
+        "venv/bin/python",
+    ):
+        p = repo / rel
+        if p.exists():
+            return str(p)
+    return sys.executable
+
+
+def find_cedar(repo):
+    """Pick the cedar-detect-server binary matching this OS/arch."""
+    machine = platform.machine().lower()
+    system = platform.system().lower()
+    if system == "darwin":
+        prefer = ["arm64"] if machine in ("arm64", "aarch64") else ["x86_64", "amd64", "x86"]
+    else:  # assume linux
+        prefer = ["aarch64", "arm64"] if machine in ("aarch64", "arm64") else ["x86_64", "amd64", "x86"]
+    files = sorted((repo / "bin").glob("cedar-detect-server*"))
+    for suffix in prefer:
+        for f in files:
+            if f.name.endswith(suffix):
+                return f
+    for f in files:  # last resort: any executable cedar binary
+        if os.access(f, os.X_OK):
+            return f
+    raise SystemExit(f"No cedar-detect-server binary found in {repo / 'bin'}")
+
+
+# ─────────────────────────── http ───────────────────────────
+
+
+def base_url(args):
+    """Resolve the API base URL from args, then the launch state file, else default."""
+    if getattr(args, "base_url", None):
+        return args.base_url.rstrip("/")
+    state = load_state()
+    if state and state.get("base_url"):
+        return state["base_url"].rstrip("/")
+    return f"http://127.0.0.1:{getattr(args, 'port', DEFAULT_PORT)}"
+
+
+def http_get(url, timeout=15):
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def http_post(url, payload, timeout=15):
+    data = json.dumps(payload if payload is not None else {}).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=data, method="POST", headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def wait_ready(base, timeout=60.0, interval=1.0):
+    """Poll /api/status until any HTTP response comes back (server is up)."""
+    ok, _, info = wait_ready_any([base], timeout=timeout, interval=interval)
+    return ok, info
+
+
+def wait_ready_any(bases, timeout=60.0, interval=1.0):
+    """Poll several candidate base URLs; return (ok, winning_base, info).
+
+    PiFinder binds port 80 when it can and otherwise falls back to 8080, so the
+    actual URL is not known until it is listening. We try each candidate every
+    round until one answers.
+    """
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        for base in bases:
+            try:
+                status, _ = http_get(base + "/api/status", timeout=5)
+                return True, base, status
+            except Exception as e:  # connection refused while still starting
+                last = e
+        time.sleep(interval)
+    return False, None, last
+
+
+# ─────────────────────────── state file ───────────────────────────
+
+
+def load_state():
+    try:
+        return json.loads(STATE_PATH.read_text())
+    except Exception:
+        return None
+
+
+def save_state(state):
+    STATE_PATH.write_text(json.dumps(state, indent=2))
+
+
+# ─────────────────────────── process control ───────────────────────────
+
+
+def pid_alive(pid):
+    if not pid:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def pgid_alive(pgid):
+    if not pgid:
+        return False
+    try:
+        os.killpg(pgid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def kill_group(pgid, label, grace=4.0):
+    """Escalate SIGTERM then SIGKILL on a process group; report what happened."""
+    if not pgid or not pgid_alive(pgid):
+        return f"{label}: already gone"
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except ProcessLookupError:
+        return f"{label}: gone"
+    deadline = time.time() + grace
+    while time.time() < deadline and pgid_alive(pgid):
+        time.sleep(0.2)
+    if pgid_alive(pgid):
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        return f"{label}: SIGKILL"
+    return f"{label}: SIGTERM"
+
+
+# ─────────────────────────── commands ───────────────────────────
+
+
+def cmd_launch(args):
+    repo = find_repo(args.repo)
+    py = find_python(repo)
+    cedar = find_cedar(repo)
+    # PiFinder binds port 80 if it can, else 8080. Unless the caller pinned a
+    # URL, probe both (the explicit --port first) and record whichever answers.
+    if args.base_url:
+        candidates = [args.base_url.rstrip("/")]
+    else:
+        ports = [args.port] + [p for p in (80, 8080) if p != args.port]
+        candidates = [f"http://127.0.0.1:{p}" for p in ports]
+
+    existing = load_state()
+    if existing and pid_alive(existing.get("main_pid")):
+        print(
+            f"PiFinder already running (pid {existing['main_pid']}, {existing['base_url']}). "
+            "Run `stop` first to relaunch.",
+            file=sys.stderr,
+        )
+        return 1
+
+    cedar_log = open(CEDAR_LOG, "wb")
+    pf_log = open(PIFINDER_LOG, "wb")
+
+    cedar_proc = subprocess.Popen(
+        [str(cedar), "-p", str(CEDAR_PORT)],
+        cwd=str(repo / "bin"),
+        stdout=cedar_log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    pf_cmd = [
+        py, "-m", "PiFinder.main",
+        "-fh", "--camera", "debug", "--keyboard", "none", "--display", "headless", "-x",
+    ]
+    pf_proc = subprocess.Popen(
+        pf_cmd,
+        cwd=str(repo / "python"),
+        stdout=pf_log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+    state = {
+        "base_url": candidates[0],  # provisional; updated once we know the real port
+        "repo": str(repo),
+        "main_pid": pf_proc.pid,
+        "main_pgid": os.getpgid(pf_proc.pid),
+        "cedar_pid": cedar_proc.pid,
+        "cedar_pgid": os.getpgid(cedar_proc.pid),
+        "started_at": time.time(),
+    }
+    save_state(state)
+    print(f"cedar-detect-server pid {cedar_proc.pid} (port {CEDAR_PORT})")
+    print(f"PiFinder pid {pf_proc.pid}, group {state['main_pgid']}")
+    print(
+        f"Waiting up to {args.timeout}s for the API "
+        f"({', '.join(candidates)}) ...\n"
+        "First launch in a fresh checkout rebuilds the catalog cache (~90s)."
+    )
+
+    ok, base, info = wait_ready_any(candidates, timeout=args.timeout)
+    if not ok:
+        print(
+            f"API did not come up within {args.timeout}s. "
+            f"Check logs: {PIFINDER_LOG}\nLast error: {info}",
+            file=sys.stderr,
+        )
+        if not pid_alive(pf_proc.pid):
+            print("PiFinder process exited during startup — see the log above.", file=sys.stderr)
+        return 1
+    state["base_url"] = base
+    save_state(state)
+    print(f"PiFinder API is up at {base} (HTTP {info}).")
+    return 0
+
+
+def cmd_ready(args):
+    base = base_url(args)
+    ok, info = wait_ready(base, timeout=args.timeout)
+    if ok:
+        print(f"ready ({base}, HTTP {info})")
+        return 0
+    print(f"not ready after {args.timeout}s: {info}", file=sys.stderr)
+    return 1
+
+
+def cmd_screen(args):
+    base = base_url(args)
+    status, body = http_get(base + "/api/screen", timeout=15)
+    if status != 200:
+        print(f"/api/screen returned HTTP {status}", file=sys.stderr)
+        return 1
+    out = Path(args.output) if args.output else LOG_DIR / f"pf_screen_{int(time.time())}.png"
+    out.write_bytes(body)
+    print(str(out))
+    return 0
+
+
+def cmd_key(args):
+    base = base_url(args)
+    rc = 0
+    for button in args.buttons:
+        # Accept a numeric keycode or a named button (UP/DOWN/SQUARE/ALT_*/LNG_* ...)
+        payload = {"button": int(button) if button.lstrip("-").isdigit() else button}
+        status, body = http_post(base + "/api/key", payload, timeout=10)
+        ok = status == 200
+        print(f"{button}: HTTP {status}{'' if ok else ' ' + body.decode('utf-8', 'replace')}")
+        if not ok:
+            rc = 1
+        time.sleep(args.delay)
+    return rc
+
+
+def _print_json(status, body):
+    try:
+        print(json.dumps(json.loads(body), indent=2, ensure_ascii=False))
+    except Exception:
+        print(body.decode("utf-8", "replace"))
+    return 0 if status == 200 else 1
+
+
+def cmd_status(args):
+    base = base_url(args)
+    return _print_json(*http_get(base + "/api/status"))
+
+
+def cmd_solution(args):
+    base = base_url(args)
+    return _print_json(*http_get(base + "/api/solution"))
+
+
+def cmd_location(args):
+    base = base_url(args)
+    return _print_json(*http_get(base + "/api/location"))
+
+
+def cmd_get(args):
+    base = base_url(args)
+    path = args.path if args.path.startswith("/") else "/" + args.path
+    return _print_json(*http_get(base + path))
+
+
+def cmd_stop(args):
+    state = load_state()
+    base = state["base_url"] if state else base_url(args)
+    results = []
+
+    # 1) Graceful: ask PiFinder to SIGINT its own group from the inside.
+    try:
+        status, _ = http_post(base + "/api/stop", {"delay": 0.3}, timeout=5)
+        results.append(f"/api/stop: HTTP {status}")
+    except Exception as e:
+        results.append(f"/api/stop: unreachable ({e})")
+
+    main_pid = state.get("main_pid") if state else None
+    main_pgid = state.get("main_pgid") if state else None
+    cedar_pgid = state.get("cedar_pgid") if state else None
+
+    # 2) Give the clean shutdown a bounded window to finish on its own.
+    deadline = time.time() + args.grace
+    while time.time() < deadline and pid_alive(main_pid):
+        time.sleep(0.2)
+
+    # 3) Escalate on the group if anything is still alive.
+    if main_pgid:
+        results.append(kill_group(main_pgid, "pifinder group"))
+    elif main_pid and pid_alive(main_pid):
+        try:
+            os.kill(main_pid, signal.SIGKILL)
+            results.append("pifinder pid: SIGKILL")
+        except ProcessLookupError:
+            pass
+
+    # 4) cedar-detect-server lives in its own group; stop it too.
+    if cedar_pgid:
+        results.append(kill_group(cedar_pgid, "cedar group"))
+
+    try:
+        STATE_PATH.unlink()
+    except FileNotFoundError:
+        pass
+
+    print("\n".join(results) if results else "nothing to stop")
+    return 0
+
+
+def cmd_kill(args):
+    state = load_state()
+    if not state:
+        print("no launch state file; nothing to kill", file=sys.stderr)
+        return 1
+    out = []
+    if state.get("main_pgid"):
+        out.append(kill_group(state["main_pgid"], "pifinder group"))
+    if state.get("cedar_pgid"):
+        out.append(kill_group(state["cedar_pgid"], "cedar group"))
+    try:
+        STATE_PATH.unlink()
+    except FileNotFoundError:
+        pass
+    print("\n".join(out))
+    return 0
+
+
+def cmd_logs(args):
+    for path in (PIFINDER_LOG, CEDAR_LOG):
+        print(f"===== {path} =====")
+        try:
+            lines = path.read_text(errors="replace").splitlines()
+            print("\n".join(lines[-args.lines:]))
+        except FileNotFoundError:
+            print("(no log yet)")
+        print()
+    return 0
+
+
+# ─────────────────────────── argparse ───────────────────────────
+
+
+def build_parser():
+    p = argparse.ArgumentParser(description="Drive a headless PiFinder over its HTTP API.")
+    p.add_argument("--base-url", help="API base URL (default from launch state, else http://127.0.0.1:8080)")
+    p.add_argument("--port", type=int, default=DEFAULT_PORT, help="API port if no base URL (default 8080)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("launch", help="start cedar + headless PiFinder and wait for the API")
+    sp.add_argument("--repo", help="PiFinder repo root (auto-detected by default)")
+    sp.add_argument("--timeout", type=float, default=90.0, help="seconds to wait for the API")
+    sp.set_defaults(func=cmd_launch)
+
+    sp = sub.add_parser("ready", help="poll until the API answers")
+    sp.add_argument("--timeout", type=float, default=60.0)
+    sp.set_defaults(func=cmd_ready)
+
+    sp = sub.add_parser("screen", help="save GET /api/screen as a PNG")
+    sp.add_argument("-o", "--output", help="output PNG path (default: temp dir)")
+    sp.set_defaults(func=cmd_screen)
+
+    sp = sub.add_parser("key", help="POST one or more buttons to /api/key, in order")
+    sp.add_argument("buttons", nargs="+", help="e.g. UP DOWN SQUARE RIGHT  (or numeric keycodes)")
+    sp.add_argument("--delay", type=float, default=0.4, help="seconds between presses (default 0.4)")
+    sp.set_defaults(func=cmd_key)
+
+    sp = sub.add_parser("status", help="GET /api/status")
+    sp.set_defaults(func=cmd_status)
+    sp = sub.add_parser("solution", help="GET /api/solution")
+    sp.set_defaults(func=cmd_solution)
+    sp = sub.add_parser("location", help="GET /api/location")
+    sp.set_defaults(func=cmd_location)
+
+    sp = sub.add_parser("get", help="GET an arbitrary /api/* path")
+    sp.add_argument("path", help="e.g. /api/imu")
+    sp.set_defaults(func=cmd_get)
+
+    sp = sub.add_parser("stop", help="graceful /api/stop, then escalate if needed")
+    sp.add_argument(
+        "--grace",
+        type=float,
+        default=5.0,
+        help="seconds to wait for a clean exit before escalating to SIGTERM "
+        "(stop returns early as soon as the main process is gone)",
+    )
+    sp.set_defaults(func=cmd_stop)
+
+    sp = sub.add_parser("kill", help="force-kill the recorded process groups (no graceful step)")
+    sp.set_defaults(func=cmd_kill)
+
+    sp = sub.add_parser("logs", help="tail the PiFinder and cedar logs")
+    sp.add_argument("-n", "--lines", type=int, default=40)
+    sp.set_defaults(func=cmd_logs)
+
+    return p
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/PiFinder/api_extensions.py
+++ b/python/PiFinder/api_extensions.py
@@ -699,6 +699,59 @@ def register_api_routes(app, server_instance, require_auth=False):
             logger.error("api/key error: %s", e)
             return _json_response({"error": str(e)}, 500)
 
+    @app.route("/api/stop", methods=["POST"])
+    def api_stop():
+        """Cleanly shut down the entire PiFinder application.
+
+        PiFinder's normal shutdown is driven by a terminal Ctrl-C: SIGINT is
+        delivered to the *whole* foreground process group at once, so every
+        child (camera, solver, integrator, imu, web server, multiprocessing
+        helpers) exits from its own KeyboardInterrupt and the main process's
+        .join() calls return. Most children run bare ``while True`` loops and
+        neither catch KeyboardInterrupt nor watch a stop flag, so signalling
+        only the main process would leave it hanging in .join() forever.
+
+        This handler runs inside the web-server child, so ``os.getpgid(0)`` is
+        the PiFinder process group. Signalling that group reproduces the Ctrl-C
+        path. The signal is fired from a short-lived timer thread so this HTTP
+        response can flush before the server process itself is torn down.
+
+        For automation that launched PiFinder in its own session (the expected
+        case), this group is isolated from the launcher, so the launcher
+        survives and can escalate to SIGTERM/SIGKILL if a child still stalls.
+
+        Body (optional JSON): {"delay": <seconds before signalling, default 0.5>}
+        """
+        import os
+        import signal
+        import threading
+
+        try:
+            body = request.get_json(silent=True) or {}
+            delay = float(body.get("delay", 0.5))
+        except Exception:
+            delay = 0.5
+        # Keep the delay sane: long enough to flush the response, not so long
+        # that an automated stop appears to hang.
+        delay = min(max(delay, 0.0), 5.0)
+
+        def _shutdown():
+            try:
+                pgid = os.getpgid(0)
+                logger.info("api/stop: sending SIGINT to process group %s", pgid)
+                os.killpg(pgid, signal.SIGINT)
+            except Exception:
+                logger.exception("api/stop: killpg failed; signalling self instead")
+                try:
+                    os.kill(os.getpid(), signal.SIGINT)
+                except Exception:
+                    logger.exception("api/stop: self-signal failed")
+
+        threading.Timer(delay, _shutdown).start()
+        return _json_response(
+            {"success": True, "note": "Shutting down PiFinder", "delay": delay}
+        )
+
     logger.info(
         "PiFinder API extensions registered (%s auth)",
         "with" if require_auth else "without",

--- a/python/PiFinder/displays.py
+++ b/python/PiFinder/displays.py
@@ -161,7 +161,41 @@ class DisplayST7789(DisplayBase):
         super().__init__()
 
 
+class DisplayHeadless(DisplayBase):
+    """In-memory display for remote control / automation.
+
+    Renders to a luma ``dummy`` device, which keeps the most recent frame as a
+    PIL image but draws no window and talks to no SPI hardware. This lets
+    PiFinder run on a machine with no physical display and no SDL/X session
+    (e.g. a CI box or a headless dev session) without pulling in pygame.
+
+    Nothing here feeds the API directly: the UI render loop already calls
+    ``shared_state.set_screen()`` right beside ``device.display()``, so the
+    current screen stays available over ``GET /api/screen`` no matter which
+    display driver is active. This driver simply makes the hardware-facing
+    half of that pair a no-op.
+    """
+
+    resolution = (128, 128)
+    color_mask = RED_RGB
+
+    def __init__(self):
+        # luma.core.device.dummy lives in luma.core (not the emulator package),
+        # so importing it does not require pygame to be installed.
+        from luma.core.device import dummy
+
+        self.device = dummy(
+            width=self.resolution[0],
+            height=self.resolution[1],
+            mode="RGB",
+        )
+        super().__init__()
+
+
 def get_display(display_hardware: str) -> DisplayBase:
+    if display_hardware == "headless":
+        return DisplayHeadless()
+
     if display_hardware == "pg_128":
         return DisplayPygame_128()
 

--- a/python/PiFinder/keyboard_none.py
+++ b/python/PiFinder/keyboard_none.py
@@ -20,7 +20,9 @@ class KeyboardNone(KeyboardInterface):
         self.q.put(key)
 
 
-def run_keyboard(q, shared_state, log_queue):
+def run_keyboard(q, shared_state, log_queue, bloom_remap=False):
+    # bloom_remap is accepted for signature parity with the local/pi keyboards
+    # (main.py always passes it); the "none" keyboard has no keys to remap.
     MultiprocLogging.configurer(log_queue)
     KeyboardNone(q)
 


### PR DESCRIPTION
## Summary

Adds a way to run PiFinder headlessly (no pygame window, no physical display) and drive it programmatically — for UI automation, screenshots, and inspection — plus a Claude Code skill that wraps the whole workflow.

### PiFinder code changes
- **`displays.py`** — new `DisplayHeadless` driver backed by `luma.core.device.dummy` (no pygame/SDL/hardware), selected with `--display headless`. The render loop already mirrors every frame into `shared_state`, so `GET /api/screen` works unchanged.
- **`api_extensions.py`** — new `POST /api/stop`. It SIGINTs the whole process group from inside the app (after the HTTP response flushes), reproducing the terminal Ctrl-C shutdown path.
- **`keyboard_none.py`** — accept the `bloom_remap` arg that `main.py` always passes, fixing a crash in the `--keyboard none` keyboard process.

### Skill
- **`.claude/skills/pifinder-remote/`** — `SKILL.md` + a zero-dependency `pf_remote.py` CLI (`launch / screen / key / status / solution / location / get / stop / kill / logs / ready`). `launch` starts `cedar-detect-server` + headless PiFinder in an isolated process group; `stop` tries the graceful endpoint then escalates `SIGTERM`→`SIGKILL`, so nothing is orphaned even when the multiprocess teardown stalls.

## On shutdown
PiFinder's workers run bare `while True` loops, aren't daemonized, and don't watch a stop flag — clean shutdown depends on SIGINT reaching the whole group at once. `POST /api/stop` does that and reliably stops the workers, but the main process can still hang in a multiprocessing-manager teardown race (the existing Ctrl-C path has the same risk). The launcher's process-group escalation guarantees teardown regardless.

## Recommended launch
`python -m PiFinder.main -fh --camera debug --keyboard none --display headless -x`

## Testing
Validated live end to end on macOS (arm64): headless launch, `/api/screen` returns the rendered UI, `/api/key` navigates menus, the solver actively solves under `--camera debug`, and `stop` leaves no orphans.

Nox suite:
- `lint` ✅, `format` ✅ (changed files clean), `smoke_tests` ✅ (5), `unit_tests` ✅ (143), `web_tests` ✅ (172 skipped — no Selenium Grid).
- `type_hints`: the 3 changed files are mypy-clean; the session's 16 errors are all pre-existing third-party stub issues (selenium/`urllib3`) in the mypy venv, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)