### PR TITLE
ci: add build-migration-progress workflow

### DIFF
--- a/.github/workflows/build-migration-progress.yml
+++ b/.github/workflows/build-migration-progress.yml
@@ -1,0 +1,59 @@
+name: build-migration-progress
+# Cross-compiles python/scripts/migration_progress.c for aarch64 and attaches
+# the binary + its SHA256 to the release. nixos_migration.sh downloads both
+# at migration time (with hash verification) instead of consuming a pre-built
+# blob from git.
+#
+# Triggers:
+#   - Tag push matching v*-migration   (auto for new migration releases)
+#   - workflow_dispatch with a tag name (re-build for an existing release)
+on:
+  push:
+    tags:
+      - 'v*-migration'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Existing release tag to attach the binary to'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install aarch64 cross-compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Build + strip + sha256
+        working-directory: python/scripts
+        run: |
+          aarch64-linux-gnu-gcc -static -O2 -Wall -o migration_progress migration_progress.c
+          aarch64-linux-gnu-strip migration_progress
+          sha256sum migration_progress | awk '{print $1}' > migration_progress.sha256
+          ls -la migration_progress migration_progress.sha256
+
+      - name: Determine release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: python/scripts
+        run: |
+          gh release upload "${{ steps.tag.outputs.tag }}" \
+            migration_progress migration_progress.sha256 \
+            --clobber


### PR DESCRIPTION
## Summary

Adds `.github/workflows/build-migration-progress.yml`: on a `v*-migration` tag push (or manual `workflow_dispatch` against an existing tag), cross-compiles `python/scripts/migration_progress.c` for aarch64 (`-static -O2`, stripped) and attaches the binary + its SHA256 sidecar to the matching release.

## Why land this separately from #433?

This workflow is the producer side of a change in #433: that PR drops the pre-compiled `migration_progress` ELF from the source tree and expects `nixos_migration.sh` to download + verify it from the release at migration time. The two changes are independent enough to review separately, and there's a practical reason to land this one first:

`workflow_dispatch` requires the workflow file to exist on the default branch to be triggerable. Until this file is on `main`, no one can manually rebuild the artifact for an existing `v*-migration` release tag. Landing this PR makes the dispatcher available even before #433 itself merges.

## Caveat

`migration_progress.c` doesn't yet exist on `main` — it arrives with #433. Until then this workflow is inert (its build step would fail with "no such file" if dispatched against `main`). The intended sequence is: this PR merges first → #433 merges → CI rebuilds the binary on the next migration tag.

## Test plan

- [ ] CI on this PR itself: lints the YAML, no execution.
- [ ] After merge, manually dispatch with a `release_tag=v2.5.0-migration` input from a branch that does have `migration_progress.c` (e.g. the `migration` branch on the fork) — verify the binary lands in the release with the expected SHA256.
