### PR TITLE
Fix: update /etc/hosts when hostname changes (closes #125)

### DIFF
--- a/python/PiFinder/sys_utils.py
+++ b/python/PiFinder/sys_utils.py
@@ -167,6 +167,43 @@ class Network:
         if hostname == self.get_host_name():
             return
         _result = sh.sudo("hostnamectl", "set-hostname", hostname)
+        self._update_etc_hosts(hostname)
+
+    @staticmethod
+    def _rewrite_hosts(contents: str, new_hostname: str) -> str:
+        """
+        Rewrite the Debian-convention ``127.0.1.1`` line in /etc/hosts to point
+        at ``new_hostname``. Preserves indentation, the IP, and any trailing
+        aliases/comments. If no ``127.0.1.1`` line exists, appends one so that
+        ``sudo`` can still resolve the host.
+        """
+        lines = contents.splitlines(keepends=True)
+        pattern = re.compile(r"^(\s*127\.0\.1\.1\s+)\S+(.*)$")
+        replaced = False
+        for i, line in enumerate(lines):
+            match = pattern.match(line)
+            if match:
+                eol = "\n" if line.endswith("\n") else ""
+                lines[i] = f"{match.group(1)}{new_hostname}{match.group(2)}{eol}"
+                replaced = True
+                break
+        if not replaced:
+            if lines and not lines[-1].endswith("\n"):
+                lines[-1] += "\n"
+            lines.append(f"127.0.1.1\t{new_hostname}\n")
+        return "".join(lines)
+
+    def _update_etc_hosts(self, new_hostname: str) -> None:
+        try:
+            with open("/etc/hosts", "r") as hosts_f:
+                contents = hosts_f.read()
+        except IOError as e:
+            logger.error(f"Error reading /etc/hosts: {e}")
+            return
+        new_contents = Network._rewrite_hosts(contents, new_hostname)
+        with open("/tmp/hosts", "w") as new_hosts:
+            new_hosts.write(new_contents)
+        sh.sudo("cp", "/tmp/hosts", "/etc/hosts")
 
     def wifi_mode(self):
         return self._wifi_mode

--- a/python/tests/test_sys_utils.py
+++ b/python/tests/test_sys_utils.py
@@ -67,6 +67,45 @@ try:
         result = sys_utils.Network._parse_wpa_supplicant(wpa_list)
         assert result[1]["psk"] == "1234@===!!!"
 
+    @pytest.mark.unit
+    def test_rewrite_hosts_standard_line():
+        contents = (
+            "127.0.0.1\tlocalhost\n"
+            "::1\t\tlocalhost ip6-localhost ip6-loopback\n"
+            "127.0.1.1\tpifinder\n"
+        )
+        result = sys_utils.Network._rewrite_hosts(contents, "pf-rich")
+        assert "127.0.1.1\tpf-rich\n" in result
+        assert "pifinder" not in result
+        assert "127.0.0.1\tlocalhost\n" in result
+
+    @pytest.mark.unit
+    def test_rewrite_hosts_preserves_aliases_and_spacing():
+        contents = "  127.0.1.1   pifinder pifinder.local  # primary\n"
+        result = sys_utils.Network._rewrite_hosts(contents, "pf-rich")
+        assert result == "  127.0.1.1   pf-rich pifinder.local  # primary\n"
+
+    @pytest.mark.unit
+    def test_rewrite_hosts_appends_when_missing():
+        contents = "127.0.0.1\tlocalhost\n"
+        result = sys_utils.Network._rewrite_hosts(contents, "pf-rich")
+        assert result.endswith("127.0.1.1\tpf-rich\n")
+        assert "127.0.0.1\tlocalhost\n" in result
+
+    @pytest.mark.unit
+    def test_rewrite_hosts_appends_with_missing_trailing_newline():
+        contents = "127.0.0.1\tlocalhost"
+        result = sys_utils.Network._rewrite_hosts(contents, "pf-rich")
+        assert result == "127.0.0.1\tlocalhost\n127.0.1.1\tpf-rich\n"
+
+    @pytest.mark.unit
+    def test_rewrite_hosts_ignores_commented_line():
+        contents = "# 127.0.1.1 oldname\n127.0.0.1\tlocalhost\n"
+        result = sys_utils.Network._rewrite_hosts(contents, "pf-rich")
+        # commented line is untouched; a real 127.0.1.1 entry is appended
+        assert "# 127.0.1.1 oldname\n" in result
+        assert result.endswith("127.0.1.1\tpf-rich\n")
+
 
 except ImportError:
     pass


### PR DESCRIPTION
## Summary
- `Network.set_host_name()` previously only ran `hostnamectl set-hostname`, leaving the Debian-convention `127.0.1.1 <oldname>` line in `/etc/hosts` pointing at the old name. This broke `sudo` (host could not be resolved) and SSH workflows after every hostname change from the web UI.
- Add `_update_etc_hosts()` to rewrite the `127.0.1.1` line in place, preserving indentation, the IP, and any trailing aliases/comments. Appends a fresh `127.0.1.1 <newname>` line if none exists, so the file self-heals on hand-edited hosts files.
- Pure rewrite logic extracted to a `@staticmethod` and unit-tested against five cases (standard Raspbian line, custom whitespace + aliases, missing line, missing trailing newline, commented-out line).

Closes #125.

## Test plan
- [x] `ruff check` clean on touched files
- [x] `mypy PiFinder/sys_utils.py` clean
- [x] Rewrite logic validated standalone against the 5 cases on dev box (existing test file is Linux-only, skipped on macOS via the same `try/except ImportError` pattern as the pre-existing wpa_supplicant tests)
- [x] Verify on real Pi: change hostname via web UI, confirm `/etc/hosts` reflects new name and `sudo` no longer warns

🤖 Generated with [Claude Code](https://claude.com/claude-code)