### PR TITLE
Clarify Cedar Detect licensing + add bin/ license and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,20 @@ A plate solving telescope finder based around a Raspberry PI, imx296 camera, and
 
 For an overview of what the PiFinder™ is and how it came to be visit the official project website at [PiFinder.io](https://www.pifinder.io/build-yours) 
 
-The PiFinder™ uses the [Ceder Detect](https://github.com/smroid/cedar-detect) and
-[Cedar Solve](https://github.com/smroid/cedar-solve) libraries with express permission.
-Thank you to [smroid] for all your support of the PiFinder project!
+The PiFinder™ uses the [Cedar Detect](https://github.com/smroid/cedar-detect) and
+[Cedar Solve](https://github.com/smroid/cedar-solve) libraries by
+[smroid](https://github.com/smroid). Cedar Solve is licensed under Apache-2.0.
+
+**Cedar Detect** is published under the Functional Source License (`FSL-1.1-MIT`),
+which permits broad non-commercial use but excludes commercial uses that compete
+with Cedar Detect. Because the PiFinder™ is also offered commercially, it bundles
+and distributes the Cedar Detect binaries under a **separate license granted
+expressly by the copyright holder** — not under the public FSL terms. The prebuilt
+binaries live in [`bin/`](./bin/); see [`bin/README.md`](./bin/README.md) for the
+full licensing details and a copy of the Cedar Detect license. Note this is
+distinct from the PiFinder project's own GPL-3.0 [`LICENSE`](./LICENSE).
+
+Thank you to [smroid](https://github.com/smroid) for all your support of the PiFinder project!
 
 ![Banner](./docs/source/images/PiFinder_v3_banner.png)
 The PiFinder™ is my attempt to improve my time at my telescope.  I don't get nearly enough of it and I want to enjoy it as much as possible.  So after years of observing with paper charts and, later, a Nexus DSC here is what I felt I was missing:

--- a/bin/LICENSE-cedar-detect.md
+++ b/bin/LICENSE-cedar-detect.md
@@ -1,0 +1,117 @@
+## Notice
+
+Copyright 2025 Steven Rosenthal smr@dt3.org
+
+All files in this directory (and subdirectories thereof) are subject
+to the license terms described in this file.
+
+The Software is available to be licensed under different terms; please
+contact the copyright holder (Steven Rosenthal smr@dt3.org) to discuss.
+
+
+# Functional Source License, Version 1.1, MIT Future License
+
+## Abbreviation
+
+FSL-1.1-MIT
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the MIT license that is effective on the fifth anniversary of the date we make
+the Software available. On or after that date, you may use the Software under
+the MIT license, in which case the following will apply:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,60 @@
+# Cedar Detect binaries
+
+This directory contains prebuilt **Cedar Detect** server binaries that the
+PiFinder uses for star detection during plate solving:
+
+| File | Platform |
+|------|----------|
+| `cedar-detect-server-aarch64` | 64-bit ARM (`aarch64`) |
+| `cedar-detect-server-arm64`   | 64-bit ARM (`arm64`)   |
+
+At runtime PiFinder launches the binary matching the host architecture as a
+local gRPC server (see the application startup notes in the project `CLAUDE.md`).
+
+## Source
+
+Cedar Detect is developed by Steven Rosenthal (**[smroid](https://github.com/smroid)**):
+
+- Repository: <https://github.com/smroid/cedar-detect>
+
+These binaries are built from that source and bundled here for convenience so
+that PiFinder runs out of the box without a separate build step.
+
+## License
+
+Cedar Detect is published under the **Functional Source License, Version 1.1,
+MIT Future License (`FSL-1.1-MIT`)**. A verbatim copy of that license, including
+the upstream copyright notice, is kept alongside the binaries in
+[`LICENSE-cedar-detect.md`](./LICENSE-cedar-detect.md).
+
+In summary, the FSL grants broad rights to use, modify, and redistribute the
+software for any *Permitted Purpose* — which includes internal use, and
+non-commercial education and research — but **excludes a "Competing Use"**: making
+the software available in a commercial product or service that substitutes for, or
+offers substantially similar functionality to, Cedar Detect. (The license also
+converts to the permissive MIT license five years after each version is released.)
+
+> **Note:** This `FSL-1.1-MIT` license applies to **Cedar Detect** (the binaries in
+> this directory). It is **separate from the GPL-3.0 license** that covers the
+> PiFinder project itself (see the [`LICENSE`](../LICENSE) file in the repository
+> root).
+
+## PiFinder's commercial use is by express, separate permission
+
+Because PiFinder is also offered as a commercial product, bundling and
+distributing Cedar Detect with it falls outside the FSL's Permitted Purpose. The
+PiFinder project does this under a **separate license granted expressly by the
+copyright holder**, Steven Rosenthal — not under the public FSL-1.1-MIT terms.
+
+The FSL itself anticipates this: *"The Software is available to be licensed under
+different terms; please contact the copyright holder (Steven Rosenthal
+smr@dt3.org) to discuss."* This separate grant covers the PiFinder project's use
+only; it does not extend the right to commercial/competing use to anyone else
+redistributing these binaries.
+
+If you fork or redistribute PiFinder commercially, you are responsible for your
+own compliance with the FSL-1.1-MIT terms or for arranging your own license with
+the copyright holder.
+
+Our thanks to [smroid](https://github.com/smroid) for supporting the PiFinder
+project.


### PR DESCRIPTION
## Summary

Makes the **Cedar Detect** licensing situation explicit. Cedar Detect (the prebuilt server binaries in `bin/`) is published under the **Functional Source License (`FSL-1.1-MIT`)**, which excludes commercial/competing use. Because PiFinder is also offered commercially, it bundles and ships these binaries under a **separate license granted expressly by the copyright holder** (Steven Rosenthal / [smroid](https://github.com/smroid)), not under the public FSL terms. The FSL itself invites this: *"The Software is available to be licensed under different terms; please contact the copyright holder."*

## Changes

- **`README.md`** — Distinguish the two upstream libraries: Cedar Solve is **Apache-2.0** (permissive), Cedar Detect is **FSL-1.1-MIT**. State that PiFinder's commercial bundling of Cedar Detect is by express separate permission, and link to `bin/`. Also fixes the "Ceder" typo and the broken `[smroid]` markdown link in the same paragraph.
- **`bin/README.md`** (new) — Describes the two binaries (`aarch64` / `arm64`), links to the upstream repo, and explains the FSL terms vs. PiFinder's separate commercial grant. Notes the distinction from the project's own GPL-3.0 license.
- **`bin/LICENSE-cedar-detect.md`** (new) — Verbatim copy of the upstream Cedar Detect license (FSL-1.1-MIT), including the copyright notice. The FSL's redistribution clause requires including a copy of (or link to) the terms and retaining copyright notices; this satisfies it.

## Notes

- The verbatim license was downloaded directly from the upstream repo (`smroid/cedar-detect@master/LICENSE.md`) rather than transcribed.
- FSL-1.1-MIT is more precisely "source-available, no competing/commercial use" rather than strictly "non-commercial" — the wording reflects that (it permits internal/educational/research use). Happy to adjust the framing if you'd prefer it phrased differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)