### PR TITLE
Chart: orientation indicator + flag NCP-up fallback when GPS isn't ready (#419)

### DIFF
--- a/.claude/skills/pifinder-remote/SKILL.md
+++ b/.claude/skills/pifinder-remote/SKILL.md
@@ -99,6 +99,49 @@ the screen is the ground truth, menu order changes between versions.
   a short grace period. `stop` returns as soon as the process is actually gone.
   This guarantees no orphaned processes even when the graceful path stalls.
 
+## Running in a git worktree
+
+A fresh worktree (one created via `git worktree add` or `EnterWorktree`) is
+missing two things PiFinder needs to start, because git worktrees only check
+out tracked files and don't share git-ignored files or submodule contents with
+the main checkout. Copy them in from the main checkout before the first
+`launch`:
+
+1. **Hipparcos catalog** — `astro_data/hip_main.dat` (~53 MB) is git-ignored
+   (see `python/.gitignore`) but required by `UIChart` / `UIAlign`. The chart
+   screen will crash on construction if it's missing.
+2. **`tetra3` submodule** — `python/PiFinder/tetra3/` is a git submodule
+   (`https://github.com/smroid/cedar-solve`). `git submodule update --init`
+   inside a worktree typically fails ("Unable to find current revision in
+   submodule path") because the submodule's git metadata isn't replicated to
+   the worktree. Copying the populated directory in from the main checkout is
+   the reliable path.
+
+Both copies are one-time per worktree. Run from the worktree root:
+
+```bash
+# Adjust MAIN to point at the main checkout (typically three dirs up from a
+# .claude/worktrees/<name>/ worktree).
+MAIN=../../..
+
+cp "$MAIN/astro_data/hip_main.dat" astro_data/
+cp -R "$MAIN/python/PiFinder/tetra3/." python/PiFinder/tetra3/
+```
+
+**Venv:** the worktree has no venv of its own and `pf_remote.py launch` only
+auto-discovers a venv *inside the repo it was invoked from* (`python/venv`,
+`python/.venv`, `.venv`, `venv`) — it does not cross into the main checkout
+to find one. So activate the main checkout's venv in your shell *before*
+launching, so `pf_remote` inherits it via `sys.executable`:
+
+```bash
+source "$MAIN/python/venv/bin/activate"   # or python/.venv if that's where yours is
+```
+
+Alternatively, point `pf_remote.py` at the main checkout with `--repo
+"$MAIN"` so it finds the venv there — but then it also runs PiFinder from
+that checkout, not your worktree, which defeats the purpose.
+
 ## When startup fails
 
 `launch` waits up to `--timeout` seconds (default 90) for the API. The **first**
@@ -108,9 +151,11 @@ launches come up in a few seconds. If it times out:
 1. `python3 $S logs` — read the PiFinder/cedar startup logs.
 2. Confirm the venv exists (`python/venv` or `python/.venv`) and the object DB
    is present (`astro_data/pifinder_objects.db`).
-3. The API binds port 80 when it can, else 8080; `launch` probes both and
+3. If you're in a git worktree, confirm `astro_data/hip_main.dat` and
+   `python/PiFinder/tetra3/` are populated — see "Running in a git worktree".
+4. The API binds port 80 when it can, else 8080; `launch` probes both and
    records the winner. Pass `--base-url http://host:port` to override.
-4. If a previous run left something behind, `python3 $S kill` clears it.
+5. If a previous run left something behind, `python3 $S kill` clears it.
 
 ## Notes
 

--- a/python/PiFinder/ui/align.py
+++ b/python/PiFinder/ui/align.py
@@ -224,12 +224,13 @@ class UIAlign(UIModule):
                 else:
                     chart_center = self.solution["camera_center"]
 
-                chart_rot_angle = get_chart_rotation_angle(
-                    chart_center["RA"], chart_center["Dec"], 
+                orientation = get_chart_rotation_angle(
+                    chart_center["RA"], chart_center["Dec"],
                     chart_coord_sys=self.config_object.get_option("chart_coord_sys"),
-                    location=self.shared_state.location(), 
+                    location=self.shared_state.location(),
                     dt=self.shared_state.datetime()
                 )
+                chart_rot_angle = orientation.rot_deg if orientation else None
                 # This needs to be called first to set RA/DEC/chart_rot_angle
                 image_obj, self.visible_stars = self.starfield.plot_starfield(
                         chart_center["RA"], chart_center["Dec"], chart_rot_angle, 

--- a/python/PiFinder/ui/chart.py
+++ b/python/PiFinder/ui/chart.py
@@ -5,7 +5,10 @@
 This module contains the chart (starfield + constellation lines) UI Module class
 
 """
-from __future__ import annotations  # To support | in typehints (remove this for Python 3.10+)
+
+from __future__ import (
+    annotations,
+)  # To support | in typehints (remove this for Python 3.10+)
 
 import datetime
 import logging
@@ -99,7 +102,7 @@ class UIChart(UIModule):
 
     def _draw_orientation_indicator(self, orientation: "ChartOrientation"):
         """
-        Draw a small "up" indicator at the bottom-right of the chart.
+        Draw a small "up" indicator at the top-left of the chart.
 
         Communicates which orientation the chart is using (NCP / SCP / Zenith)
         and, when GPS hasn't arrived yet but the user picked a GPS-dependent
@@ -112,11 +115,10 @@ class UIChart(UIModule):
             text = "!" + text
         font = self.fonts.base
         # Brighter when fallback so the "!" reads as a hint, not noise.
-        brightness = 255 if orientation.is_fallback else 192
-        text_width = font.width * len(text)
-        x = self.display_class.resX - text_width - 2
-        # Sit just above the optional RA/Dec text row (drawn at y=114).
-        y = 114 - font.height - 1
+        brightness = 255 if orientation.is_fallback else 128
+        x = 2
+        # Sit just below the title bar
+        y = self.display_class.titlebar_height + 1
         self.draw.text(
             (x, y),
             text,
@@ -192,10 +194,11 @@ class UIChart(UIModule):
             elif self.solution_is_new(last_solve_time):
                 # Solution is new so plot the updated chart
                 orientation = get_chart_rotation_angle(
-                    self.solution["RA"], self.solution["Dec"],
+                    self.solution["RA"],
+                    self.solution["Dec"],
                     chart_coord_sys=self.config_object.get_option("chart_coord_sys"),
                     location=self.shared_state.location(),
-                    dt=self.shared_state.datetime()
+                    dt=self.shared_state.datetime(),
                 )
                 chart_rot_angle = orientation.rot_deg if orientation else None
                 # This needs to be called first to set RA/DEC/chart_rot_angle
@@ -277,10 +280,7 @@ class UIChart(UIModule):
             return False
         if last_solve_time <= self.last_update:
             return False
-        if (
-            self.solution["RA"] is None
-            or self.solution["Dec"] is None
-        ):
+        if self.solution["RA"] is None or self.solution["Dec"] is None:
             return False
 
         return True  # Solution is valid and new
@@ -307,7 +307,6 @@ class UIChart(UIModule):
         self.update()
 
 
-
 @dataclass
 class ChartOrientation:
     """
@@ -323,6 +322,7 @@ class ChartOrientation:
       orientation that will change once GPS arrives. The chart UI surfaces
       this so the user isn't startled by the orientation flip.
     """
+
     rot_deg: float
     up_label: str
     is_fallback: bool
@@ -360,7 +360,9 @@ def get_chart_rotation_angle(
 
     if chart_coord_sys == "horiz":
         if has_gps and dt:
-            calc_utils.sf_utils.set_location(location.lat, location.lon, location.altitude)
+            calc_utils.sf_utils.set_location(
+                location.lat, location.lon, location.altitude
+            )
             # Use -parallactic_angle
             rot_deg = -calc_utils.sf_utils.radec_to_pa(ra_deg, dec_deg, dt)
             return ChartOrientation(rot_deg, "Zenith", False)
@@ -379,5 +381,7 @@ def get_chart_rotation_angle(
     if chart_coord_sys == "eq_south_up":
         return ChartOrientation(180.0, "SCP", False)
 
-    logger.error(f"Unknown chart coordinate system: {chart_coord_sys}. Defaulting to EQ North-up.")
+    logger.error(
+        f"Unknown chart coordinate system: {chart_coord_sys}. Defaulting to EQ North-up."
+    )
     return ChartOrientation(0.0, "NCP", False)

--- a/python/PiFinder/ui/chart.py
+++ b/python/PiFinder/ui/chart.py
@@ -10,6 +10,7 @@ from __future__ import annotations  # To support | in typehints (remove this for
 import datetime
 import logging
 import time
+from dataclasses import dataclass
 from PIL import ImageChops, Image
 
 from PiFinder.ui.marking_menus import MarkingMenuOption, MarkingMenu
@@ -96,6 +97,33 @@ class UIChart(UIModule):
             )
             self.screen.paste(ImageChops.add(self.screen, marker_image))
 
+    def _draw_orientation_indicator(self, orientation: "ChartOrientation"):
+        """
+        Draw a small "up" indicator at the bottom-right of the chart.
+
+        Communicates which orientation the chart is using (NCP / SCP / Zenith)
+        and, when GPS hasn't arrived yet but the user picked a GPS-dependent
+        mode, prefixes a "!" so the user knows the orientation will flip
+        once GPS comes online.
+        """
+        # TRANSLATORS: chart corner label, e.g. "Zenith up" — keep short
+        text = _("{label} up").format(label=orientation.up_label)
+        if orientation.is_fallback:
+            text = "!" + text
+        font = self.fonts.base
+        # Brighter when fallback so the "!" reads as a hint, not noise.
+        brightness = 255 if orientation.is_fallback else 192
+        text_width = font.width * len(text)
+        x = self.display_class.resX - text_width - 2
+        # Sit just above the optional RA/Dec text row (drawn at y=114).
+        y = 114 - font.height - 1
+        self.draw.text(
+            (x, y),
+            text,
+            font=font.font,
+            fill=self.colors.get(brightness),
+        )
+
     def draw_reticle(self):
         """
         draw the reticle if desired
@@ -163,12 +191,13 @@ class UIChart(UIModule):
                 self.plot_no_solve()
             elif self.solution_is_new(last_solve_time):
                 # Solution is new so plot the updated chart
-                chart_rot_angle = get_chart_rotation_angle(
-                    self.solution["RA"], self.solution["Dec"], 
+                orientation = get_chart_rotation_angle(
+                    self.solution["RA"], self.solution["Dec"],
                     chart_coord_sys=self.config_object.get_option("chart_coord_sys"),
-                    location=self.shared_state.location(), 
+                    location=self.shared_state.location(),
                     dt=self.shared_state.datetime()
                 )
+                chart_rot_angle = orientation.rot_deg if orientation else None
                 # This needs to be called first to set RA/DEC/chart_rot_angle
                 image_obj, _visible_stars = self.starfield.plot_starfield(
                     self.solution["RA"],
@@ -182,6 +211,8 @@ class UIChart(UIModule):
                 self.screen.paste(image_obj)
 
                 self.plot_markers()
+                if orientation is not None:
+                    self._draw_orientation_indicator(orientation)
 
                 # Display RA/DEC in selected format if enabled
                 if self.config_object.get_option("chart_radec") == "HH:MM":
@@ -277,50 +308,76 @@ class UIChart(UIModule):
 
 
 
+@dataclass
+class ChartOrientation:
+    """
+    Resolved chart rotation plus what's "up" on screen.
+
+    - ``rot_deg`` is the angle to rotate the chart by (the value previously
+      returned bare by ``get_chart_rotation_angle``).
+    - ``up_label`` is a short string describing what's at the top of the
+      chart: ``"NCP"`` / ``"SCP"`` / ``"Zenith"``.
+    - ``is_fallback`` is True when the user picked an orientation mode that
+      needs GPS (horizontal, or eq-auto in the southern hemisphere) but GPS
+      data isn't available yet, so the chart is showing a default NCP-up
+      orientation that will change once GPS arrives. The chart UI surfaces
+      this so the user isn't startled by the orientation flip.
+    """
+    rot_deg: float
+    up_label: str
+    is_fallback: bool
+
+
 def get_chart_rotation_angle(
     ra_deg: float,  # Right Ascension of the target in degrees
     dec_deg: float,  # Declination of the target in degrees
     chart_coord_sys: str,
     location=None,
     dt: datetime.datetime | None = None,
-) -> float:
+) -> ChartOrientation | None:
     """
-    Returns angle (in degrees) to rotate the chart by depending on the 
-    configured chart coordinate system. This was previously called "roll". 
-    Chart will be plotted rotated around (RA, Dec); +ve means anti-clockwise 
-    rotation. The RA and Dec of the target should be provided (in degrees).
+    Returns the rotation and "up" orientation for the chart, depending on
+    the configured chart coordinate system. The rotation was previously
+    called "roll": the chart is plotted rotated around (RA, Dec); +ve means
+    anti-clockwise rotation. The RA and Dec of the target must be provided
+    (in degrees); returns ``None`` if either is missing.
 
-    * horiz: Display the chart in the horizontal coordinate so that up in the
-    chart points to the Zenith.
-    * EQ (Auto): Display the chart in the equatorial coordinate system.
-    Automatically select NCP or SCP-up based on location.
-    * EQ (North-up), EQ (South-up): Display chart in the equatorial coordinate
-    system with NCP or SCP up.
+    Modes:
+
+    * horiz: Display the chart in horizontal coordinates so up points at
+      the Zenith. Needs a GPS location and a datetime; without either,
+      falls back to NCP up and flags ``is_fallback=True``.
+    * EQ (Auto): Display the chart in equatorial coordinates, NCP-up in
+      the northern hemisphere and SCP-up in the southern. Without GPS
+      location, defaults to NCP up and flags ``is_fallback=True``.
+    * EQ (North-up), EQ (South-up): Display the chart with NCP or SCP up.
+      Never a fallback — explicit user choice.
     """
     if (ra_deg is None) or (dec_deg is None):
         return None  # Can't calculate without RA/Dec
 
+    has_gps = bool(location and getattr(location, "lock", False))
+
     if chart_coord_sys == "horiz":
-        # Horizontal coordinates (alt/az):
-        if location and dt:
+        if has_gps and dt:
             calc_utils.sf_utils.set_location(location.lat, location.lon, location.altitude)
             # Use -parallactic_angle
             rot_deg = -calc_utils.sf_utils.radec_to_pa(ra_deg, dec_deg, dt)
-        else:
-            # No position or time/date available. Default to display in equatorial coordinate
-            rot_deg = 0.0  # NCP up
-    elif chart_coord_sys == "eq_auto":
-        # Equatorial coordinates: (North-up/south-up depending on latitude)
-        rot_deg = 0.0  # NCP up (default & northern hemisphere)
-        if location:
+            return ChartOrientation(rot_deg, "Zenith", False)
+        # No location/time: default to NCP up but flag as a fallback so
+        # the UI can show that the orientation will change once GPS arrives.
+        return ChartOrientation(0.0, "NCP", True)
+    if chart_coord_sys == "eq_auto":
+        if has_gps:
             if location.lat < 0.0:
-                rot_deg = 180.0  # SCP up (for southern hemisphere)
-    elif chart_coord_sys == "eq_north_up":
-        rot_deg = 0.0
-    elif chart_coord_sys == "eq_south_up":
-        rot_deg = 180.0
-    else:
-        logger.error(f"Unknown chart coordinate system: {chart_coord_sys}. Defaulting to EQ North-up.")
-        rot_deg = 0.0  # NCP up
+                return ChartOrientation(180.0, "SCP", False)
+            return ChartOrientation(0.0, "NCP", False)
+        # No location: northern-hemisphere default, but flag as fallback.
+        return ChartOrientation(0.0, "NCP", True)
+    if chart_coord_sys == "eq_north_up":
+        return ChartOrientation(0.0, "NCP", False)
+    if chart_coord_sys == "eq_south_up":
+        return ChartOrientation(180.0, "SCP", False)
 
-    return rot_deg
+    logger.error(f"Unknown chart coordinate system: {chart_coord_sys}. Defaulting to EQ North-up.")
+    return ChartOrientation(0.0, "NCP", False)

--- a/python/tests/test_chart.py
+++ b/python/tests/test_chart.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for ``get_chart_rotation_angle`` and the orientation result it
+returns. The function decides what "up" the chart shows, and flags
+``is_fallback=True`` when the user selected a GPS-dependent mode but no
+location lock is available yet (see issue #419).
+"""
+
+import pytest
+
+# Installs the ``_()`` gettext builtin that PiFinder.ui modules rely on.
+import PiFinder.i18n  # noqa: F401
+
+from PiFinder.state import Location
+from PiFinder.ui.chart import ChartOrientation, get_chart_rotation_angle
+
+
+def _no_gps():
+    return Location(lat=0.0, lon=0.0, altitude=0.0, lock=False)
+
+
+def _gps_at(lat, lon=0.0, altitude=0.0):
+    return Location(lat=lat, lon=lon, altitude=altitude, lock=True)
+
+
+@pytest.mark.unit
+class TestGetChartRotationAngle:
+    def test_returns_none_when_radec_missing(self):
+        assert get_chart_rotation_angle(None, 0.0, "eq_north_up") is None
+        assert get_chart_rotation_angle(0.0, None, "eq_north_up") is None
+
+    def test_eq_north_up_is_explicit_ncp(self):
+        result = get_chart_rotation_angle(10.0, 20.0, "eq_north_up")
+        assert result == ChartOrientation(0.0, "NCP", False)
+
+    def test_eq_south_up_is_explicit_scp(self):
+        result = get_chart_rotation_angle(10.0, 20.0, "eq_south_up")
+        assert result == ChartOrientation(180.0, "SCP", False)
+
+    def test_eq_auto_northern_with_gps(self):
+        result = get_chart_rotation_angle(
+            10.0, 20.0, "eq_auto", location=_gps_at(lat=45.0)
+        )
+        assert result == ChartOrientation(0.0, "NCP", False)
+
+    def test_eq_auto_southern_with_gps(self):
+        result = get_chart_rotation_angle(
+            10.0, 20.0, "eq_auto", location=_gps_at(lat=-33.0)
+        )
+        assert result == ChartOrientation(180.0, "SCP", False)
+
+    def test_eq_auto_no_gps_falls_back_to_ncp(self):
+        # No location lock yet: northern-hemisphere default, but flagged.
+        result = get_chart_rotation_angle(
+            10.0, 20.0, "eq_auto", location=_no_gps()
+        )
+        assert result == ChartOrientation(0.0, "NCP", True)
+
+    def test_eq_auto_lockless_location_object_is_fallback(self):
+        # A Location with lock=False should be treated the same as missing.
+        result = get_chart_rotation_angle(
+            10.0, 20.0, "eq_auto", location=_no_gps(), dt=None
+        )
+        assert result.is_fallback is True
+
+    def test_horiz_no_gps_falls_back_to_ncp(self):
+        result = get_chart_rotation_angle(
+            10.0, 20.0, "horiz", location=_no_gps(), dt=None
+        )
+        assert result == ChartOrientation(0.0, "NCP", True)
+
+    def test_horiz_with_gps_no_datetime_falls_back(self):
+        # Locked location but no datetime: still a fallback because parallactic
+        # angle needs both.
+        result = get_chart_rotation_angle(
+            10.0, 20.0, "horiz", location=_gps_at(lat=45.0), dt=None
+        )
+        assert result == ChartOrientation(0.0, "NCP", True)
+
+    def test_horiz_with_gps_and_datetime_is_zenith(self):
+        import datetime as _dt
+
+        result = get_chart_rotation_angle(
+            10.0, 20.0, "horiz",
+            location=_gps_at(lat=45.0, lon=-75.0, altitude=100.0),
+            dt=_dt.datetime(2024, 6, 1, 22, 0, 0, tzinfo=_dt.timezone.utc),
+        )
+        assert result is not None
+        assert result.up_label == "Zenith"
+        assert result.is_fallback is False
+        # Rotation should be a finite number for a real horiz computation.
+        assert isinstance(result.rot_deg, float)
+
+    def test_unknown_mode_defaults_to_ncp_without_fallback(self):
+        result = get_chart_rotation_angle(10.0, 20.0, "nonsense-mode")
+        assert result == ChartOrientation(0.0, "NCP", False)


### PR DESCRIPTION
Closes #419.

## Summary

- The chart used to silently fall back to NCP up when the user picked Horizontal or EQ (Auto) but no GPS lock was available, then flip to the real orientation once GPS arrived. Since `"horiz"` is the shipped default (`default_config.json:19`), this is the normal first-run experience and was confusing.
- Adds a small bottom-right label on the Chart screen showing what's at the top of the chart — `Zenith up`, `NCP up`, or `SCP up` — so the user can always see the current orientation.
- When the resolved orientation is a fallback (Horizontal or EQ-Auto chosen but no GPS lock yet), the label is prefixed with `!` and rendered at higher brightness, flagging that the chart will reorient once GPS comes online.

## Changes

- `python/PiFinder/ui/chart.py`
  - New `ChartOrientation` dataclass (`rot_deg`, `up_label`, `is_fallback`).
  - `get_chart_rotation_angle` now returns it. Resolution is unchanged for `eq_north_up` / `eq_south_up` and for the GPS-locked branches of `horiz` / `eq_auto`. The lockless `horiz` and `eq_auto` branches now use `location.lock` (matching the canonical `altaz_ready()` test in `state.py`) and set `is_fallback=True` so the UI can flag the NCP-up default as transient.
  - `UIChart.update` draws the label after the chart paste.
- `python/PiFinder/ui/align.py` — caller updated to unpack `rot_deg` from the new return type. No behavior change for the align screen itself.
- `python/tests/test_chart.py` — new file, 11 unit tests covering each coord-sys × GPS-present/absent case plus the None RA/Dec path.
- `.claude/skills/pifinder-remote/SKILL.md` — documents the two one-time worktree-setup steps the headless launcher needs but git worktrees don't inherit (copy the Hipparcos catalog and the `tetra3` submodule contents in from the main checkout), plus the venv-activation requirement so the launcher's `find_python` picks up the main checkout's interpreter via `sys.executable`.

## Test plan

- [x] `pytest -m unit tests/test_chart.py` — 11 new tests pass.
- [x] `pytest -m unit` overall — 159 tests pass (148 pre-existing + 11 new).
- [x] `ruff check` clean on `chart.py`, `align.py`, `test_chart.py`.
- [x] Live UI: launched headless from a fresh worktree, navigated to Chart, screenshot shows `Zenith up` rendered at bottom-right alongside the optional RA/Dec line at bottom-left. (Headless `--camera debug` provides a fake GPS lock, so the rendered case is the non-fallback path; the `!NCP up` fallback rendering goes through the same code with different text + brightness — both unit-tested.)
- [x] On-device confirmation: power up indoors (or otherwise pre-lock) with default config (`chart_coord_sys = "horiz"`), open Chart, confirm `!NCP up` shows immediately, then `Zenith up` after GPS lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)