### PR TITLE
Docs: dev guide refresh, agentic-docs + skills section, complete JSON API page

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,41 +1,149 @@
 Machine-readable API
 ====================
 
-PiFinder exposes optional JSON endpoints for automation and external tools.
+PiFinder exposes a set of optional JSON and image endpoints under ``/api/`` for
+automation and external tools. They are registered on the same web server that
+serves the PiFinder web interface, and by default they require **no
+authentication**, so any client on the same network can call them.
 
-Endpoints
----------
+Everything is served relative to the PiFinder's address, for example
+``http://pifinder.local/api/status``. JSON endpoints return
+``application/json``; image endpoints return ``image/png``. When the data a call
+needs isn't ready yet — no GPS lock, no plate solve, no IMU or SQM reading — that
+endpoint returns HTTP ``503`` with a short JSON ``note`` explaining why, rather
+than failing outright.
+
+Status and data
+---------------
+
+These endpoints return JSON. ``/api/status`` is the convenient one-shot call; the
+rest let you fetch a single value on demand.
 
 GET /api/status
-    Returns current power state, solve state, camera type, location, solution,
-    IMU, SQM, and software version.
+    Aggregated snapshot, fetching everything in one call: ``power_state``,
+    ``solve_state``, ``camera_type``, ``location``, ``solution``, ``datetime``
+    (both ``utc`` and ``local``), ``imu``, ``sqm`` and ``software_version``.
+
+GET /api/time
+    The current ``utc`` and ``local`` time plus the active ``timezone``.
+
+GET /api/location
+    The current GPS location (latitude, longitude, altitude, timezone and lock
+    state). The GPS cache is refreshed before responding, and the call returns
+    ``503`` if GPS is not locked.
 
 GET /api/solution
-    Returns current plate solve solution when available.
+    The current plate-solve solution — RA, Dec, Roll, field of view and the
+    matched-star statistics. ``Alt`` and ``Az`` are added when a location and
+    time are available. Returns ``503`` if there is no valid solve yet.
+
+GET /api/imu
+    The current IMU data (orientation and movement state). Returns ``503`` when
+    no IMU is present or no reading is available.
+
+GET /api/sqm
+    The latest Sky Quality Meter estimate of sky brightness. Returns ``503``
+    when no reading is available.
 
 GET /api/visible_stars
-    Returns visible stars for the current field.
+    Re-renders the star field for the current pointing and returns the visible
+    stars as structured data, optionally with the rendered chart as a base64
+    PNG. It uses the camera solve (RA / Dec / Roll) so the result isn't shifted
+    by IMU dead-reckoning.
 
-Query parameters:
+    The response carries the solve ``source`` and pointing, the ``filters`` that
+    were applied, a ``count`` and ``label_count``, and a ``visible_stars`` array.
+    Each star includes its catalog fields, a ``display_name``, and a ``label``
+    flag (with ``label_reason``) marking the stars suggested for on-screen
+    labelling. Rendered star positions are returned in the coordinate system set
+    by ``render_size``.
+
+Query parameters for ``/api/visible_stars``:
 
 ``render_mag_limit``
-    Magnitude limit for stars returned for rendering. Default: 5.5.
+    Magnitude limit for the stars returned for rendering. Default: ``5.5``. The
+    legacy name ``mag_limit`` is still accepted.
 
 ``label_mag_limit``
-    Magnitude limit for stars suggested for labeling. Default: 2.5.
+    Magnitude limit for the stars suggested for labelling. Default: ``2.5``.
 
 ``max_labels``
-    Maximum number of suggested labels. Default: 5.
+    Maximum number of suggested labels, clamped to 0–30. Default: ``5``. If too
+    few stars fall within ``label_mag_limit``, the brightest stars in the field
+    are added to reach this count.
 
-``source``
-    ``camera`` uses ``solution.camera_solve``.
-    ``screen`` uses top-level ``solution.RA`` / ``solution.Dec`` / ``solution.Roll``.
+``use_camera_solve``
+    Prefer the camera solve over the integrated, IMU-corrected solution.
+    Default: ``true``.
+
+``fov``
+    Rendering field of view in degrees. Default: the solve's FOV, or ``10.2``.
+
+``render_size``
+    Output resolution in pixels, clamped to 128–4096. Star positions are
+    returned in this coordinate system. Default: ``1088``.
+
+``constellation_brightness``
+    Brightness of the constellation lines (0–255). Default: ``32``.
+
+``shade_frustrum``
+    Whether to shade the camera frustum. Default: ``true``.
+
+``include_image``
+    Include the rendered star chart in the response as a base64-encoded PNG.
+    Default: ``false``.
+
+Images
+------
+
+These endpoints return a PNG directly, which makes them easy to embed in a
+browser or save to a file.
+
+GET /api/screen
+    The current 128×128 device screen as a PNG — the same image shown on the
+    OLED.
+
+GET /api/camera/raw
+    The raw CMOS camera image as a PNG, when one is available; otherwise
+    ``503``.
+
+GET /api/camera/debug
+    The most recent solver debug frame from the debug-dump directory, as a PNG;
+    ``503`` if none have been written.
+
+Control
+-------
+
+These endpoints accept a POST with a JSON body and change the state of the
+PiFinder, so use them with care.
+
+POST /api/key
+    Simulate a keypad press. JSON body: ``{"button": "UP"}`` (a button name) or
+    ``{"button": 1}`` (a raw key code).
+
+POST /api/stop
+    Cleanly shut down the entire PiFinder application, reproducing a terminal
+    Ctrl-C. Optional JSON body ``{"delay": <seconds>}`` (default ``0.5``, capped
+    at ``5``) sets how long to wait before signalling, so the HTTP response can
+    flush first.
 
 Example
 -------
 
 .. code-block:: bash
 
+    # One-shot status, then individual values
     curl http://pifinder.local/api/status
-    curl "http://pifinder.local/api/visible_stars?source=camera&render_mag_limit=5.5"
-    curl "http://pifinder.local/api/visible_stars?source=screen&render_mag_limit=5.5"
+    curl http://pifinder.local/api/solution
+    curl http://pifinder.local/api/sqm
+
+    # Visible stars, with the rendered chart embedded as a base64 PNG
+    curl "http://pifinder.local/api/visible_stars?render_mag_limit=5.5&include_image=true"
+
+    # Save the current screen to a file
+    curl http://pifinder.local/api/screen -o screen.png
+
+    # Simulate pressing the UP button
+    curl -X POST http://pifinder.local/api/key \
+         -H "Content-Type: application/json" \
+         -d '{"button": "UP"}'

--- a/docs/source/dev_arch.rst
+++ b/docs/source/dev_arch.rst
@@ -2,8 +2,17 @@
 Architecture
 ================
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",
 "MAY", and "OPTIONAL" in this page are to be interpreted as described in `RFC 2119 <https://datatracker.ietf.org/doc/html/rfc2119>`_.
+
+.. note::
+
+   This page describes the system-wide architecture. Per-context detail — the
+   vocabulary, data flow and design decisions for each slice of the system
+   (Catalog, Positioning, SQM, Equipment, UI) — lives in the repository under
+   ``CONTEXT-MAP.md`` and ``docs/ax/``. See
+   :ref:`dev_guide:reference documentation and ai assistant skills` for how that
+   documentation is organised.
 
 Solution Platform Constraints
 --------------------------------

--- a/docs/source/dev_guide.rst
+++ b/docs/source/dev_guide.rst
@@ -96,7 +96,7 @@ To checkout one of the forks of the repository, run the following commands:
 .. code-block:: bash
 
     cd ~/PiFinder
-    git add remote <rname> <url-of-fork>
+    git remote add <rname> <url-of-fork>
     git fetch --all
     git checkout -b <branch> <rname>/<branch>
 
@@ -139,11 +139,12 @@ the ending ``.rst``. The documentation is then published to `readthedocs.io <htt
 to the official GitHub repository (using readthedocs's infrastructure). 
 
 You can link your fork also to your account on readthedocs.io, but it is easier to build the documentation locally. 
-For this install sphinx using pip: 
+For this, install Sphinx and the Read the Docs theme from the pinned
+requirements file (run this from the ``docs`` directory):
 
 .. code-block::
 
-    pip install -r sphinx sphinx_rtd_theme
+    pip install -r source/requirements.txt
 
 You can then use the supplied ``Makefile`` to build a html tree using ``make html`` and running a http server in the directory with the files: 
 
@@ -151,6 +152,68 @@ You can then use the supplied ``Makefile`` to build a html tree using ``make htm
 
     cd build/html; python -m http.server
 
+
+Reference documentation and AI assistant skills
+-----------------------------------------------
+
+Alongside this manual, the repository carries a second layer of documentation
+aimed at people working *in* the code rather than reading about the product. It
+captures the project's vocabulary and the reasoning behind choices that aren't
+obvious from the code alone, and it doubles as guidance for AI coding assistants
+working in the repo. Reading the relevant pieces before you change an area saves
+you from guessing, and from accidentally renaming a concept the rest of the
+codebase depends on.
+
+The domain model
+................
+
+PiFinder is split into a handful of *contexts* — distinct slices of the running
+system, each with its own vocabulary. This documentation lives under ``docs/`` in
+the repository (it is not part of this Sphinx site) and is organised like this:
+
+- ``CONTEXT-MAP.md`` (repository root) — the index of contexts (Catalog,
+  Positioning, SQM, Equipment, UI) and how they relate to one another. Start
+  here for any cross-context question.
+- ``docs/ax/<area>/CONTEXT.md`` — the canonical glossary for each context. These
+  define what each domain term means, which words to avoid, and how related
+  ideas fit together. When one of these defines a term, prefer it over synonyms
+  in your code, comments, commit messages and pull requests.
+- ``docs/ax/<area>.md`` — an architecture deep-dive for each context: data flow,
+  lifecycle and the gotchas that catch newcomers out. These sit alongside the
+  system-wide :doc:`dev_arch` page.
+- ``docs/adr/NNNN-*.md`` — short Architecture Decision Records that capture the
+  *why* behind a non-obvious or hard-to-reverse choice, so you can tell a
+  deliberate decision from an accident.
+
+Keeping everyone on the same words is the point: when the code, the conversation
+and the commit history all use the same terms, changes are far easier to discuss
+and review. If you find language in the code that conflicts with a ``CONTEXT.md``,
+that's worth flagging.
+
+AI assistant skills
+...................
+
+If you work with an AI coding assistant such as
+`Claude Code <https://www.claude.com/product/claude-code>`_, the repository
+bundles a set of *skills* in ``.claude/skills/``. Each one packages a common
+PiFinder workflow — the right files, conventions and steps — so the assistant
+follows the house way of doing things instead of guessing. They are entirely
+optional; you don't need them to contribute, but they save time. Invoke one by
+its name (for example ``/docs``):
+
+- **docs** — author and edit this user-facing manual in the house style,
+  including building it to check for broken cross-references. See the
+  `Documentation`_ section above.
+- **grill-with-docs** — stress-test a plan against the domain model described
+  above, sharpen the terminology, and update the ``CONTEXT.md`` glossaries and
+  ADRs as decisions settle.
+- **i18n** — run the translation workflow: mark strings, run the Babel
+  extract/update/compile pipeline, and fill in missing translations. See
+  `Internationalization`_ below.
+- **pifinder-remote** — run PiFinder headlessly and drive it like a user over
+  its HTTP API: press keys to navigate the menus, capture the 128×128 screen as
+  a PNG, and read live state such as the current solve, location and IMU. Handy
+  for reproducing a UI bug or grabbing a screenshot without real hardware.
 
 Internationalization
 -----------------------
@@ -320,6 +383,13 @@ The defined sessions are:
   session is not run by default, but is executed on code check in to the PiFinder
   repository.
 
+- ui_tests -> Runs PyTest against the UI module smoke harness
+  (``tests/test_ui_modules.py``).  It builds every UI screen through a real
+  ``MenuManager`` and exercises each screen's key handlers as a crash-only smoke
+  test.  Because it builds the real catalogs and may download ``hip_main.dat`` on
+  first run, it is heavier and more network-dependent than the unit suite, so it
+  lives in its own session and is not run by default.
+
 - babel -> Runs the complete toolchain for internationalization (based on `pybabel`).
   That means extracts strings to translate and updates the `.po`-files in `python/locale/**`
   Then these are compiled into `.mo`-files. Unfortunately, this changes the `.mo`-files in any case,
@@ -351,9 +421,9 @@ the web interface works correctly.
 The tests exercise the remote control features of PiFinder, changing **the state of the PiFinder** and
 therefore should **not be run** against a PiFinder you are actively using for observing.
 
-... tip
+.. tip::
 
-    Note that the whole test suite runs approximately 20 min. 
+    Note that the whole test suite runs approximately 20 min.
 
 Running Website Tests locally
 _______________________________
@@ -400,7 +470,7 @@ If you want to test against a real PiFinder, set the ``PIFINDER_HOMEPAGE`` envir
     nox -s web_tests
 
 If you run the tests with-out a working Selenium Grid instance, the tests will all be skipped. 
-You can also run individual tests with PyTest directly, use ``SELENIUM_GRID_URL=... PIFINDER_HOMEPAGE=... pytest tests/webstite/test_file.py``.
+You can also run individual tests with PyTest directly, use ``SELENIUM_GRID_URL=... PIFINDER_HOMEPAGE=... pytest tests/website/test_file.py``.
 
 Note that due to the tests depending on the response times of the PiFinder web server and the Selenium Grid server, there may be occasional timeouts or failures.
 If you encounter such issues, simply re-run the tests. We need to strike a balance between test speed and reliability, and this may require some tuning in the future.
@@ -457,38 +527,24 @@ You can do this by running the following command in another terminal window:
 
 .. code-block::
 
-    cd /home/pifinder/PiFinder/python/PiFinder/bin
+    cd /home/pifinder/PiFinder/bin
     ./cedar-detect-server-<your arch> -p 50551
 
 -h, --help | available command line arguments
 .............................................
 
-Get all ``PiFinder.main`` options with the "--help" flag.
+Run ``PiFinder.main`` with the ``-h`` flag to print every available option:
 
 .. code-block::
 
-    pifinder@pifinder:~/PiFinder/python $ python3 -m PiFinder.main -h
-    Starting PiFinder ...
-    usage: main.py [-h] [-fh] [-c CAMERA] [-k KEYBOARD] [--script SCRIPT] [-f] [-n] [-x] [-l]
-    
-    eFinder
-    
-    optional arguments:
-      -h, --help            show this help message and exit
-      -fh, --fakehardware   Use a fake hardware for imu, gps
-      -c CAMERA, --camera CAMERA
-                            Specify which camera to use: pi, asi, debug or none
-      -k KEYBOARD, --keyboard KEYBOARD
-                            Specify which keyboard to use: pi, local or server
-      --script SCRIPT       Specify a testing script to run
-      -f, --fps             Display FPS in title bar
-      -n, --notmp           Don't use the /dev/shm temporary directory. (useful if not on pi)
-      -x, --verbose         Set logging to debug mode
-      -l, --log             Log to file
+    python3 -m PiFinder.main -h
 
 .. note::
 
-   The available command line flags may change with forthcoming releases. Always refer to the real output of the command line parameter "-h".
+   The set of command line flags changes between releases, so rather than
+   reproduce the full list here it is best to consult the real output of
+   ``-h``.  The flags you'll reach for most often are described in their own
+   sections below.
 
 -x, --verbose | debug information
 .................................
@@ -578,16 +634,8 @@ My app crashes
 When crashing, there are many unrelated stack traces running. Search for the
 relevant one. The rest is not important, these are the other threads stopping.
 
-.. ::attention
-
-   Needs an example
-
 Test the IMU
 ............
-
-.. ATTENTION::
-
-   Other possibilities? E.g. cover some pins?
 
 First power up the unit and look at the Status page while moving it around. The
 status screen is part of the :ref:`user_guide:tools` menu.
@@ -611,11 +659,20 @@ The demo mode - it is cloudy, but I like to test my PiFinder anyways
 
 Using the **demo mode** you will be able to run the PiFinder and almost all it's functionality, but not under the stars. Therefore the PiFinder get's an image of the sky from the disc instead from the camera and uses it. You can use all PiFinder commands, like searching for an object, you see the IMU run and you get a "fake" GPS signal. You also can check the PiFinder keyboard and the complete menu cycle. 
 
-The way to get this functionality, is to enter PiFinder in the 'test' or 'debug' mode.
+There are a few ways to enter this 'test' (or 'debug') mode.
 
-First method: Press (short press) **"ENT-A"** again and again to cycle through the screens until you get to the **Console screen**. There press the **"0"** key (the display shows the message "Debug: true"). This will supply a fake GPS lock, time and cause the PiFinder to just solve an image from disk.  But it will respond to IMU movement and allow use of things like Push-To and all the other functions that require a solve/lock. You can leave the "demo mode" by just again cycle to the Console screen and press "0" again (the display shows the message "Debug: false").
+The easiest is from the menu: open **Tools › Test Mode**. This supplies a fake
+GPS lock and time and has the PiFinder solve a stored image from disk instead of
+the camera, while still responding to IMU movement, so Push-To and everything
+else that needs a solve/lock keeps working.
 
-Second method: run PiFinder with the :ref:`dev_guide:Running/Debugging from the command line` functionality.
+You can also toggle it from the keyboard: short-press **ENT-A** repeatedly to
+cycle through the screens until you reach the **Console screen**, then press
+**0** (the display shows "Debug: true"). Press **0** on the Console screen again
+to leave it (the display shows "Debug: false").
+
+Finally, you can start straight into this mode from the command line — see the
+:ref:`dev_guide:Running/Debugging from the command line` section above.
 
 .. note::
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,4 +72,5 @@ Join the `PiFinder Discord server <https://discord.gg/Nk5fHcAtWD>`_ for support 
    skysafari
    dev_guide
    dev_arch
+   api
    BOM


### PR DESCRIPTION
## Summary

Developer-facing documentation updates, plus completion of the previously orphaned JSON API reference page.

### `dev_guide.rst`
- New **"Reference documentation and AI assistant skills"** section covering the in-repo domain model (`CONTEXT-MAP.md`, the `docs/ax` glossaries and deep-dives, ADRs) and the bundled Claude Code skills (`docs`, `grill-with-docs`, `i18n`, `pifinder-remote`).
- Fixed stale/broken content found while reviewing:
  - `git remote add` (was `git add remote`)
  - docs build deps → `pip install -r source/requirements.txt`
  - a `.. tip::` admonition that wasn't rendering (`... tip`)
  - cedar-detect-server path corrected to `bin/` at the repo root
  - added the `ui_tests` nox session to the session list
  - trimmed the rotting pasted `-h` snapshot down to a live invocation + note
  - removed leaked author TODO notes ("Needs an example", "Other possibilities…")
  - fixed `tests/webstite` → `tests/website` typo
  - documented **Tools › Test Mode** as the menu route into demo/test mode

### `dev_arch.rst`
- Added a note pointing to `CONTEXT-MAP.md` and `docs/ax/` for per-context detail.

### `api.rst` (Machine-readable API)
- Completed the page: all 12 live `/api` endpoints documented (verified against `api_extensions.py`), grouped into **Status and data**, **Images**, and **Control**.
- Fixed an inaccurate query param: the page described `source=camera|screen`, but the real param is `use_camera_solve` (boolean).
- Noted that the endpoints are **unauthenticated by default** and return `503` with a JSON `note` when data isn't ready.

### `index.rst`
- Wired `api.rst` into the toctree (it was an orphan page, never published).

## Verification
- `sphinx-build -b html -n source` builds successfully.
- The `api.rst` orphan warning is resolved (clean-build warning count 12 → 11); no new warnings, and no `:ref:`/`:doc:` or rST warnings reference the changed pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)