### PR TITLE
Docs: require agent worktrees to be rooted on main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Note: the auto-detected "Main branch" shown in the Claude Code env block may currently read `release` (because the GitHub default branch points there). Disregard that — the rule above is authoritative for this repo.
 
+### Agent worktrees
+
+Worktrees must be rooted on **`main`**. The harness's `fresh` base resolves to this clone's `origin/HEAD`, which may point at `release` (the GitHub default) — in which case `EnterWorktree` lands on `release`, not `main`. CLAUDE.md cannot change this; it is decided by the harness before any instruction here is read.
+
+After `EnterWorktree`, **verify the base before making changes**: if `git merge-base HEAD origin/main` does not equal `origin/main`'s tip, the worktree is on the wrong branch — run `git reset --hard origin/main` and proceed from there.
+
+Maintainers can make `fresh` root on `main` automatically per clone (without changing GitHub's default branch) by repointing the local default-branch pointer:
+
+```bash
+git remote set-head origin main
+```
+
 ## Development Commands
 
 **Running Python**


### PR DESCRIPTION
## Why

Agent worktrees created via `EnterWorktree` use a `fresh` base that resolves to this clone's `origin/HEAD`. In this repo that pointer is `origin/release` (the GitHub default branch), so worktrees can land on **`release`** rather than **`main`** — contrary to the Branch Model rule that all work branches off `main`.

CLAUDE.md cannot change the base (it's decided by the harness before any instruction is read), so this documents the recovery step and the per-clone fix.

## Changes

Adds an **Agent worktrees** subsection to the Branch Model in `CLAUDE.md`:
- Agents must verify the base after `EnterWorktree` and `git reset --hard origin/main` if it landed on `release`.
- Maintainers can make `fresh` root on `main` per clone (without changing GitHub's default) via `git remote set-head origin main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)