### PR TITLE
Docs: lean-pass rewrite of the user manual + succinct tone guidance

### DIFF
--- a/.claude/skills/docs/SKILL.md
+++ b/.claude/skills/docs/SKILL.md
@@ -83,18 +83,28 @@ discrepancy.
 
 The manual is written warmly and directly, but it stays measured and
 professional — clear guidance from someone who knows the instrument well, not
-breezy chat. Match it:
+breezy chat. It is also **lean**: the reader is usually at the eyepiece in the
+dark, so every sentence earns its place. Keep the warmth, cut the padding. Match
+it:
 
 - **Talk to the reader as "you."** "You'll then see the Main Menu appear."
 - **Be warm but measured.** Keep the tone calm and confident rather than
   breathless. Reserve exclamation points for the rare genuinely delightful
   moment and prefer plain, declarative sentences the rest of the time.
+- **Be succinct.** Say it once, in as few words as carry the meaning. Cut
+  throat-clearing ("In order to…", "You should note that…"), redundant
+  restatement, and hedging. Favour the active voice and concrete verbs. When a
+  procedure runs to more than two or three ordered steps, prefer a numbered list
+  over a chain of "To begin… Next… Once you have…" paragraphs.
 - **Write complete sentences; don't open with a conjunction.** Never begin a
   sentence with "And" — join the thought to the sentence before it, or rephrase.
   The same goes for opening with "But" or "So."
-- **Explain the *why*, not just the *what*.** The existing docs constantly say
-  things like "This helps save battery power and can prevent glare at the
-  eyepiece." A reader who understands the reason trusts the instruction.
+- **Explain the *why*, but compress it.** A reader who understands the reason
+  trusts the instruction, so keep the *why* — but state it in a clause, not a
+  paragraph. "The PiFinder dims the screen after a while to save battery and
+  prevent glare" earns its keep; a three-sentence aside reassuring the reader
+  that this is normal usually does not. When a caveat genuinely needs more room,
+  put it in a `.. note::` rather than swelling the main flow.
 - **Plain language over jargon.** When a technical term is unavoidable (plate
   solving, alt/az), define it in passing the first time, the way the quick start
   glosses "plate solving" as taking continuous pictures and comparing them.

--- a/docs/source/build_guide.rst
+++ b/docs/source/build_guide.rst
@@ -6,71 +6,69 @@ Build Guide
 Introduction and Overview
 =================================
 
-Welcome to the PiFinder build guide!  This guide is split into three main parts, one for building the :ref:`UI Board<build_guide:pifinder ui hat>` with Screen and Buttons, a section related to :ref:`3d printing<build_guide:printed parts>` and preparing the case parts, and one for :ref:`final assembly<build_guide:assembly>`.   Along with these sections, please consult the :doc:`Bill of Materials<BOM>` for a full list of parts required and reach out with any questions via `email <mailto:info@pifinder.io>`_ or `discord <https://discord.gg/Nk5fHcAtWD>`_
+Welcome to the PiFinder build guide. It's split into three main parts: building the :ref:`UI Board<build_guide:pifinder ui hat>` with its screen and buttons, :ref:`3d printing<build_guide:printed parts>` and preparing the case parts, and :ref:`final assembly<build_guide:assembly>`. Alongside these, consult the :doc:`Bill of Materials<BOM>` for the full parts list, and reach out with any questions via `email <mailto:info@pifinder.io>`_ or `discord <https://discord.gg/Nk5fHcAtWD>`_
 
 
 PiFinder UI Hat
 ========================
 
-A key part of the PiFinder is a custom 'Hat' which matches the general form factor of the Raspberry Pi and connects to its GPIO header.  It contains the switches, screen and Inertial Measurement Unit along with keypad backlight components
+A key part of the PiFinder is a custom 'Hat' that matches the general form factor of the Raspberry Pi and connects to its GPIO header. It carries the switches, screen, Inertial Measurement Unit, and the keypad backlight components.
 
-It's all through-hole components, so should be approachable to even beginners... but the component build order is important as some items block access to others.
+Everything is through-hole, so this is approachable even for beginners. The build order matters, though, as some components block access to others.
 
-There are still some older photos here from the v1 non-backlit board, but the assembly is the same once the backlight components are in place.
+Some photos here still show the v1 non-backlit board, but the assembly is the same once the backlight components are in place.
 
-You'll need the TWO pcb's to start with.  One contains the electronic components and the other has the shine-through legends and goes on top of the assembled board at the end.  You can find the gerber files for both in the main `PiFinder git repo <https://github.com/brickbots/PiFinder/tree/release/gerbers>`_
+You'll need the TWO PCBs to start. One holds the electronic components; the other carries the shine-through legends and goes on top of the assembled board at the end. Gerber files for both are in the main `PiFinder git repo <https://github.com/brickbots/PiFinder/tree/release/gerbers>`_
 
 Backlight Components
 ------------------------
 
-I like to start with the LEDs.  They sit close to the board and doing them first makes it 
-easier to make sure they are all aligned.  
+Start with the LEDs. They sit close to the board, and doing them first makes it easier to keep them aligned.
 
 .. image:: images/build_guide/ui_module_1.jpeg
 
 
-Polarity matters here, so mind the direction.  The longer lead of the LED should go through the round hole in the footprint.  The photo below shows the orientation
+Polarity matters, so mind the direction. The longer lead of the LED goes through the round hole in the footprint. The photo below shows the orientation.
 
 .. image:: ../../images/build_guide/led_build_03.jpeg
 
-Take your time and make sure each is positioned well.  They should be pretty uniform, but little inconsistencies don't matter too much.  I like to place them all in the board, and then tape them in place.
+Position each one carefully. They should be fairly uniform, though small inconsistencies don't matter much. Place them all in the board, then tape them in place.
 
 .. image:: images/build_guide/ui_module_2.jpeg
 
 .. image:: images/build_guide/ui_module_3.jpeg
 
-Pull the legs straight and solder one of each LED.  Then remove the tape and check them again.  If any
-are wildly out of place, you can heat up the solder on the one leg and adjust.  
+Pull the legs straight and solder one leg of each LED. Remove the tape and check again. If any are wildly out of place, reheat that one joint and adjust.
 
 .. image:: images/build_guide/ui_module_4.jpeg
 
-When satisfied, solder the remaining legs and clip the leads up to a single pair. In the next section we are now going to check if the LEDs work before moving on. If you leave a pair of legs long, you can use them to power the backlight for testing.
+When satisfied, solder the remaining legs and clip the leads down to a single pair. We'll check the LEDs in the next section before moving on, so leave one pair of legs long to power the backlight for testing.
 
 .. image:: images/build_guide/ui_module_5.jpeg
 
-The two resistors and transistor are next.  R2 is the vertical oriented 330ohm part and R1 is the 22ohm oriented horizontally.  Direction does not matter with these, but it's important for the transistor. Check the photo below for orientation and make sure this is bent flat against the PCB and the resistors are low.  Solder them from the back and clip the leads once you've verified they look good.
+The two resistors and the transistor are next. R2 is the vertical 330 ohm part; R1 is the 22 ohm part oriented horizontally. Direction doesn't matter for the resistors, but it does for the transistor. Check the photo below for orientation, and make sure the transistor sits flat against the PCB and the resistors are low. Solder from the back and clip the leads once they look good.
 
 .. image:: images/build_guide/ui_module_6a.jpeg
 
 Testing the Backlight
 ______________________________________
 
-Using a CR2032 (any 3V coin cell will do) battery, you can test the backlight now (and LEDs).  Connect the positive part of the battery to the longer pin of LED and the negative part of the battery to the shorter pin, as demonstrated in the following picture with a single LED. This also works with all the LEDs as they are connected in parallel on the board. Once you connect the battery, all the LEDs should light up: 
+Test the backlight (and LEDs) now using any 3V coin cell, such as a CR2032. Connect the positive side of the battery to the longer pin of an LED and the negative side to the shorter pin, as shown below with a single LED. This works for all the LEDs at once since they're wired in parallel on the board. Once connected, every LED should light up:
 
 .. image:: images/build_guide/test_leds_1.jpeg
 
-Replace the LEDs, which are not working properly before proceeding.
+Replace any LEDs that aren't working properly before proceeding.
 
 Switches
 ------------------------
 
-Switches are easy and can go next.  Place each one on a footprint and press it down fully.  Once they are all inserted, before you start soldering visually inspect them for any that are tilted.  
+Switches go next. Place each one on its footprint and press it down fully. Before soldering, visually inspect them for any that are tilted.
 
 
 .. image:: images/build_guide/ui_module_6b.jpeg
 
 
-It's also a good idea to place the top legend plate over them to make sure they all clear the holes properly.  Then solder them up!  You don't need to clip the leads on all the switches, they have plenty of room.
+It's also worth placing the top legend plate over them to confirm they all clear the holes properly. Then solder them up. You don't need to clip the leads on the switches; they have plenty of room.
 
 .. image:: images/build_guide/ui_module_6c.jpeg
 
@@ -78,24 +76,23 @@ It's also a good idea to place the top legend plate over them to make sure they 
 Headers
 ---------
 
-I like to do all the headers next.  These will eventually receive the IMU, GPS and Screen.  The procedure is roughly the same for 
-all three: Insert them, solder one pin, check that they are flat and straight and then solder the rest of the pins.  Clip them flush and apply some insulating tape.  
+Do the headers next. These will receive the IMU, GPS, and Screen. The procedure is the same for all three: insert the header, solder one pin, check that it's flat and straight, then solder the rest. Clip the pins flush and apply some insulating tape.
 
-Start with the IMU header.  It goes on the underside of the board and is soldered from the top
+Start with the IMU header. It goes on the underside of the board and is soldered from the top.
 
 .. image:: images/build_guide/ui_module_7.jpeg
 
 .. image:: images/build_guide/ui_module_8.jpeg
 
-Apply the insulating tape and move on to the screen header.  It goes in from the top side:
+Apply the insulating tape and move on to the screen header, which goes in from the top side:
 
 .. image:: images/build_guide/ui_module_9.jpeg
 
-Trim the pins and tape it up
+Trim the pins and tape it up.
 
 .. image:: images/build_guide/ui_module_10.jpeg
 
-The GPS header is next. The modules come with a yellow header, but any will do.  It gets inserted from the bottom, soldered and taped liked the rest.
+The GPS header is next. The modules ship with a yellow header, but any will do. It inserts from the bottom, then gets soldered and taped like the rest.
 
 .. image:: images/build_guide/ui_module_11.jpeg
 
@@ -105,14 +102,14 @@ The GPS header is next. The modules come with a yellow header, but any will do. 
 IMU
 ------------------------
 
-The Inertial Measurement unit is next.  The IMU has an annoyingly bright green LED on it, which you will either want to paint over with a few layers of black nail polish, or you can use your soldering iron to destroy it.  It can be handled  after it's soldered if you forget, but it's much easier beforehand.  See the image below to ID the offending component.
+The Inertial Measurement Unit is next. It has an annoyingly bright green LED that you'll want to either paint over with a few layers of black nail polish or destroy with your soldering iron. You can deal with it after soldering if you forget, but it's much easier beforehand. See the image below to identify the offending component.
 
 .. image:: ../../images/build_guide/adafruit_IMU.png
    :target: ../../images/build_guide/adafruit_IMU.png
    :alt: Green led on IMU
 
 
-The photo below shows the orientation on the back of the PCB. Make sure it sits flat and square with the board.  It does not need to be perfect, but should be secure and low-profile. Solder it into position and you're good to go!
+The photo below shows the orientation on the back of the PCB. Make sure it sits flat and square with the board. It doesn't need to be perfect, but should be secure and low-profile. Solder it into position and you're good to go.
 
 .. image:: images/build_guide/ui_module_13.jpeg
 
@@ -120,9 +117,9 @@ The photo below shows the orientation on the back of the PCB. Make sure it sits 
 Display
 ------------------
 
-The display comes next and will cover the solder points for the IMU header, so double check your solder joints there before proceeding!
+The display comes next and will cover the IMU header's solder points, so double-check those joints before proceeding.
 
-You'll need to remove the stand-offs by unscrewing them from the front.  
+Remove the stand-offs by unscrewing them from the front.
 
 
 .. image:: ../../images/build_guide/IMG_4648.jpeg
@@ -136,7 +133,7 @@ You'll need to remove the stand-offs by unscrewing them from the front.
    :alt: Display with standoffs removed
 
 
-Next you'll need to remove the plug from the underside of the board.  This is not absolutely necessary, but will help the display sit lower and flatter.  Use a sharp pair of cutters to cut each of the leads to the connector first.  Cut down low, but the exact location is not critical.  Once this is done, you can use clippers to cut away the plastic at the attachment points on both of the short sides.
+Next, remove the plug from the underside of the board. This isn't strictly necessary, but it helps the display sit lower and flatter. Use sharp cutters to cut each lead to the connector first, cutting low though the exact spot isn't critical. Then use clippers to cut away the plastic at the attachment points on both short sides.
 
 
 .. image:: ../../images/build_guide/IMG_4650.jpeg
@@ -144,7 +141,7 @@ Next you'll need to remove the plug from the underside of the board.  This is no
    :alt: Connector cut free
 
 
-To make the top plate fit a bit better and look tidier, I suggest sanding back or simply cutting the bottom tabs on the display PCB.  There is no circuitry there, they are just providing screw points which are not needed.
+To make the top plate fit better and look tidier, sand back or cut the bottom tabs on the display PCB. There's no circuitry there; they just provide unneeded screw points.
 
 
 .. image:: ../../images/build_guide/IMG_4652.jpeg
@@ -152,7 +149,7 @@ To make the top plate fit a bit better and look tidier, I suggest sanding back o
    :alt: Cut/Sand tabs on display
 
 
-It's not a bad idea to test fit the screen with the header installed and the top-plate in place.  Everything should fit nicely and be square. 
+Test-fit the screen with the header installed and the top plate in place. Everything should fit nicely and sit square.
 
 
 .. image:: ../../images/build_guide/IMG_4653.jpeg
@@ -160,7 +157,7 @@ It's not a bad idea to test fit the screen with the header installed and the top
    :alt: Screen test fit
 
 
-When you are ready, solder the screen in place.  Do one pin first and check it all around to make sure it's sitting flat.  If not, heat that one joint and adjust.
+When you're ready, solder the screen in place. Do one pin first and check all around to make sure it's sitting flat. If not, heat that one joint and adjust.
 
 .. image:: images/build_guide/ui_module_14.jpeg
 
@@ -168,23 +165,22 @@ GPS
 ------------------
 
 .. danger::
-   The :ref:`Testing the Backlight<build_guide:testing the backlight>` step should be carried out before soldering on the GPS unit. The GPS unit will block access to some LED pins and will need to be removed before replacing the blocked LEDs. Removing the GPS unit is a difficult operation in which you might destroy the PCB. It has happened to us. Make sure the LEDs are working nicely before proceeding. 
-   
-   If you need to desolder the GPS unit later, be very careful and patient. We recommend using a desoldering pump, if you need to do it.
+   Complete the :ref:`Testing the Backlight<build_guide:testing the backlight>` step before soldering on the GPS unit. The GPS unit blocks access to some LED pins and would need to be removed to replace any blocked LEDs. Removing it is difficult and can destroy the PCB. It has happened to us. Make sure the LEDs work before proceeding.
+
+   If you do need to desolder the GPS unit later, be very careful and patient, and use a desoldering pump.
 
 
 .. caution::
-   Note that if you want to test the switches, you can leave out the GPS unit entirely until the end as well, since it also blocks access to some switch pins. The GPIO connector for connecting the hat to the Raspberry Pi will then make this awkward. 
-   
-   This is not recommended: While the LEDs have given us problems in the past, the switches have usually been rock solid.
+   If you want to test the switches, you can leave the GPS unit out entirely until the end, since it also blocks access to some switch pins. The GPIO connector for attaching the hat to the Raspberry Pi will then make this awkward.
+
+   This isn't recommended: the LEDs have given us trouble in the past, but the switches have usually been rock solid.
 
 
-The last active component is the GPS module.  It goes component side up so you can access the antenna plug.  Check the photo below and solder it securely.
+The last active component is the GPS module. It goes component side up so you can access the antenna plug. Check the photo below and solder it securely.
 
 .. image:: images/build_guide/ui_module_15.jpeg
 
-Connect the antenna to the GPS module. It's a bit fiddly, so check the alignment carefully before
-applying too much force.  It will snap in and then rotate pretty easily. 
+Connect the antenna to the GPS module. It's fiddly, so check the alignment carefully before applying too much force. It will snap in and then rotate easily.
 
 .. list-table::
 
@@ -193,8 +189,7 @@ applying too much force.  It will snap in and then rotate pretty easily.
      - .. image:: images/build_guide/common_4.jpeg
 
 
-The routing of the antenna cable is important for the best possible reception.  Reference the photo below and tape it to the back of
-the board to keep it secure and out of the way during the build.
+Routing the antenna cable well matters for reception. Following the photo below, tape it to the back of the board to keep it secure and out of the way during the build.
 
 
 .. image:: images/build_guide/ui_module_15b.jpeg
@@ -202,33 +197,32 @@ the board to keep it secure and out of the way during the build.
 Connector
 ------------------
 
-Attaching the GPIO connector is the last soldered bit for the Hat.  To get this properly spaced, you'll need to mount the PCB to your Pi using the stand-off's you'll be using for final assembly.  
+The GPIO connector is the last soldered part of the Hat. To space it correctly, mount the PCB to your Pi using the stand-offs you'll use for final assembly.
 
-The pins on the connector are long to accommodate various spacings.  Plug the connector firmly into your Pi and once you have mounted the PiFinder hat to your Pi with stand-offs/screws you'll be able to solder the connector with the correct spacing.
+The connector's pins are long to accommodate various spacings. Plug the connector firmly into your Pi, mount the PiFinder hat with stand-offs and screws, and then solder the connector at the correct spacing.
 
-Make sure you've added any heatsinks you plan to use. Take your time here and make sure the hat is secured properly to the Pi, that there is no mechanical interference, and that you're satisfied with the spacing before soldering the connector.  
+Add any heatsinks you plan to use first. Take your time and make sure the hat is secured properly to the Pi, that there's no mechanical interference, and that you're happy with the spacing before soldering.
 
-Check the photos below for the procedure, it's easier than it sounds!  There are a lot of pins, make sure each is secure as this
-part can have force applied as the hat is installed and removed.  
+Check the photos below for the procedure; it's easier than it sounds. There are a lot of pins, so make sure each is secure, as this part takes force every time the hat is installed and removed.
 
 .. image:: images/build_guide/ui_module_16.jpeg
 
 .. image:: images/build_guide/ui_module_17.jpeg
 
-After you have all the pins soldered, it's a good time to insert the SD card and power it up to double check everything is working
+With all the pins soldered, insert the SD card and power it up to double-check everything works.
 
 .. image:: images/build_guide/ui_module_18.jpeg
 
-Once it started completely, you will be greeted with :ref:`"the menu"<user_guide:the menu system>`. You can now use the buttons below the screen to navigate. See the faceplate for button functions.
+Once it has started completely, you'll be greeted with :ref:`"the menu"<user_guide:the menu system>`. Use the buttons below the screen to navigate; see the faceplate for button functions.
 
-Navigate to the ``Tools > Status`` :ref:`screen<user_guide:status screen>` and verify that the IMU is detected properly: The lines displaying "IMU" in the status screen should show some numbers. Then navigate to the ``Objects > Name Search`` entry and use it to test the keypad to enter a few letters of an object name.  Congratulations, the keypad is working properly.
+Navigate to the ``Tools > Status`` :ref:`screen<user_guide:status screen>` and verify the IMU is detected: the "IMU" lines should show some numbers. Then go to ``Objects > Name Search`` and enter a few letters of an object name to test the keypad. The keypad is now working properly.
 
-There you go!  The PiFinder hat is fully assembled and you can move on to printing your parts or :ref:`final assembly<build_guide:assembly>`
+There you go. The PiFinder hat is fully assembled, and you can move on to printing your parts or :ref:`final assembly<build_guide:assembly>`
 
 Configurations Overview
 ========================
 
-There are three different ways to build a PiFinder allowing it to be conveniently used on a variety of telescopes.  
+There are three ways to build a PiFinder so it works conveniently on a variety of telescopes.
 
 
 .. list-table::
@@ -245,32 +239,29 @@ There are three different ways to build a PiFinder allowing it to be convenientl
 
           Flat
 
-Any configuration can technically work with any scope, but since the camera always needs to face the sky the different configurations allow the screen and keyboard to be placed for easy access.  The Left and Right configurations are primarily for newtonian style scopes, like dobsonians, which have the focuser perpendicular to the light path.
+Any configuration can work with any scope, but since the camera always needs to face the sky, the different configurations let you place the screen and keyboard for easy access. The Left and Right configurations are mainly for newtonian-style scopes, like dobsonians, whose focuser sits perpendicular to the light path.
 
-The Flat configuration places the keypad and screen in easy reach for refractors, SCT's and other rear-focuser scopes.  When the scope is pointed upward, the screen is tilted towards you for quick access.
+The Flat configuration puts the keypad and screen in easy reach for refractors, SCTs, and other rear-focuser scopes. When the scope points upward, the screen tilts towards you for quick access.
 
-All the STL files for the PiFinder case parts can be found in the main `PiFinder git repo case folder <https://github.com/brickbots/PiFinder/tree/release/case>`_
+All the STL files for the PiFinder case parts are in the main `PiFinder git repo case folder <https://github.com/brickbots/PiFinder/tree/release/case>`_
 
 
 Printed Parts
 ===========================
 
 
-The PiFinder can be built in a left, right or flat configuration to work well on many types of telescopes.  See the :ref:`configurations overview<build_guide:configurations overview>` for more information including example photos.  To build each configuration, only a subset of the available parts are required.
+The PiFinder can be built in a left, right, or flat configuration to suit many telescopes. See the :ref:`configurations overview<build_guide:configurations overview>` for more, including example photos. Each configuration needs only a subset of the available parts.
 
 
 Common Parts
 -----------------------
 
-There are some parts which are common to all three configurations.  The Bezel, Camera Cover and RPI Mount are used in all configurations. 
+Some parts are common to all three configurations. The Bezel, Camera Cover, and RPI Mount are used in every build.
 
 Right and Left configurations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Below is an image showing all the parts required to build a left or right hand PiFinder.  
-Due to the use of edge inserts, these pieces can be assembled in either left, or right, handed 
-configurations so you just need the one set of parts regardless of which side your focuser is 
-facing.  In the assembly guide you'll find info about how to orient the pieces as you put them together. 
+Below are all the parts needed to build a left- or right-hand PiFinder. Thanks to the edge inserts, these pieces assemble into either configuration, so you need just one set of parts regardless of which side your focuser faces. The assembly guide covers how to orient the pieces as you put them together.
 
 .. image:: images/build_guide/parts_1.jpeg
    :target: images/build_guide/parts_1.jpeg
@@ -280,7 +271,7 @@ facing.  In the assembly guide you'll find info about how to orient the pieces a
 Flat Configuration
 ^^^^^^^^^^^^^^^^^^
 
-The pieces required for building the flat versions are pictured below.  The same parts are used with or without a PiSugar battery.
+The pieces for the flat version are pictured below. The same parts are used with or without a PiSugar battery.
 
 .. image:: images/build_guide/parts_2.jpeg
    :target: images/build_guide/parts_2.jpeg
@@ -289,21 +280,19 @@ The pieces required for building the flat versions are pictured below.  The same
 Printing
 --------
 
-These pieces will print without supports in the orientation shown in the photos.  I use 3 perimeter layers and 15% infill, but the pieces are not large and don't need to handle heavy forces so almost any print settings should work.
+These pieces print without supports in the orientation shown. I use 3 perimeter layers and 15% infill, but the parts are small and don't take heavy forces, so almost any print settings will work.
 
-You will want to consider using a material other than PLA, as your PiFinder is likely to experience some sunlight in it's lifetime and PLA degrades under moderate heat and UV.  PETG or some co-polymer like NGen would be a good choice.  Prusament Galaxy PETG is the official PiFinder filament and is pictured in most of the build guide, except where grey provided needed contrast.
+Use a material other than PLA, since your PiFinder will likely see some sunlight and PLA degrades under moderate heat and UV. PETG or a co-polymer like NGen is a good choice. Prusament Galaxy PETG is the official PiFinder filament and appears in most of the build guide, except where grey provided needed contrast.
 
 Inserts
 -------
 
-Only some holes receive inserts, the rest have M2.5 screws inserted through them into the inserts in other pieces.  The brass inserts used in this project are 
-M2.5 x 4mm long.  There are some inserts that go into holes through the entire piece thickness, and some that go into blind holes in the edges.  Each part
-with inserts is pictured below for reference:
+Only some holes receive inserts; the rest take M2.5 screws that pass through into inserts in other pieces. The brass inserts used here are M2.5 x 4mm long. Some go into holes through the full thickness of the piece, and some go into blind holes in the edges. Each part with inserts is pictured below for reference:
 
 Pi Mount
 ^^^^^^^^^
 
-There are eight inserts total for the Pi Mount.  Four go in the printed stand-offs and four go into the edges.
+The Pi Mount takes eight inserts total: four in the printed stand-offs and four in the edges.
 
 .. image:: images/build_guide/parts_3.jpeg
    :target: images/build_guide/parts_3.jpeg
@@ -314,7 +303,7 @@ There are eight inserts total for the Pi Mount.  Four go in the printed stand-of
 Bottom
 ^^^^^^^
 
-For left/right builds this is the bottom piece.  It needs four inserts for attaching the dovetail mount.
+For left/right builds this is the bottom piece. It needs four inserts to attach the dovetail mount.
 
 .. image:: images/build_guide/parts_5.jpeg
    :target: images/build_guide/parts_5.jpeg
@@ -323,11 +312,10 @@ For left/right builds this is the bottom piece.  It needs four inserts for attac
 Flat Adaptor
 ^^^^^^^^^^^^^
 .. note::
-   The photos for the Flat Adaptor and the Back shown here are for the v2 build.  The v2.5 parts 
-   are almost identical, but have 2 camera mount holes rather than 4. 
+   The photos for the Flat Adaptor and the Back shown here are for the v2 build. The v2.5 parts
+   are almost identical, but have 2 camera mount holes rather than 4.
 
-This piece takes the place of the bottom and back piece in the left/right build.  It needs eight inserts, 
-four to attach the dovetail mount and four to attach the camera
+This piece replaces the bottom and back pieces from the left/right build. It needs eight inserts: four to attach the dovetail mount and four to attach the camera.
 
 .. image:: images/build_guide/parts_6.jpeg
    :target: images/build_guide/parts_6.jpeg
@@ -336,9 +324,7 @@ four to attach the dovetail mount and four to attach the camera
 Back
 ^^^^^^^^^
 
-The back piece holds the camera for left/right builds and reinforces the PiMount and Bottom piece to 
-help keep everything square and sturdy.  It needs six inserts; four to mount the camera and two in the bottom
-edge to connect with the bottom piece
+The back piece holds the camera for left/right builds and reinforces the PiMount and Bottom piece to keep everything square and sturdy. It needs six inserts: four to mount the camera and two in the bottom edge to connect with the bottom piece.
 
 .. image:: images/build_guide/parts_7.jpeg
    :target: images/build_guide/parts_7.jpeg
@@ -346,10 +332,7 @@ edge to connect with the bottom piece
 Dovetail Bottom
 ^^^^^^^^^^^^^^^^
 
-The dovetail bottom has two inserts to receive the longer 12mm screws which allow angle adjustment.  These inserts
-are placed in the side opposite where the top piece connects.  The screws pass through the top piece and part of the 
-bottom before engaging with the inserts.  This makes this assembly strong enough to hold the set angle with the screws 
-sufficiently tightened.
+The dovetail bottom has two inserts for the longer 12mm screws that allow angle adjustment. These inserts go in the side opposite where the top piece connects. The screws pass through the top piece and part of the bottom before engaging the inserts. This makes the assembly strong enough to hold the set angle once the screws are sufficiently tight.
 
 .. image:: images/build_guide/parts_8.jpeg
    :target: images/build_guide/parts_8.jpeg
@@ -358,7 +341,7 @@ sufficiently tightened.
 Installation
 ^^^^^^^^^^^^^
 
-Because I use a lot of these inserts, I use a tool to help seat them plumb into the parts,  but I've done plenty freehand and it's not overly difficult.  Use a temperature a bit below your normal printing temperature (for reference, I print PETG at 230c and use 170-200c for inserts) and give the plastic time to melt around them.  
+Because I use a lot of these inserts, I use a tool to seat them plumb into the parts, but I've done plenty freehand and it's not difficult. Use a temperature a bit below your normal printing temperature (I print PETG at 230c and use 170-200c for inserts) and give the plastic time to melt around them.
 
 
 .. image:: ../../images/build_guide/v1.4/build_guide_02.jpg
@@ -370,9 +353,7 @@ Because I use a lot of these inserts, I use a tool to help seat them plumb into 
 Mounting
 --------
 
-Most people will want to print the dovetail mount which fits into the finder shoe included on most telescopes.  
-The dovetail mount is angle adjustable.  This allows to orient the screen surface (roughly) vertical and perpendicular to the ground. 
-This puts the inertial motion sensor into the expected position. See the image below for a better explanation:
+Most people will print the dovetail mount, which fits the finder shoe included on most telescopes. The dovetail mount is angle adjustable, letting you orient the screen surface roughly vertical and perpendicular to the ground. This puts the inertial motion sensor into its expected position. See the image below for a clearer explanation:
 
 
 .. image:: ../../images/finder_shoe_angle.png
@@ -383,9 +364,9 @@ This puts the inertial motion sensor into the expected position. See the image b
 Adjustable Dovetail Assembly
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you print your own parts, you'll need to add heat-set inserts as pictured in the photo above.  Note that the inserts must be inserted from the outside of the bottom piece, as pictured.  The holes on the inside are not large enough for inserts, they just allow the screws to pass through into the inserts.
+If you print your own parts, add heat-set inserts as pictured in the photo above. The inserts must go in from the outside of the bottom piece, as pictured. The holes on the inside aren't large enough for inserts; they just let the screws pass through into the inserts.
 
-See the photos below for how the pieces fit together.  Once assembled you can loosen both screws to adjust the angle up to 40 degrees from horizontal and then secure them again.  No need to go too tight, but a bit of friction will be required to hold the angle.
+See the photos below for how the pieces fit together. Once assembled, loosen both screws to adjust the angle up to 40 degrees from horizontal, then secure them again. No need to go too tight, but a bit of friction is required to hold the angle.
 
 
 .. image:: images/build_guide/dovetail_1.jpeg
@@ -397,14 +378,14 @@ See the photos below for how the pieces fit together.  Once assembled you can lo
 .. image:: images/build_guide/dovetail_4.jpeg
 
 
-If you need more flexibility, there is also a go-pro compatible plate that will bolt into the bottom plate.  You'll need to add inserts into the bottom plate mounting footprint to use this option.
+If you need more flexibility, there's also a go-pro compatible plate that bolts into the bottom plate. You'll need to add inserts into the bottom plate mounting footprint to use this option.
 
-Once you've got all the parts printed and inserts inserted, you're ready to :ref:`assemble<build_guide:assembly>`!
+Once all the parts are printed and the inserts are seated, you're ready to :ref:`assemble<build_guide:assembly>`!
 
 Rigel Quickfinder Assembly
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This is the list of things, that you'll need for a Rigel Quickfinder adapter: 
+You'll need the following for a Rigel Quickfinder adapter:
 
 .. list-table::
    :header-rows: 1
@@ -422,20 +403,17 @@ This is the list of things, that you'll need for a Rigel Quickfinder adapter:
      - `git repo quikfinder <https://github.com/brickbots/PiFinder/tree/release/case/adapter/quikfinder>`_
      - You'll need both this and the previous item
    * - 2
-     - heat-set insert M2.5 x 4 mm 
-     - 
+     - heat-set insert M2.5 x 4 mm
+     -
      - Same as for the case
 
-Please make sure to print "Part 2" in way, such as to maximize the strength of the "hook"! Please print it with supports like this: 
+Print "Part 2" to maximize the strength of the "hook". Print it with supports, like this:
 
 .. image:: images/build_guide/quickfinder_base_4.jpeg
 
-If you print your own parts, you'll need to add heat-set inserts as pictured in the photos below. As the space is limited, you'll need to
-fix it first to the PiFinder and then insert the second part. Just tighten the screws a little bit, to hold the second part, so it can't fall off.
+If you print your own parts, add heat-set inserts as pictured below. Space is limited, so fix it to the PiFinder first and then insert the second part. Tighten the screws just a little to hold the second part so it can't fall off.
 
-After putting it on a Rigel Quickfinder base, tighten the screws fully. Note that the foam double-sided adhesive that's distributed with the
-Rigel Quikfinder might be compressed by the weight of the PiFinder (the PiFinder is ~6 times the weight of a Quikfinder), so you might need to reconsider
-how the base plate is fixed to your scope.  
+After putting it on a Rigel Quickfinder base, tighten the screws fully. Note that the double-sided foam adhesive supplied with the Rigel Quikfinder may compress under the weight of the PiFinder (about 6 times the weight of a Quikfinder), so you may need to reconsider how the base plate is fixed to your scope.
 
 
 .. image:: images/build_guide/quickfinder_base_1.jpeg
@@ -445,7 +423,7 @@ how the base plate is fixed to your scope.
 .. image:: images/build_guide/quickfinder_base_3.jpeg
 
 
-Optionally, if you need to adjust the orientation of your PiFinder to make it vertical on your scope, you need these in addition:
+Optionally, if you need to adjust your PiFinder's orientation to make it vertical on your scope, you'll also need these:
 
 .. list-table::
    :header-rows: 1
@@ -463,24 +441,23 @@ Optionally, if you need to adjust the orientation of your PiFinder to make it ve
      - `git repo dovetail <https://github.com/brickbots/PiFinder/tree/release/case/v2>`_
      - You'll at least need this and the previous item
    * - 6
-     - heat-set insert M2.5 x 4 mm 
-     - 
+     - heat-set insert M2.5 x 4 mm
+     -
      - Same as for the case
-   
-You need to add 4 heat-set inserts as indicated in the following pictures:
+
+Add 4 heat-set inserts as indicated in the following pictures:
 
 .. image:: images/build_guide/quickfinder_base_5.jpeg
 
 .. image:: images/build_guide/quickfinder_base_6.jpeg
 
-The assembly is then like the dovetail assembly in the previous section. Depending on your needs, you can fix the optional adapter 
-in two orientations. Make sure the "long lip" is pointing in the same directions like the PiFinder. The completely assembled adapter looks like this:
+Assembly then follows the dovetail assembly in the previous section. Depending on your needs, you can fix the optional adapter in two orientations. Make sure the "long lip" points the same direction as the PiFinder. The fully assembled adapter looks like this:
 
 .. image:: images/build_guide/quickfinder_base_7.jpeg
 
 .. image:: images/build_guide/quickfinder_base_8.jpeg
 
-Once you've got all the parts printed and inserts inserted, you're ready to :ref:`assemble<build_guide:assembly>`!
+Once all the parts are printed and the inserts are seated, you're ready to :ref:`assemble<build_guide:assembly>`!
 
 
 Assembly
@@ -490,14 +467,14 @@ Assembly
 Assembly Overview
 -----------------
 
-From here on out you'll need the M2.5 screws, stand-offs, and thumbscrews along with the 3d printed parts, UI hat and other bits like the camera, lens and GPS unit.  Most of the photos in this part of the guide show a build with the PiSugar, but if you are powering the PiFinder in some other way, the assembly is almost identical.
+From here you'll need the M2.5 screws, stand-offs, and thumbscrews along with the 3d printed parts, UI hat, and the camera, lens, and GPS unit. Most photos in this part show a build with the PiSugar, but if you're powering the PiFinder another way the assembly is almost identical.
 
-*In all cases, don't over tighten the hardware!*  There is no need and you could end up damaging the 3d printed pieces, inserts or screws.  Once they feel snug, that's probably enough force.  The case forms a rigid assembly once everything is in place and will easily support the camera and other bits.
+*In all cases, don't over tighten the hardware.* There's no need, and you could damage the 3d printed pieces, inserts, or screws. Once they feel snug, that's enough. The case forms a rigid assembly once everything is in place and will easily support the camera and other bits.
 
 Pi Mounting
 ---------------------------
 
-The first step is to mount the Pi and PiSugar battery to the Pi Mount piece.  The pieces you'll need are shown below
+First, mount the Pi and PiSugar battery to the Pi Mount piece. The pieces you'll need are shown below.
 
 
 .. image:: images/build_guide/common_1.jpeg
@@ -505,18 +482,18 @@ The first step is to mount the Pi and PiSugar battery to the Pi Mount piece.  Th
    :alt: Build Guide Step
 
 
-Regardless of the orientation of your build, the Raspberry Pi and battery always mount in this same orientation.  The Raspberry Pi and PiSugar (if you are using one) will mount on top of the posts in the RPI Holder.
+Whatever your build's orientation, the Raspberry Pi and battery always mount this same way, on top of the posts in the RPI Holder.
 
-If you are using a PiSugar it's time to mount the battery pack.  If not, just skip this step and continue on.  Flip the PiMount piece over and use the zip ties to secure the battery as shown.  No need to tighten these down very much, doing so may damage the battery.  It needs just enough to keep it from moving too much. 
+If you're using a PiSugar, mount the battery pack now; otherwise skip this step. Flip the PiMount piece over and use the zip ties to secure the battery as shown. Don't tighten these much, as that may damage the battery, just enough to keep it from moving too much.
 
-Mind the orientation of the battery pack to make sure the connector is situated in the notch as shown below
+Mind the orientation of the battery pack so the connector sits in the notch as shown below.
 
 
 .. image:: images/build_guide/common_1b.jpeg
    :target: _images/common_1b.jpeg
 
 
-Snip the zip-ties off and you are ready to move on.
+Snip the zip-ties off and you're ready to move on.
 
 
 .. image:: images/build_guide/common_1c.jpeg
@@ -527,40 +504,27 @@ Snip the zip-ties off and you are ready to move on.
 Camera Prep
 ---------------------------
 
-The new v3 camera may come with one of two different lens holders already installed. No matter 
-which your camera has you'll be removing and replacing it.
+The new v3 camera may come with one of two lens holders already installed. Either way, you'll remove and replace it.
 
 .. image:: images/v25_upgrade/v25_upgrade_11.jpeg
 
-Some cameras have pin headers installed, if you have one of these, you'll need to clip them as close
-as reasonable to the board. It can help here to remove the black plastic portion by pulling it with
-a pair of pliers.  Alternatively, you can just cut through it to get as close to the PCB as possible.
-Take care not to clip any of the surrounding components.
+Some cameras have pin headers installed. If yours does, clip them as close to the board as reasonable. It helps to remove the black plastic portion by pulling it off with pliers, or just cut through it to get as close to the PCB as possible. Take care not to clip any surrounding components.
 
 .. image:: images/v25_upgrade/v25_upgrade_12.jpeg
 
 .. image:: images/v25_upgrade/v25_upgrade_13.jpeg
 
-Grab the lens holder and look through it to make sure it's clear of any obstructions.
+Grab the lens holder and look through it to make sure it's clear of obstructions.
 
-Place the lens holder on the table with the large side up oriented as in the photo below.  The two screw
-tabs on the lens holder must stick out the opposite sides from the cream-white and dark-grey cable connector on the PCB.
-You'll be removing the two screws (yours might be black) near the center of the green PCB and lifting it gently
-to the new lens holder.  
+Place the lens holder on the table with the large side up, oriented as in the photo below. The two screw tabs on the lens holder must stick out the opposite sides from the cream-white and dark-grey cable connector on the PCB. Remove the two screws (yours might be black) near the center of the green PCB and lift it gently onto the new lens holder.
 
-Mind the sensor surface on the under side of the PCB. It should sit nicely in the square recess of the lens holder.
-Use the same two screws to affix the sensor PCB to the lens holder.  The screws will be cutting their own threads, but
-there are holes there to help get started.  Tighten the screws down against the PCB so nothing is wiggling/moving.
+Mind the sensor surface on the underside of the PCB; it should sit nicely in the square recess of the lens holder. Use the same two screws to affix the sensor PCB to the lens holder. The screws cut their own threads, but the holes help get them started. Tighten them down against the PCB so nothing wiggles.
 
 .. image:: images/v25_upgrade/v25_upgrade_14.jpeg
 
 .. image:: images/v25_upgrade/v25_upgrade_15.jpeg
 
-Flip the camera assembly over and thread in the lens.  Be slow and careful here.  With gentle force
-the lens should slide in a few MM to get everything aligned and stop.  When it stops, check to make sure it seems
-straight and start screwing it into place.  To get focus about right, You'll want a 6mm gap (pictured below) between the 
-top of the lens holder and the bottom of the lip on the lens.  Don't fret too much about it as you'll do final focus 
-under the stars.
+Flip the camera assembly over and thread in the lens. Go slow and careful here. With gentle force the lens should slide in a few mm to align everything and stop. When it stops, check that it looks straight and start screwing it into place. To get focus about right, aim for a 6mm gap (pictured below) between the top of the lens holder and the bottom of the lip on the lens. Don't fret too much; you'll do final focus under the stars.
 
 .. image:: images/v25_upgrade/v25_upgrade_16.jpeg
 
@@ -570,28 +534,28 @@ under the stars.
 Cable Routing
 ---------------------------
 
-If you are building a flat unit, just set the camera cable to the side as it gets routed in a different manner.  For left/right builds, it's easier to get the cable roughly positioned now.
+For a flat unit, set the camera cable aside, as it's routed differently. For left/right builds, it's easier to position the cable roughly now.
 
-Return to the Raspberry Pi assembly and thread the camera cable through as shown.  Note the orientation/direction of the silver contacts at each end of the cable.  The photos below show the cable routing for left and right hand builds.
+Return to the Raspberry Pi assembly and thread the camera cable through as shown. Note the orientation of the silver contacts at each end of the cable. The photos below show the cable routing for left- and right-hand builds.
 
 .. list-table::
 
    * - .. image:: images/build_guide/left_1.jpeg
-          :target: images/build_guide/left_1.jpeg 
+          :target: images/build_guide/left_1.jpeg
 
        Left hand cable routing
 
      - .. image:: images/build_guide/right_1.jpeg
-          :target: images/build_guide/right_1.jpeg 
+          :target: images/build_guide/right_1.jpeg
 
        Right hand cable routing
 
 .. important::
-    If you are using the recommended S Plus unit, now is the time to make sure you've got it all prepared.
+    If you're using the recommended S Plus unit, prepare it now.
 
-    * Turn the 'Auto Startup' switch on the bottom of the unit to OFF. Having this in the ON position will prevent i2c from working and the IMU will not be used. See the image below:  The switch is outlined in orange, and the photo shows the correct OFF position.
+    * Turn the 'Auto Startup' switch on the bottom of the unit to OFF. Leaving it ON prevents i2c from working and the IMU won't be used. The switch is outlined in orange in the image below, shown in the correct OFF position.
 
-    * The blue power light on the PiSugar board is very bright.  You'll definitely want to cover it with some black nail polish or use a soldering iron to destroy it.  Plug it in to the battery and turn it on to make sure it's subdued.  Check the image below for the position of this LED.  It's already blacked out with nail polish in the photo, but the orange arrow indicates which one you'll want to cover.
+    * The blue power light on the PiSugar board is very bright. Cover it with black nail polish or destroy it with a soldering iron. Plug it into the battery and turn it on to confirm it's subdued. The orange arrow in the image below indicates which LED to cover; it's already blacked out with nail polish in the photo.
 
 
 .. image:: ../../images/build_guide/pisugar_setup.jpg
@@ -599,7 +563,7 @@ Return to the Raspberry Pi assembly and thread the camera cable through as shown
    :alt: Build Guide Step
 
 
-The PiSugar will have a protective film on the screw posts as seen in the photo below, make sure to remove this or you'll have a frustrating time getting everything screwed together.
+The PiSugar ships with a protective film on the screw posts, as seen below. Remove it, or you'll have a frustrating time getting everything screwed together.
 
 
 .. image:: ../../images/build_guide/v1.6/build_guide_01.jpeg
@@ -607,26 +571,26 @@ The PiSugar will have a protective film on the screw posts as seen in the photo 
    :alt: Build Guide Step
 
 
-The PiSugar sits under the Raspberry Pi with the gold pogo pins pressed up against the bottom of the Raspberry Pi.  The side facing up in the image above is the side that should press against the bottom of the Raspberry Pi.  The PiSugar documentation has more info if needed. 
+The PiSugar sits under the Raspberry Pi with the gold pogo pins pressed against the bottom of the Pi. The side facing up in the image above is the side that should press against the bottom of the Raspberry Pi. The PiSugar documentation has more info if needed.
 
-The combined PiSugar/RPI stack then gets secured to the PI Mount using the 20mm stand-offs.  The photos below show the right/left hand stack with their respective cable routing.  For flat configurations, it builds just the same without any camera cable.
+The combined PiSugar/RPI stack then gets secured to the PI Mount using the 20mm stand-offs. The photos below show the right/left-hand stack with their respective cable routing. Flat configurations build the same way, without any camera cable.
 
 .. list-table::
 
    * - .. figure:: images/build_guide/left_2.jpeg
-     
+
           Left hand PiSugar stack
 
      - .. figure:: images/build_guide/right_2.jpeg
-     
+
           Right hand PiSugar stack
 
    * - .. figure:: images/build_guide/left_3.jpeg
-     
+
           Secured with stand offs
 
      - .. figure:: images/build_guide/right_3.jpeg
-     
+
           Secured with stand offs
 
 
@@ -634,14 +598,11 @@ The combined PiSugar/RPI stack then gets secured to the PI Mount using the 20mm 
 Right / Left Configuration
 ---------------------------
 
-Continue on with this section to build a Right/Left hand unit.  The build progresses the same for both versions with some differences in the part orientation.  
-You'll see photos for each step with left hand version on the left and right on the right.
+Continue here to build a Right/Left-hand unit. The build is the same for both versions, with some differences in part orientation. Each step shows photos with the left-hand version on the left and the right on the right.
 
-Now that the RPI is mounted, it's time to secure the mount plate to the bottom plate.  The bottom plate can be flipped to allow for the screen to 
-be facing the right, or left side.  As you can see from the two photos below.
+Now that the RPI is mounted, secure the mount plate to the bottom plate. The bottom plate can be flipped so the screen faces the right or left side, as the two photos below show.
 
-In both cases, the RPI/Screen will always be face the same direction as the long, flat side of the bottom piece.  The angled cut out is 
-always on the camera side, and the lens faces the angled portion.  
+In both cases, the RPI/Screen always faces the same direction as the long, flat side of the bottom piece. The angled cutout is always on the camera side, and the lens faces the angled portion.
 
 .. list-table::
 
@@ -650,8 +611,7 @@ always on the camera side, and the lens faces the angled portion.
      - .. image:: images/build_guide/right_4.jpeg
 
 
-The first step is to screw the Pi Mount assembly to the bottom plate.  You'll use two screws from underneath running through the bottom plate into the threaded
-inserts in the side of the Pi Mount piece.
+First, screw the Pi Mount assembly to the bottom plate. Use two screws from underneath, running through the bottom plate into the threaded inserts in the side of the Pi Mount piece.
 
 
 .. list-table::
@@ -662,9 +622,7 @@ inserts in the side of the Pi Mount piece.
 
 
 
-The back piece is next, but first screw in the four short stand-offs which will support the camera module.  These stand-offs
-can be screwed in either side for left or right hand configurations.  Take a look at photos below to match up how the 
-back piece fits with both configurations to decide which side to put the stand-offs in.
+The back piece is next, but first screw in the four short stand-offs that support the camera module. These can go on either side for left- or right-hand configurations. Check the photos below to match how the back piece fits each configuration and decide which side to put the stand-offs in.
 
 .. list-table::
 
@@ -676,10 +634,7 @@ back piece fits with both configurations to decide which side to put the stand-o
 
      - .. image:: images/build_guide/right_7.jpeg
 
-Then the back piece secures to the rest of the assembly via three M2.5 8mm screws.  One goes through the 
-back plate into the side-insert in the RPI Mount, there is one of these inserts on either side of the 
-RPI Mount for left/right hand builds.  The other two go through the bottom plate into the side-inserts 
-on the back plate. 
+The back piece then secures to the assembly with three M2.5 8mm screws. One goes through the back plate into the side-insert in the RPI Mount; there's one of these inserts on either side of the RPI Mount for left/right-hand builds. The other two go through the bottom plate into the side-inserts on the back plate.
 
 
 .. list-table::
@@ -692,31 +647,24 @@ on the back plate.
 
      - .. image:: images/build_guide/right_9.jpeg
 
-Now it's time to mount the camera module.  You'll need the module, camera tray and 2x12mm m2.5 screws
+Now mount the camera module. You'll need the module, camera tray, and 2x 12mm M2.5 screws.
 
 .. note::
-   The images here show an older back piece and camera tray. New kits have a back piece 
-   with two holes which match the camera holder.  In this simpler arrangement the camera
+   The images here show an older back piece and camera tray. New kits have a back piece
+   with two holes which match the camera holder. In this simpler arrangement the camera
    tray is not directly secured to the back piece, but rather has two holes through it.
    The camera holder is secured with longer screws through the tray into the two holes
    in the back piece
 
-Start by connecting the cable to the new camera module.  Open the connector all the way
-by sliding the dark-grey piece away from the PCB.  Be gentle as this part can break with too
-much force. 
+Start by connecting the cable to the new camera module. Open the connector all the way by sliding the dark-grey piece away from the PCB. Be gentle, as this part can break under too much force.
 
-Once the connector is open, slide the cable into the connector using gentle force and making 
-sure it's well aligned.  Take your time and watch the
-dark-grey clip.  It should not close as you are inserting the cable, and if it does, you'll need
-to re-open it to get the cable to slide in all the way.
+With the connector open, slide the cable in using gentle force, keeping it well aligned. Take your time and watch the dark-grey clip. It shouldn't close as you insert the cable; if it does, re-open it so the cable can slide all the way in.
 
-Once the cable is seated in the connector, close the dark-grey clip by sliding it shut, this 
-may take a little force to get it completely closed.  Check the photo below if in doubt!
+Once the cable is seated, close the dark-grey clip by sliding it shut. This may take a little force to fully close. Check the photo below if in doubt.
 
 .. image:: images/v25_upgrade/v25_upgrade_24.jpeg
 
-Situate the camera in the adapter and use the two new screws to secure it.  They are 
-the same size as the other four, if they get mixed up.
+Situate the camera in the adapter and use the two new screws to secure it. They're the same size as the other four, in case they get mixed up.
 
 .. image:: images/v25_upgrade/v25_upgrade_25.jpeg
 
@@ -724,15 +672,15 @@ the same size as the other four, if they get mixed up.
 
 .. note::
    The remainder of the build guide is yet to be updated with new photos
-   including the v2.5 camera.  The build proceeds just the same and we
+   including the v2.5 camera. The build proceeds just the same and we
    will be updating the photos soon.
 
 
-Flip the unit over and connect the RPI end of the camera cable.  The photo below show the proper orientation of the cable into the connector.  Note the silver contacts facing the white portion of the connector.
+Flip the unit over and connect the RPI end of the camera cable. The photo below shows the proper cable orientation into the connector, with the silver contacts facing the white portion of the connector.
 
 .. image:: images/build_guide/assembly_insert_cable.jpeg
 
-For the left hand version you will need a twist in the cable before it enters the connector on the RPI.  Be gentle with it and you'll be able to adjust as you put on the UI Module later.
+For the left-hand version you'll need a twist in the cable before it enters the connector on the RPI. Be gentle, and you'll be able to adjust it as you put on the UI Module later.
 
 .. list-table::
 
@@ -741,12 +689,11 @@ For the left hand version you will need a twist in the cable before it enters th
      - .. image:: images/build_guide/right_14.jpeg
 
 .. note::
-   The remainder of the build is almost the same for left or right hand units.  The photos below are a mix of left and 
+   The remainder of the build is almost the same for left- or right-hand units. The photos below are a mix of left and
    right handed builds, but where there are important differences, you'll see both indicated for clarity.
 
 
-Next up is to connect the UI Board and affix the shroud. Lay out the board as it will be connected and slide the antenna into the holder on the Pi Mount piece.  
-The ceramic top with the silver dimple on it needs to face upwards.  Consult the photos below
+Next, connect the UI Board and affix the shroud. Lay out the board as it will be connected and slide the antenna into the holder on the Pi Mount piece. The ceramic top with the silver dimple needs to face upwards. Consult the photos below.
 
 .. image:: images/build_guide/right_16.jpeg
 
@@ -755,11 +702,10 @@ The ceramic top with the silver dimple on it needs to face upwards.  Consult the
 .. image:: images/build_guide/right_18.jpeg
 
 .. note::
-   The images above have the GPS cable loose and not routed properly.  Please use the 
+   The images above have the GPS cable loose and not routed properly. Please use the
    routing shown in the :ref:`GPS<build_guide:gps>` section
 
-Now carefully plug the UI Module into the Raspberry Pi.  Make sure both rows of pins are aligned and take your time to 
-manage the camera and GPS cables.  The photos below show the left and right configurations for the cable routing.
+Now carefully plug the UI Module into the Raspberry Pi. Make sure both rows of pins are aligned and take your time to manage the camera and GPS cables. The photos below show the left and right configurations for the cable routing.
 
 .. list-table::
 
@@ -768,21 +714,17 @@ manage the camera and GPS cables.  The photos below show the left and right conf
      - .. image:: images/build_guide/right_20.jpeg
 
 
-The screw holes on the UI Board should line up with three of the four stand-offs.  The fourth provides support, but is not used to secure the outer case. Collect up the Shroud, Bezel and cover plate along with three of the 12mm screws for the next steps
+The screw holes on the UI Board should line up with three of the four stand-offs. The fourth provides support but isn't used to secure the outer case. Collect the Shroud, Bezel, and cover plate along with three of the 12mm screws for the next steps.
 
 .. image:: images/build_guide/common_5.jpeg
    :target: images/build_guide/common_5.jpeg
 
 
-The shroud has three optional openings, one for the PiSugar power switch on top, one for the USB ports, 
-and one for the SD Card on the side if you want easier access.  These can all be removed with a little force 
-or a sharp knife.  If you are using a PiSugar battery, you'll absolutely need to make sure that tab is removed
-See the photo below:
+The shroud has three optional openings: one for the PiSugar power switch on top, one for the USB ports, and one for the SD Card on the side for easier access. Remove these with a little force or a sharp knife. If you're using a PiSugar battery, you'll definitely need to remove that tab. See the photo below:
 
 .. image:: images/build_guide/common_6.jpeg
 
-Slide the shroud over the unit then stack the bezel and the front PCB plate on top and secure
-them all with the three screws
+Slide the shroud over the unit, then stack the bezel and the front PCB plate on top and secure them all with the three screws.
 
 .. image:: images/build_guide/common_7.jpeg
 
@@ -792,10 +734,7 @@ them all with the three screws
 
 .. image:: images/build_guide/common_10.jpeg
 
-That's looking great!  Now we just need a way to mount it to the scope.  The top portion of the adjustable dovetail
-gets screwed directly to the bottom of the PiFinder and then the bottom portion of the dovetail gets secured to the 
-top portion.  The orientation of the top part is important to make sure the dovetail adjusts the proper way.  See
-the left/right hand photos below:
+That's looking great. Now you just need a way to mount it to the scope. The top portion of the adjustable dovetail screws directly to the bottom of the PiFinder, then the bottom portion secures to the top. The orientation of the top part matters so the dovetail adjusts the proper way. See the left/right-hand photos below:
 
 
 .. image:: images/build_guide/right_21.jpeg
@@ -803,8 +742,7 @@ the left/right hand photos below:
 .. image:: images/build_guide/right_22.jpeg
 
 
-It's tricky to photograph the final dovetail assembly details on the PiFinder, so check these photos below
-and secure the bottom dovetail portion to the top:
+The final dovetail assembly is tricky to photograph on the PiFinder, so check these photos below and secure the bottom dovetail portion to the top:
 
 .. image:: images/build_guide/dovetail_1.jpeg
 
@@ -816,9 +754,9 @@ and secure the bottom dovetail portion to the top:
 
 
 
-That's it! You now have a fully assembled PiFinder!  
+That's it! You now have a fully assembled PiFinder.
 
-Continue on to the :doc:`software setup<software>` if you've not already prepared a SD card.  
+Continue to the :doc:`software setup<software>` if you haven't already prepared an SD card.
 
 
 .. image:: images/build_guide/common_11.jpeg
@@ -828,7 +766,7 @@ Continue on to the :doc:`software setup<software>` if you've not already prepare
 Flat Assembly
 ----------------
 
-This section of the build guide contains the steps to complete a Flat build.  This configuration is great for refractors, SCT's and other scopes with rear-focusers as the screen is 'flat' when mounted and the camera faces forward:
+This section covers a Flat build. This configuration is great for refractors, SCTs, and other rear-focuser scopes, as the screen is 'flat' when mounted and the camera faces forward:
 
 
 .. image:: ../../images/flat_mount.png
@@ -836,7 +774,7 @@ This section of the build guide contains the steps to complete a Flat build.  Th
    :alt: Flat example
 
 
-If you have not already followed the :ref:`general assembly guide<build_guide:assembly>` through to get to the point pictured below, please do so and then return here.
+If you haven't already followed the :ref:`general assembly guide<build_guide:assembly>` through to the point pictured below, do so and then return here.
 
 
 .. image:: ../../images/build_guide/v1.6/build_guide_11.jpeg
@@ -844,9 +782,9 @@ If you have not already followed the :ref:`general assembly guide<build_guide:as
    :alt: Pi Module Assembled
 
 
-If you routed the cable as above, pull the camera cable out to remove it from the RPI assembly as the routing is different for a flat build.  
+If you routed the cable as above, pull the camera cable out to remove it from the RPI assembly, as the routing differs for a flat build.
 
-Collect the flat adapter and dovetail.  The dovetail will be secured to the underside of the flat adapter via screws through the adapter and the RPI mount assembly will slot into it the flat adapter and be secured via screws into the edge inserts.  See the photos below for details.
+Collect the flat adapter and dovetail. The dovetail secures to the underside of the flat adapter via screws through the adapter, and the RPI mount assembly slots into the flat adapter and is secured via screws into the edge inserts. See the photos below for details.
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_01.jpeg
    :target: ../../images/build_guide/v1.6/flat/flat_build_guide_01.jpeg
@@ -873,7 +811,7 @@ Collect the flat adapter and dovetail.  The dovetail will be secured to the unde
    :alt: Assembly Steps
 
 
-Note the one additional screw on the other side visible in the next photo.  Once the RPI Mount is secured to the flat adapter, connect the camera cable to the RPi and the Camera as shown below.
+Note the one additional screw on the other side, visible in the next photo. Once the RPI Mount is secured to the flat adapter, connect the camera cable to the RPi and the camera as shown below.
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_06.jpeg
@@ -881,7 +819,7 @@ Note the one additional screw on the other side visible in the next photo.  Once
    :alt: Assembly Steps
 
 
-Turn the PiFinder around and screw in the three thumbscrews as shown.  Check for any excess plastic in the threads and if you run into resistance, try screwing them from the other side first to clear any obstruction.   Screw them most of the way in, but leave some amount for adjustment.
+Turn the PiFinder around and screw in the three thumbscrews as shown. Check for excess plastic in the threads; if you hit resistance, try screwing them from the other side first to clear any obstruction. Screw them most of the way in, but leave some room for adjustment.
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_07.jpeg
@@ -889,7 +827,7 @@ Turn the PiFinder around and screw in the three thumbscrews as shown.  Check for
    :alt: Assembly Steps
 
 
-Next you'll position the camera module and use the longer M2.5 screw to secure it.  The screw should be inserted through the center hole in the flat adapter back and threaded into the center hole in the camera cell.  It should screw in 3-4mm and pull the camera cell against the ends of the three thumbscrews.  If it's not secure, extend the thumbscrews until it's supported.  No need to tighten anything too much here, you'll adjust again to align the PiFinder with your telescopes optical axis.
+Next, position the camera module and use the longer M2.5 screw to secure it. Insert the screw through the center hole in the flat adapter back and thread it into the center hole in the camera cell. It should screw in 3-4mm and pull the camera cell against the ends of the three thumbscrews. If it's not secure, extend the thumbscrews until it's supported. No need to tighten anything too much here; you'll adjust again to align the PiFinder with your telescope's optical axis.
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_09.jpeg
@@ -897,7 +835,7 @@ Next you'll position the camera module and use the longer M2.5 screw to secure i
    :alt: Assembly Steps
 
 
-Gently plug in the UI Module, working to tuck the cable underneath it.  Take your time and make sure the camera cable is not pinched between the stand-offs and the UI Module.
+Gently plug in the UI Module, tucking the cable underneath it. Take your time and make sure the camera cable isn't pinched between the stand-offs and the UI Module.
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_10.jpeg
@@ -915,9 +853,9 @@ Gently plug in the UI Module, working to tuck the cable underneath it.  Take you
    :alt: Assembly Steps
 
 
-Once the UI Module is plugged in all the way and the cable is tidy, gather the remaining parts to wrap up the build!  The shroud will slip over the UI Module first, then the bezel slots on top and finally the top PCB.  Use three of the long screws to secure everything together per the photos below.
+Once the UI Module is plugged in all the way and the cable is tidy, gather the remaining parts to wrap up the build. The shroud slips over the UI Module first, then the bezel slots on top, and finally the top PCB. Use three of the long screws to secure everything together, per the photos below.
 
-NOTE:  If you have not already flashed and inserted the SD card into the Raspberry Pi, nows a good time.  It will be harder to get to after the shroud is installed.  Also check to make sure the PiSugar power switch access is cut and punched out of the shroud if you are using a PiSugar.
+NOTE: If you haven't already flashed and inserted the SD card into the Raspberry Pi, now's a good time, as it's harder to reach after the shroud is installed. Also check that the PiSugar power switch access is cut and punched out of the shroud if you're using a PiSugar.
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_13.jpeg
@@ -946,7 +884,7 @@ NOTE:  If you have not already flashed and inserted the SD card into the Raspber
    :alt: Assembly Steps
 
 
-The only remaining thing to do is to affix the camera lens.  Unscrew the cap from the camera module, but make sure you leave the knurled adapter in place as it's required to get the focus distance correct.  Remove the cap from the silver end of the lens and gently screw them together.
+The only thing left is to affix the camera lens. Unscrew the cap from the camera module, but leave the knurled adapter in place, as it's required to get the focus distance correct. Remove the cap from the silver end of the lens and gently screw them together.
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_19.jpeg
@@ -954,5 +892,4 @@ The only remaining thing to do is to affix the camera lens.  Unscrew the cap fro
    :alt: Assembly Steps
 
 
-Congratulations, you have a PiFinder! See the :doc:`Software Setup<software>` guide for next steps!
-
+Congratulations, you have a PiFinder! See the :doc:`Software Setup<software>` guide for next steps.

--- a/docs/source/catalogs.rst
+++ b/docs/source/catalogs.rst
@@ -2,24 +2,22 @@
 PiFinder™ Catalogs
 ===================
 
-The PiFinder comes with a number of astronomical catalogs which can be searched and filtered.
-Each has a short catalog code displayed on the PiFinder UI.  You can select which catalogs
-are active via the :ref:`Filters<user_guide:filters>`
-menu.
+The PiFinder ships with several astronomical catalogs you can search and filter.
+Each carries a short catalog code shown on the UI. Choose which catalogs are
+active in the :ref:`Filters<user_guide:filters>` menu.
 
-A few of these catalogs — the Washington Double Star catalog especially — hold far too many
-entries to scroll through.  For those, use **Name Search** to jump straight to an object by
-its designation, or sort a list by **Nearest** to surface the objects closest to where your
-scope is currently pointed.
+A few catalogs — the Washington Double Star catalog especially — hold far too many
+entries to scroll. For those, use **Name Search** to jump to an object by its
+designation, or sort by **Nearest** to surface the objects closest to where your
+scope is pointed.
 
 Abl
 ----
-The Abell Catalog of Planetary Nebulae (1966 by George O. Abell) contains 79 entries confirmed to be planetary nebulae.
+The Abell Catalog of Planetary Nebulae (George O. Abell, 1966): 79 confirmed planetary nebulae.
 
 Arp
 ----
-Atlas of Peculiar Galaxies    (Arp 1966)
-Select galaxies with interest morphology.  See `Wikipedia - Atlas of Peculiar Galaxies <https://en.wikipedia.org/wiki/Atlas_of_Peculiar_Galaxies>`_
+Atlas of Peculiar Galaxies (Arp 1966). Galaxies with unusual morphology. See `Wikipedia - Atlas of Peculiar Galaxies <https://en.wikipedia.org/wiki/Atlas_of_Peculiar_Galaxies>`_
 
 B
 ----
@@ -31,20 +29,19 @@ Caldwell catalog
 
 Col
 ----------
-The Collinder catalogue has 471 open clusters compiled by Swedish astronomer Per Collinder.
+471 open clusters compiled by Swedish astronomer Per Collinder.
 
 EGC
 ----
-Catalog of Extra-Galactic Globular Clusters. This catalog features globulars associated with nearby galaxies and are visible through modest amateur telescopes, mostly in Andromeda.
+Catalog of Extra-Galactic Globular Clusters: globulars associated with nearby galaxies, mostly in Andromeda, visible through modest amateur telescopes.
 
 H
 ----------
-The Herschel 400 catalogue is a subset of William Herschel's original Catalogue of Nebulae and Clusters of Stars, selected in response to a letter in Sky and Telescope.
+A subset of William Herschel's original Catalogue of Nebulae and Clusters of Stars, selected in response to a letter in Sky and Telescope.
 
 Harris
 -------
-Globular Clusters in the Milky Way (Harris, 1997)
-This catalog compiled was by William E. Harris and used by permisson.
+Globular Clusters in the Milky Way (Harris, 1997). Compiled by William E. Harris, used by permission.
 
 IC
 ----------
@@ -60,12 +57,11 @@ Messier catalog
 
 NGC
 ----------
-NGC 2000.0, The Complete New General Catalogue and Index Catalogue of Nebulae and Star Clusters by J.L.E. Dreyer Sinnott, R.W.  (edited by)
+NGC 2000.0, The Complete New General Catalogue and Index Catalogue of Nebulae and Star Clusters by J.L.E. Dreyer (edited by R.W. Sinnott).
 
 RDS
 ----
-the RASC Double Stars Observing Program.
-The 110 double star targets are visible from the northern hemisphere in many constellations.
+The RASC Double Stars Observing Program: 110 double-star targets visible from the northern hemisphere across many constellations.
 
 SaA
 ----------
@@ -73,8 +69,7 @@ Saguaro Astronomy Club Asterisms Database Version 3.2
 
 SaM
 ----
-Saguaro Astronomy Club Double Star Database Version 4.0
-2162 double stars.
+Saguaro Astronomy Club Double Star Database Version 4.0: 2,162 double stars.
 
 SaR
 ----
@@ -82,15 +77,15 @@ SAC Red Stars Database Version 2.0
 
 Sh2
 ----
-The Sharpless catalog is a list of 313 H II regions (emission nebulae) intended to be comprehensive north of declination −27°.
+313 H II regions (emission nebulae), comprehensive north of declination −27°.
 
 Str
 ----
-A catalog of named bright stars.  Especially useful for aligning GoTo scopes.
+Named bright stars. Especially useful for aligning GoTo scopes.
 
 Ta2
 ----------
-The TAAS 200 deep sky astronomical observing list designed for the intermediate observer, and includes the best 200 non Messier objects easily visible from central New Mexico, (objects north of declination -48).
+The TAAS 200 deep-sky observing list for the intermediate observer: the best 200 non-Messier objects easily visible from central New Mexico (north of declination −48°).
 
 TLK
 ----
@@ -98,8 +93,8 @@ TLK's hand-picked list of interesting variable stars visible from the northern h
 
 WDS
 ----
-The Washington Double Star Catalog — the PiFinder includes over 130,000 double and multiple
-star pairs from it.  Because the full list is far too long to scroll, find a pair with
-**Name Search** (type its WDS designation) or sort the list by **Nearest** to bring up the
-doubles closest to where your scope is pointing.
-For more information on WDS, please see: `https://www.astro.gsu.edu/wds/ <https://www.astro.gsu.edu/wds/>`_
+The PiFinder includes over 130,000 double and multiple star pairs from the
+Washington Double Star Catalog. The full list is far too long to scroll, so find
+a pair with **Name Search** (type its WDS designation) or sort by **Nearest** to
+bring up the doubles closest to where your scope is pointing.
+For more on WDS, see `https://www.astro.gsu.edu/wds/ <https://www.astro.gsu.edu/wds/>`_

--- a/docs/source/equipment.rst
+++ b/docs/source/equipment.rst
@@ -1,44 +1,40 @@
 Equipment
 =========
 
-The PiFinder can keep track of the telescopes and eyepieces you observe with.
-Telling it about your gear is optional, but it unlocks several conveniences:
-it works out the magnification and true field of view for any
-telescope-and-eyepiece pairing, it sizes and orients the survey images on the
-:ref:`user_guide:object details` screen to match what you actually see at the
-eyepiece, and it lets the push-to arrows follow the way your particular setup
-moves.
+The PiFinder can track the telescopes and eyepieces you observe with. Telling
+it about your gear is optional, but it unlocks several conveniences: it works
+out the magnification and true field of view for any telescope-and-eyepiece
+pairing, sizes and orients the survey images on the
+:ref:`user_guide:object details` screen to match the eyepiece view, and lets
+the push-to arrows follow the way your setup moves.
 
-You manage your equipment from two places. The :ref:`user_guide:web interface`
-is where you add and edit telescopes and eyepieces, and the Equipment screen on
-the PiFinder itself is where you pick which ones are active for tonight's
-session.
+You manage equipment from two places: the :ref:`user_guide:web interface` is
+where you add and edit telescopes and eyepieces, and the Equipment screen on the
+PiFinder is where you pick which ones are active for tonight's session.
 
 Telescopes and eyepieces
 ------------------------
 
-A **telescope** records the optical details of one of your instruments: its
-make and name, aperture, focal length, central obstruction, and mount type,
-along with a few display options covered below. The aperture and focal length
-are what let the PiFinder calculate magnification and field of view.
+A **telescope** records the optical details of one instrument: make and name,
+aperture, focal length, central obstruction, and mount type, plus a few display
+options covered below. Aperture and focal length drive the magnification and
+field-of-view calculations.
 
-An **eyepiece** records its focal length and apparent field of view (and, if
-you know it, the field stop, which gives a more precise field-of-view figure).
-You can store as many of each as you like and switch between them as you change
-eyepieces through the night.
+An **eyepiece** records its focal length and apparent field of view, plus the
+field stop if you know it, which gives a more precise field-of-view figure.
+Store as many of each as you like and switch between them as the night goes on.
 
 Adding and editing your gear
 ----------------------------
 
-Telescopes and eyepieces are added through the :ref:`user_guide:web interface`.
+Add telescopes and eyepieces through the :ref:`user_guide:web interface`.
 Connect to the PiFinder as described there, then open the Equipment page from
-the navigation menu. You'll find a list of your telescopes and a list of your
-eyepieces, each with buttons to add a new one, edit an existing one, or remove
-it.
+the navigation menu. You'll find a list of telescopes and a list of eyepieces,
+each with buttons to add, edit, or remove an item.
 
 A new PiFinder starts with a generic 200mm Dobsonian and a small set of Plössl
-eyepieces so the calculations have something to work with out of the box. Edit
-or replace these with your own equipment whenever you're ready.
+eyepieces so the calculations work out of the box. Edit or replace these with
+your own gear whenever you're ready.
 
 .. note::
    The on-device Equipment menu builds its list of telescopes and eyepieces
@@ -49,68 +45,68 @@ or replace these with your own equipment whenever you're ready.
 Choosing your active telescope and eyepiece
 -------------------------------------------
 
-The PiFinder uses one **active** telescope and one **active** eyepiece at a
-time for its calculations and displays. You can set these from either place:
+The PiFinder uses one **active** telescope and one **active** eyepiece at a time
+for its calculations and displays. Set these from either place:
 
 * **On the PiFinder**, open the :ref:`user_guide:tools` menu and select
-  Equipment. The Equipment screen shows your active telescope and eyepiece and,
+  Equipment. The Equipment screen shows the active telescope and eyepiece and,
   when both are set, the resulting magnification and true field of view. Choose
   "Telescope..." or "Eyepiece..." to pick from your stored gear.
 * **In the web interface**, use the Equipment page to mark a telescope or
-  eyepiece as active.
+  eyepiece active.
 
 .. image:: images/equipment/equipment_screen_docs.png
 
-Choosing "Telescope..." or "Eyepiece..." opens a list of your stored gear, with
-a check mark next to the active one. Use the **UP/DOWN** arrows to highlight a
-different item and **RIGHT** to make it active.
+Choosing "Telescope..." or "Eyepiece..." opens a list of your stored gear, a
+check mark beside the active one. Use the **UP/DOWN** arrows to highlight an
+item and **RIGHT** to make it active.
 
 .. image:: images/equipment/select_telescope_docs.png
    :width: 45%
 .. image:: images/equipment/select_eyepiece_docs.png
    :width: 45%
 
-If nothing is selected, the PiFinder simply skips the magnification and
-field-of-view figures and shows the object image in its default orientation.
+If nothing is selected, the PiFinder skips the magnification and field-of-view
+figures and shows the object image in its default orientation.
 
 Magnification and true field of view
 -------------------------------------
 
-Once an active telescope and eyepiece are set, the PiFinder shows two numbers
-on the Equipment screen:
+With an active telescope and eyepiece set, the PiFinder shows two numbers on the
+Equipment screen:
 
-* **Magnification** is the telescope's focal length divided by the eyepiece's
-  focal length. A 1000mm telescope with a 25mm eyepiece gives 40×.
-* **True field of view** (TFOV) is how much sky you actually see through that
-  combination, in degrees. This is the figure to compare against the push-to
-  distance: when the object is within half your true field of view of the
-  centre, it's in the eyepiece.
+* **Magnification** is the telescope's focal length divided by the eyepiece's.
+  A 1000mm telescope with a 25mm eyepiece gives 40×.
+* **True field of view** (TFOV) is how much sky you see through that
+  combination, in degrees. Compare it against the push-to distance: when the
+  object is within half your true field of view of the centre, it's in the
+  eyepiece.
 
 The true field of view also sets the starting zoom of the survey image on the
 :ref:`user_guide:object details` screen, so the image frames roughly the same
-patch of sky your eyepiece shows. You can still zoom in and out from there with
-the **+** and **-** keys.
+patch of sky your eyepiece shows. Zoom in and out from there with the **+** and
+**-** keys.
 
-Both figures also appear on the object image itself — the field of view in the
-top-left corner and the magnification in the top-right — so you always know the
-scale of what you're looking at.
+Both figures appear on the object image too — field of view in the top-left
+corner, magnification in the top-right — so you always know the scale of what
+you're looking at.
 
 .. image:: images/equipment/object_image_fov_mag_docs.png
 
 Matching the object image to your eyepiece: flip and flop
 ---------------------------------------------------------
 
-The survey images on the object details screen are oriented to match the view
-through your eyepiece, so you can compare them to what you see directly. Because
-different telescopes flip the view in different ways, two per-telescope options
-let you correct the orientation:
+The survey images on the object details screen are oriented to match your
+eyepiece view, so you can compare them directly. Different telescopes flip the
+view in different ways, so two per-telescope options let you correct the
+orientation:
 
 * **Flip image (upside down)** mirrors the image top to bottom.
 * **Flop image (left right)** mirrors the image left to right.
 
-You don't need to reason about your optics to set these. Point at a bright,
-recognisable object, compare the object image to your eyepiece view, and toggle
-the two options until they match:
+You don't need to reason about your optics. Point at a bright, recognisable
+object, compare the object image to your eyepiece view, and toggle the two
+options until they match:
 
 * If the image is **upside down** compared to the eyepiece, turn on **Flip**.
 * If the image is **mirrored** left-to-right, turn on **Flop**.
@@ -141,7 +137,7 @@ As a starting point for common setups:
 A plain Newtonian or Dobsonian needs neither option, which is why both are off
 by default. A star diagonal produces a mirror image, so you'll need exactly one
 of Flip or Flop; which one depends on how the diagonal sits in the focuser, so
-just pick whichever makes the image match.
+pick whichever makes the image match.
 
 .. note::
    Early PiFinder software shipped the default Dobsonian with Flop turned on by
@@ -151,9 +147,9 @@ just pick whichever makes the image match.
 Reversing the push-to arrows
 ----------------------------
 
-The same telescope settings include **Reverse Arrow A** and **Reverse Arrow B**.
-These flip the direction of the push-to arrows so they point the way your
-telescope actually moves. If you find that nudging the scope in the direction an
-arrow points sends the target further away instead of closer, turn on the
-matching reverse option. The two arrows cover the two directions of movement, so
-enable A, B, or both until the arrows guide you the right way.
+The same telescope settings include **Reverse Arrow A** and **Reverse Arrow B**,
+which flip the push-to arrows so they point the way your telescope actually
+moves. If nudging the scope in the direction an arrow points sends the target
+further away instead of closer, turn on the matching reverse option. The two
+arrows cover the two directions of movement, so enable A, B, or both until the
+arrows guide you the right way.

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -4,73 +4,67 @@ Quick Start
 .. note::
    This documentation is for v3 and v2.5 PiFinders running software 2.2.0 or above.
    You can see what version of software is running by looking in the upper right of
-   the welcome screen. 
+   the welcome screen.
 
    If you need docs for a previous version please choose `1.x.x <https://pifinder.readthedocs.io/en/v1.11.2/index.html>`_
    , `2.0.x <https://pifinder.readthedocs.io/en/v2.0.4/index.html>`_
    or `2.1.x <https://pifinder.readthedocs.io/en/v2.1.1/index.html>`_
 
-Congratulations on getting your hands on a PiFinder™! Whether you’ve built it from scratch, or ordered a completed model 
-from BBLabs, you’re on your way to a whole new level of accuracy and ease while observing the night sky.
+Congratulations on getting your hands on a PiFinder™! Whether you built it yourself or
+ordered a finished unit from BBLabs, you're on your way to a new level of accuracy and
+ease at the eyepiece.
 
-This Quick Start guide aims to get you out and observing with most everything you need.  For more depth and information
-about non observing functions, checkout the full :doc:`User Guide<user_guide>` 
+This Quick Start gets you out and observing with most of what you need. For the rest —
+settings and non-observing functions — see the full :doc:`User Guide <user_guide>`.
 
-We’ll walk you through getting your PiFinder up and running for the first time, give you step-by-step instructions for 
-your first night out, show you how to change your settings, and get you confident in understanding how PiFinder works. 
+We'll get your PiFinder running for the first time, walk you through your first night out,
+show you how to change your settings, and leave you confident in how it works.
 
-PiFinder uses its camera to take continuous pictures of the stars it sees, compares those stars to its database, and 
-then tells you exactly where you’re pointed. It does that process, called “plate solving”, constantly, so it always 
-knows where you’re aimed. It also uses an accelerometer (much like most modern mobile phones) to feel when you move 
-the scope, and these two processes help tell it where you are, and the PiFinder in turn can tell you where you need 
-to go.
-
-PiFinder was created by software engineer and amateur astronomer Richard Wolff-Jacobson, who realized he could use 
-his engineering and coding experience to create a brand new way to get more out of his time at the telescope. He saw 
-that plate solving technology could be handled by the famous Raspberry Pi single-board computer and a simple camera. 
-The software and rig he developed will turn your telescope into an accurate guide through the night sky.
+PiFinder takes continuous pictures of the stars, compares them to its database, and tells
+you exactly where your scope is pointed. This process — called *plate solving* — runs
+constantly, so the PiFinder always knows your aim. An accelerometer (like the one in a
+mobile phone) senses when you move the scope, so between solves the PiFinder can still
+tell you where to go.
 
 .. image:: images/quick_start/v3_slate_family_front.jpeg
 
 Unboxing
 --------
 
-The PiFinder comes fully assembled and ready to use.  The keypad and screen are the primary way you'll interact
-with the PiFinder, choosing what to look for, getting Push-To guidance and logging objects.
+The PiFinder arrives fully assembled and ready to use. The keypad and screen are how
+you'll interact with it — choosing what to look for, getting Push-To guidance, and logging
+objects.
 
 .. image:: images/quick_start/pf_front.jpeg
    :width: 45%
 .. image:: images/quick_start/pf_rear.jpeg
    :width: 45%
 
-Depending on the configuration of your PiFinder the camera may be facing a different direction or be located
-in a different spot.  This is to make sure the camera sees the sky while the keypad and screen are comfortable
-for an observer to reach on any type of scope.
+Depending on your configuration, the camera may face a different direction or sit in a
+different spot, so it can see the sky while the keypad and screen stay within easy reach
+on any type of scope.
 
 
 Powering the PiFinder
 ----------------------
 
-If you purchased or built your PiFinder with the optional internal battery, you’ll need to charge the 
-battery before first use. Plug a USB-C charging cable into the port on the top of the PiFinder, 
-closest to the back of the case, as indicated below with an arrow.  The charging indicator will glow 
-blue when charging and switch to green when complete.
+If your PiFinder has the optional internal battery, charge it before first use. Plug a
+USB-C cable into the port on top, closest to the back of the case, arrowed below. The
+charging indicator glows blue while charging and turns green when complete.
 
-For battery powered units, the power switch is the small white switch located on top of the PiFinder 
-above the screen highlighted with a box below. While facing the screen slide it right to turn it on, left to turn it off. 
+The power switch is the small white switch on top, above the screen, boxed below. Facing
+the screen, slide it right for on, left for off.
 
 .. image:: images/quick_start/power.jpeg
 
-If you use an external power source, you can use either USB-C port to power the unit.  The USB-C port on the Raspberry Pi which 
-is closest to the keypad (there will be only one if you don't have the internal battery) will power the unit, but not 
-charge the internal battery. You can use the regular charging connector to both power the unit and charge the battery 
-from external power if you turn the white power switch to the 'On' position.
+For external power, either USB-C port will run the unit. The port on the Raspberry Pi
+nearest the keypad (the only one if you don't have the internal battery) powers the
+PiFinder but won't charge the battery. To both power the unit and charge the battery from
+external power, use the charging connector with the white switch set to On.
 
-Note that when you turn on your PiFinder for the first time, it will take a minute to start up. During initial
-startup, the welcome screen will come and go as the PiFinder restarts but subsequent power-on's will be much quicker.
-
-Once the PiFinder is powered on, an welcome image will appear on the screen.  You’ll then see some information about 
-the loading process and finally the Main Menu will appear.
+The first power-on takes a minute, and the welcome screen may come and go as the PiFinder
+restarts; later start-ups are much quicker. Once it's powered on, you'll see a welcome
+image, then some loading information, and finally the Main Menu.
 
 
 
@@ -78,63 +72,64 @@ the loading process and finally the Main Menu will appear.
 Using the PiFinder
 -------------------
 
-The PiFinder features a scrolling menu with the active option highlighted in the middle of the screen.  
+The PiFinder uses a scrolling menu with the active option highlighted in the middle of
+the screen.
 
 .. image:: images/quick_start/pifinder_main_menu.png
 
-All the features of the PiFinder are available through this menu by scrolling, selecting options
-or moving to new menu screens.
+Every feature is reached through this menu — by scrolling, selecting options, or moving
+between screens:
 
-- The **UP** and **DOWN** arrows will scroll the current menu
-- The **RIGHT** arrow will activate the current option; selecting it or moving to another menu
-- The **LEFT** arrow will take you back to the previous menu or screen
-- Holding **LEFT** for more than one second will always take you back to the TOP of the menus
+- The **UP** and **DOWN** arrows scroll the current menu
+- The **RIGHT** arrow activates the current option, selecting it or moving to another menu
+- The **LEFT** arrow takes you back to the previous menu or screen
+- Holding **LEFT** for more than a second always jumps back to the TOP of the menus
 
-Some menus, like the catalog selection, allow you to check on an off multiple options using
-the RIGHT arrow
+Some menus, like the catalog selection, let you check multiple options on and off with the
+**RIGHT** arrow.
 
 .. image:: images/quick_start/filter_menu_docs.png
 .. image:: images/quick_start/catalog_select_docs.png
 
-There are menu items which take you to specific functions, like a star chart showing where
-your telescope is currently pointing.
+Other menu items take you to specific functions, like a star chart showing where your
+telescope is currently pointing.
 
 .. image:: images/quick_start/chart_menu_select_docs.png
 .. image:: images/quick_start/chart_docs.png
 
-The **LEFT** arrow will always take you back to the previous menu or screen. 
+The **LEFT** arrow always takes you back to the previous menu or screen.
 
-Many screens will use the number keys along with **+**,**-**, and **SQUARE** to perform other functions.  
-These are listed in the help pages for that screen.
+Many screens use the number keys along with **+**, **-**, and **SQUARE** for extra
+functions, listed in that screen's help pages.
 
-To access the help page for a screen (along with other useful screen specific items) hold down 
-the **SQUARE** button for more than 1 second to bring up the handy Radial Menu
+To open a screen's help (and other screen-specific options), hold **SQUARE** for more than
+a second to bring up the handy Radial Menu.
 
 
 .. image:: images/quick_start/main_menu_marking.png
 
-The Radial menu presents four options you can access quickly using the arrow keys.  The **UP** 
-arrow will normally select HELP.  
+The Radial Menu offers four options you can reach quickly with the arrow keys; **UP**
+normally selects HELP.
 
 .. image:: images/quick_start/main_menu_help.png
 
-You can read through all the help for a particular screen by using the **UP** and **DOWN** arrows.
+Use the **UP** and **DOWN** arrows to read through all of a screen's help.
 
-The PiFinder has a lot of powerful features, but they are all available from this menu system 
-and are designed to use this same basic set of buttons to move around.
+The PiFinder has a lot of powerful features, but they all live in this menu system and use
+the same basic set of buttons to get around.
 
 Configuration Setup
 --------------------
 
-The PiFinder is available in multiple configurations (Right/Left/Straight/Flat).  You'll need to set the correct 
-configuration in the software so the PiFinder can provide appropriate pointing directions for your specific set up.
+The PiFinder comes in several configurations (Right/Left/Straight/Flat). Set yours in the
+software so the PiFinder can give pointing directions that match your setup.
 
-Use the menu to select Settings from the main menu and then scroll down and select PiFinder Type
+From the main menu, select Settings, then scroll down and select PiFinder Type.
 
 .. image:: images/quick_start/settings_select.png
 .. image:: images/quick_start/settings_menu_config.png
 
-Scroll to highlight the type of PiFinder you are using and press RIGHT to make your selection.  This will restart
+Highlight the type of PiFinder you're using and press **RIGHT** to select it. This restarts
 the PiFinder software.
 
 .. image:: images/quick_start/pifinder_type_select.png
@@ -143,9 +138,9 @@ the PiFinder software.
 Mounting
 ---------
 
-The PiFinder comes set up for a dovetail for mounting, which is 32mm wide and fits the standard 
-finder shoe found on most scopes. Here's an image of the finder shoe and a version 1 PiFinder 
-mounted in it.  Current PiFinders attach to your scope in just the same way.
+The PiFinder comes set up with a 32 mm dovetail that fits the standard finder shoe found on
+most scopes. Below is the finder shoe with a version 1 PiFinder mounted in it; current
+PiFinders attach the same way.
 
 
 .. image:: images/quick_start/mount_shoe.jpeg
@@ -154,42 +149,41 @@ mounted in it.  Current PiFinders attach to your scope in just the same way.
 .. image:: images/quick_start/pifinder_mounted.jpeg
    :width: 47%
 
-The PiFinder must be mounted in a way that is close to perpendicular to the ground, otherwise it will
-not be as accurate when estimating position while moving. The beauty of the PiFinder is that it always 
-knows where it’s looking in the sky and it is programmed to assume it is perpendicular to the earth, so 
-it will give you instructions based on that assumption.
+Mount the PiFinder close to perpendicular to the ground, or it won't be as accurate when
+estimating position as you move. The PiFinder always knows where it's looking and assumes
+it's perpendicular to the earth, giving its instructions on that basis.
 
-The dovetail that comes with the PiFinder is adjustable to allow the PiFinder to sit upright, even if 
-your finder shoe is not right at the top of your optical tube.  Loosen the two screws in the dovetail, 
-put the PiFinder on your scope and adjust the angle until it’s roughly perpendicular to the ground.  
-Once you’re happy, remove the PiFinder and tighten the two adjustment screws.  You should be all set for a night of observing!
+The dovetail is adjustable so the PiFinder can sit upright even if your finder shoe isn't
+right at the top of the optical tube. Loosen the two dovetail screws, set the PiFinder on
+your scope, and adjust the angle until it's roughly perpendicular to the ground. Once
+you're happy, remove the PiFinder and tighten the two screws. You're all set for a night
+of observing.
 
 .. note::
-   * Make sure to mount the PiFinder in such a way that the camera has an unimpeded view of the sky. 
-   * There are different versions of the PiFinder for left, right, straight and flat mounting and the software 
-     needs to be configured properly for each.  Check the 'Configuration Setup' section above to see how to adjust this.
+   * Mount the PiFinder so the camera has an unimpeded view of the sky.
+   * Left, right, straight and flat versions each need the software configured to match —
+     see the 'Configuration Setup' section above.
 
 
 First Time Out
 --------------
 
-Once your PiFinder is charged and your mount is set on your scope, you’re ready to  head out 
-to your observing site! Set up your scope, mount your PiFinder, and read on…
+Once your PiFinder is charged and your mount is set on your scope, you're ready to head out
+to your observing site. Set up your scope, mount your PiFinder, and read on.
 
-You’ll be able to turn on your PiFinder and start using it as soon as you see multiple stars in 
-the part of the sky where the PiFinder is pointed. PiFinder uses the stars (and its internal GPS 
-sensor) to learn where it is and what it’s looking at, so it needs a few stars in order to get 
-started. This may happen a little after sunset, or, if you’re in an area with light pollution, 
-you may have to wait until full darkness. 
+You can start using the PiFinder as soon as several stars are visible in the part of the
+sky it faces — it uses those stars (and its internal GPS sensor) to learn where it is and
+what it's looking at, so it needs a few stars to get going. That might be soon after
+sunset, or, under light pollution, not until full darkness.
 
-There are two icons in the upper right of the screen that will tell you if the PiFinder knows 
-where it is: one shows a satellite dish which will be solid when there is a GPS signal and 
-a location has been acquired, and will flash when searching for a location and time.
+Two icons in the upper right tell you whether the PiFinder knows where it is. The satellite
+dish is solid once a GPS signal is received and a location acquired, and flashes while
+searching for location and time.
 
-The other indicator shows how the PiFinder has determined your current telescope position.  It will 
-display a camera if it has plate-solved its current view and this camera icon will fade if the scope 
-is moving and it's using the accelerometer.  If you see an 'X', the PiFinder has yet to determine 
-where it's pointing (see :ref:`quick_start:setting focus & first solve`)
+The other icon shows how the PiFinder determined your telescope's position. A camera means
+it has plate-solved its current view; the camera fades when the scope is moving and it's
+relying on the accelerometer. An 'X' means it hasn't worked out where it's pointing yet
+(see :ref:`quick_start:setting focus & first solve`).
 
 .. list-table::
 
@@ -214,32 +208,28 @@ where it's pointing (see :ref:`quick_start:setting focus & first solve`)
 
 
 .. note::
-   The GPS receiver in the PiFinder must be outside to get a GPS lock and may take several
-   minutes to receive all the data required to calculate its location and date/time.
+   The GPS receiver must be outside to get a lock, and it can take several minutes to
+   gather everything it needs to calculate its location and date/time. Expect a longer wait
+   after the PiFinder has been off for a long period, or moved a distance while off; later
+   start-ups at the same location are quicker.
 
-   This delay is longer after the PiFinder has been off for a long period or moved a distance
-   while it's turned off.  Subsequent start ups at the same location should be quicker.
-
-   Leaving the PiFinder on the GPS Status screen will result in a faster lock time as 
-   this screen disables the camera, reducing the overall EM noise and helping the GPS
-   receiver see more satellites.
+   Leaving the PiFinder on the GPS Status screen speeds up the lock: this screen disables
+   the camera, which reduces EM noise and helps the receiver see more satellites.
 
 
 
 Adjusting Brightness
 ^^^^^^^^^^^^^^^^^^^^^
 
-The PiFinder is designed to allow you to adjust the brightness of the screen and keypad at any 
-time: simply hold down the **SQUARE** button and push **+** for brighter, or **-** for dimmer. In a dark sky 
-site, you can turn the brightness down to preserve your dark-adapted vision.
+You can adjust the brightness of the screen and keypad at any time: hold **SQUARE** and
+press **+** for brighter, or **-** for dimmer. At a dark sky site, turn it right down to
+preserve your dark-adapted vision.
 
 .. note::
-   The PiFinder will dim the screen and reduce the frequency of exposures, solving, and other processes 
-   when it’s been idle for a period of time. This helps save battery power and can also prevent glare 
-   at the eyepiece in especially dark environments. The default is 30 seconds and this can be configured, 
-   or turned off completely, in the :ref:`user_guide:settings menu`
-
-   Pressing any button, or moving the PFinder will wake it from power save mode.
+   After it's been idle for a while, the PiFinder dims the screen and slows its exposures,
+   solving, and other processes to save battery and prevent glare at the eyepiece. The
+   default is 30 seconds; you can change it, or turn it off, in the
+   :ref:`user_guide:settings menu`. Any button press, or moving the PiFinder, wakes it.
 
 Start with the Start menu
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -250,24 +240,24 @@ At the start of each session, you may need to do three things:
 - Align the PiFinder by telling it where your scope is pointing
 - Check the status of the GPS lock
 
-We've organized these three items into the 'Start' menu listed at the top of the PiFinder main menu.
+These three items live in the 'Start' menu at the top of the PiFinder main menu.
 
 .. image:: images/quick_start/pifinder_main_menu.png
 
-You may not need to do all of these things at the start of every session.  The focus should generally remain 
-the same from night to night and if you leave your PiFinder on your scope you may not need to adjust the 
-alignment each time.  To perform most functions the PiFinder will require a GPS signal, and this should
-happen automatically, but the GPS Status screen can be used to monitor progress towards a lock and also 
-boosts the GPS signal.  This can help in marginal situations or to speed things along.
+You won't always need all three. Focus generally holds from night to night, and if you
+leave your PiFinder on your scope you may not need to re-align. Most functions need a GPS
+signal, which happens automatically — but the GPS Status screen lets you monitor progress
+toward a lock and boost the signal, which helps in marginal conditions or to speed things
+along.
 
 
 Setting Focus & First Solve
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Once you see stars populating the sky, turn on your PiFinder and aim your scope at one of the brightest 
-best stars you can see. Make sure your lens cap is off, and immediately PiFinder will get to work solving 
-what it sees.... the focus point of the lens is set when your PiFinder is assembled, but it may need
-some adjustment to see the dimmest stars.
+Once stars are populating the sky, turn on your PiFinder, take off the lens cap, and aim at
+one of the brightest stars you can see; it gets to work solving straight away. The lens
+focus is set when your PiFinder is assembled, but may need a little adjustment to catch the
+dimmest stars.
 
 .. note::
    **Focus is the single most common reason a PiFinder won't solve.**  Stars that look
@@ -275,20 +265,19 @@ some adjustment to see the dimmest stars.
    to 2x and 4x with the **+/-** keys and keep adjusting until the stars are as small as
    you can make them.
 
-Screw the lens in and out in the holder to adjust focus if needed.  If you're starting
-from scratch — a new build, or a lens that's been moved — set the lens so about 6mm of
-thread is showing (roughly the width of a pencil).  That's close to in focus and a good
-place to begin.
+Screw the lens in and out in the holder to adjust focus. Starting from scratch — a new
+build, or a lens that's been moved — set the lens so about 6 mm of thread is showing
+(roughly the width of a pencil). That's close to in focus and a good place to begin.
 
-Use the menu system to select the 'Focus' option under the 'Start' menu
+Select the 'Focus' option under the 'Start' menu.
 
 .. image:: images/quick_start/start_menu.png
 
-The Focus screen shows a live preview of what the camera is seeing.  It uses special image processing to 
-highlight stars and remove background skyglow so that you can easily focus your PiFinder camera.
+The Focus screen shows a live preview of what the camera is seeing, with special image
+processing that highlights stars and removes background skyglow to make focusing easier.
 
-If there are no stars visible or the image is too defocused the screen may seem too bright or dark or 
-have a noisy appearance, this is normal until the camera is near focus.  See below for some examples
+With no stars visible or the image well out of focus, the screen may look too bright, too
+dark, or noisy — normal until the camera is near focus. Some examples:
 
 .. list-table::
 
@@ -301,14 +290,14 @@ have a noisy appearance, this is normal until the camera is near focus.  See bel
           Tightly focused star with darkened background
 
 
-Try to pan your scope until you see some bright object in the camera view.  You can screw the lens in and out 
-to adjust focus.  Once something star-like is in the FOV and near focus, the image processing in the preview screen 
-will work properly and start dimming the background and highlighting the stars.
+Pan your scope until a bright object appears in the camera view. Screw the lens in and out
+to focus; once something star-like is in the FOV and near focus, the preview's image
+processing will work properly and start dimming the background and highlighting the stars.
 
-Good focus is important for the quickest solves.  Close will work, but you should use the **+/-** keys to zoom the view to 2x and 4x
-to get the stars as tight as you reasonably can.  If the sky is dark enough and you've got focus 
-correct, you should see the camera icon appear in the top right and the current constellation will be shown in 
-the title bar.  Congratulations, the PiFinder knows where it is pointing!
+Good focus means the quickest solves. Close will work, but use the **+/-** keys to zoom the
+view to 2x and 4x and get the stars as tight as you reasonably can. With dark enough skies
+and good focus, the camera icon appears in the top right and the current constellation
+shows in the title bar. Congratulations — the PiFinder knows where it's pointing!
 
 
 .. note::
@@ -329,206 +318,190 @@ the title bar.  Congratulations, the PiFinder knows where it is pointing!
 
 Alignment
 ^^^^^^^^^^^
-In order to get the most out of PiFinder, you must align it with your telescope. The PiFinder
-uses a digital alignment system. Rather than physically adjust the PiFinder so the center
-of it's FOV lines up with your telescope, you tell the PiFinder where within it's wide FOV 
-your telescope is pointing.
+To get the most out of PiFinder, you need to align it with your telescope. PiFinder uses
+*digital* alignment: instead of physically nudging the PiFinder so its field of view matches
+your scope, you simply tell it where your scope is pointing within its wide field.
 
-The PiFinder camera sees a patch of sky that is 10 degrees wide.  That's about 20 full moons
-across and the much smaller field of view (FOV) of your telescope is somewhere in 
-that patch of sky.  By pointing your telescope at a star, and then selecting that same star 
-on the PiFinder's alignment chart, you are telling the PiFinder where to put DSO's so they
-are in the middle of your eyepiece each time.
+The camera sees a 10° patch of sky — about 20 full moons across — and your eyepiece's much
+smaller field sits somewhere inside it. By pointing your telescope at a star and then
+selecting that same star on PiFinder's chart, you tell PiFinder exactly where to place
+objects so they land in the center of your eyepiece.
 
 .. note::
-   The instructions below are for the new alignment system in PiFinders running software
-   version 2.1.0 and above.  For the previous alignment instructions, please 
-   `click here <https://pifinder.readthedocs.io/en/v2.0.4/quick_start.html#alignment>`_
+   These instructions cover the alignment system in software version 2.1.0 and above. For
+   the previous instructions, `click here <https://pifinder.readthedocs.io/en/v2.0.4/quick_start.html#alignment>`_.
 
-
-To begin, select the 'Align' option from the 'Start' menu 
+To begin, select 'Align' from the 'Start' menu.
 
 .. image:: images/quick_start/start_align_selected.png
 
-You'll see a rendered star chart with constellation lines showing the area of the sky the
-PiFinder is seeing.  If you instead see a message about not having a solve, return to the 
-focus section above.
+You'll see a rendered star chart with constellation lines showing the sky PiFinder is
+currently seeing. If you instead see a message about not having a solve, return to the focus
+section above.
 
 .. image:: images/quick_start/align_intro.png
 
-In this chart view the current alignment point is shown with a Telrad style reticle. As
-you move your telescope, this chart will update and you can zoom in and out using the **+/-**
-keys.
+The current alignment point is marked with a Telrad-style reticle. As you move your
+telescope the chart updates, and you can zoom in and out with the **+/-** keys.
 
 .. note::
-   The Telrad-style reticle marks where your telescope is currently pointing *within* the
-   camera's wide 10° field of view.  It is not meant to sit in the center of the chart, so
-   seeing it off to one side — as in the image above — is completely normal and does not
-   mean your PiFinder is misaligned or faulty.
+   The reticle marks where your telescope is pointing *within* the camera's wide 10° field,
+   so it normally sits off to one side rather than in the center. That's expected and does
+   not mean your PiFinder is misaligned.
 
-Next, pick a star you can easily recognize in the sky.  This can be a bright star, or 
-a star which is part of a distinctive constellation or asterism.  You can choose any star
-you can see with your naked eye, but you can't align using a planet.  Point your telescope
-at this star and roughly center it in your eyepiece.
+Now align in a few steps:
 
-Look at the screen of the PiFinder and you should see the star plotted there.  You can use
-the **+/-** key to zoom out and make it easier to identify the star if needed.
+1. Pick a star you can easily recognize — a bright star, or one in a distinctive
+   constellation or asterism. Any naked-eye star works, but you can't align on a planet.
+   Point your telescope at it and roughly center it in your eyepiece.
+2. Look at the PiFinder screen and find that star plotted there. Use the **+/-** keys to
+   zoom out if it helps you identify it.
+3. Press **SQUARE** to switch to star-selection mode.
 
-Press the **SQUARE** button to switch to star-selection mode
+   .. image:: images/quick_start/align_start.png
 
-.. image:: images/quick_start/align_start.png
+   The large reticle is replaced by a small selection marker. The arrow keys jump it to the
+   next closest star in that direction.
 
-The large reticle will be replaced with a smaller selection marker that you can move from star
-to star using the arrow keys.  Pressing one of the arrows will move the selection to the next 
-closest star in that direction.
+   .. image:: images/quick_start/align_select.png
 
-.. image:: images/quick_start/align_select.png
-
-Once you have used the arrow keys to highlight the star your telescope is pointing at 
-go back to the eyepiece and center it up as well you can.  When you press the 
-**SQUARE** button to select the star, the PiFinder will put objects you want to see
-wherever in your telescope eyepiece the star is at that moment
-
-Press the **SQUARE** button to complete the alignment, or you can press the **0** key
-to exit alignment mode without changing the alignment point.
+4. Use the arrow keys to highlight the star your telescope is pointing at, then return to
+   the eyepiece and center it as well as you can.
+5. Press **SQUARE** to complete the alignment — PiFinder will now place objects wherever in
+   your eyepiece that star sits. Or press **0** to exit without changing the alignment point.
 
 .. image:: images/quick_start/align_done.png
 
-The indicator will return to the normal Telrad style reticle to indicate the newly adjusted
-alignment point.  
-
-The PiFinder will save this alignment point so you won't need to complete this process again
-unless you remove and re-attach your PiFinder to your telescope.
+The marker returns to the normal Telrad-style reticle, showing your newly adjusted alignment
+point. PiFinder saves it, so you won't need to repeat this unless you remove and re-attach
+the PiFinder to your telescope.
 
 .. note::
-   You can also align using any catalog object!  If you have used the PiFinder to find an object
-   and it's not centered in your eyepiece, center it up, hold down the **SQUARE** key for one 
-   second and choose align.  
-
-   This is not the same as adding alignment points to a standard DSC to improve accuracy, this is 
-   simply telling the PiFinder where in your eyepiece you'd like objects to be put if your initial
-   alignment was not quite to your liking.
+   You can also align on any catalog object. If you've found an object and it's not centered,
+   center it up, hold **SQUARE** for one second, and choose align. This isn't like adding
+   alignment points to a standard DSC for accuracy — it simply tells PiFinder where in your
+   eyepiece you'd like objects placed if your initial alignment wasn't quite right.
 
 
 GPS Status
 ^^^^^^^^^^^
 
-There is a GPS status indicator in the PiFinder title bar which will flash while the PiFinder is 
-searching for it's position and time.  This indicator will turn solid once the PiFinder knows where
-it's at and what time it is.  You can monitor this process and activate a special signal boost mode
-via the 'GPS Status' menu item in the 'Start' menu.
+A GPS status indicator in the PiFinder title bar flashes while the PiFinder searches for its
+position and time, and turns solid once it knows where and when it is. You can monitor this
+process and turn on a signal-boost mode from the 'GPS Status' item in the 'Start' menu.
 
 .. image:: images/quick_start/start_gps_selected.png
 
-This screen has two modes, one with basic details in larger text and a full details mode.  You can 
-switch between them using the SQUARE button.
+The screen has two modes — a large-text summary and a full-details view — and you switch
+between them with the **SQUARE** button.
 
 .. list-table::
 
    * - .. figure:: images/quick_start/GPS_Status.png
 
-          Easy to read summary 
+          Easy to read summary
 
      - .. figure:: images/quick_start/GPS_Status_details.png
 
           Full details view
 
 
-If you are using the PiFinder under partially obstructed skies, or locking is just taking longer than
-you like, you can leave this screen active to enhance the GPS signal by temporarily stopping the camera.
-Like most electronics, the camera system generates electromagnetic noise that can make it more difficult
-for the subtle GPS satellite signals.
+Under partially obstructed skies, or when a lock is just taking longer than you'd like,
+leave this screen active to boost the GPS signal by temporarily stopping the camera. Like
+most electronics, the camera generates electromagnetic noise that can drown out the faint
+GPS satellite signals.
 
-Once a lock is indicated, you can press the LEFT arrow to return to the menu, re-activate the camera, 
-and continue on to find your first object!
+Once a lock shows, press the **LEFT** arrow to return to the menu, re-activate the camera,
+and go find your first object.
 
 
 
 Find Your First Object
 ^^^^^^^^^^^^^^^^^^^^^^^^
-Now that you’re aligned, it’s time to explore!  We'll walk you through the steps to select an object to find,
-get some information about it, and push your scope so it's in the eyepiece.
+Now that you're aligned, it's time to explore. We'll select an object, get some information
+about it, and push your scope until it's in the eyepiece.
 
-- Hold the **LEFT** arrow button for more than a second to jump to the main menu if you are not already there
+- Hold the **LEFT** arrow for more than a second to jump to the main menu if you're not
+  already there
 - Select Objects from the menu
 
 .. image:: images/quick_start/main_menu_01_docs.png
 .. image:: images/quick_start/objects_menu_01.png
 
-- Scroll down to find the By Catalog option to browse objects by catalog
+- Scroll down to By Catalog to browse objects by catalog
 - Select the Messier catalog from the menu
 
 .. image:: images/quick_start/objects_menu_02.png
 .. image:: images/quick_start/by_catalog_01.png
 
-After selecting the Messier catalog you'll see the heart of the PiFinder observing system, the Objects List!
-In this case the Objects List is showing all the objects that match your :ref:`filters<user_guide:filters>`
-from the Messier catalog.  
+Selecting the Messier catalog brings up the heart of the PiFinder observing system, the
+Objects List. Here it shows every Messier object that matches your
+:ref:`filters<user_guide:filters>`.
 
 .. image:: images/quick_start/messier_01.png
 .. image:: images/quick_start/messier_02.png
 
-- Press the **SQUARE** key to cycle through the different information to display about each object: Locate,
-  Names, or Magnitude/Size
+- Press the **SQUARE** key to cycle the information shown for each object: Locate, Names, or
+  Magnitude/Size
 
 .. image:: images/quick_start/messier_03.png
 .. image:: images/quick_start/messier_04.png
 
-- Use the **UP** and **DN** keys to browse objects and select one you want to view
-- Press the **RIGHT** arrow key to access Object Details, including Push-To guidance
+- Use the **UP** and **DOWN** keys to browse objects and pick one you want to view
+- Press the **RIGHT** arrow to open Object Details, including Push-To guidance
 
 .. image:: images/quick_start/M13_locate.png
 
-Object Details will show Push-To instructions by default, but you can use the **SQUARE** key to see
-an image of any object or catalog details.
+Object Details shows Push-To instructions by default; press the **SQUARE** key to see an
+image of the object or its catalog details instead.
 
 .. image:: images/quick_start/M13_image.png
 .. image:: images/quick_start/M13_details.png
 
-Now it's time to point your scope at the selected object!
+Now point your scope at the object.
 
-- Press the **SQUARE** to cycle through the object information until you see the Push-To instructions
+- Press **SQUARE** to cycle the object information until you see the Push-To instructions
 
 .. image:: images/quick_start/M13_locate.png
 
-The Push-To instructions show how many degrees to move your scope on each axis in order to find the
-current object.  The top arrow and number tell you which direction to spin your scope clockwise vs. 
-counterclockwise, and how far in degrees. The lower arrow tells you whether to move your scope up towards 
-zenith, or down towards the horizon, and how far in degrees.
+The Push-To instructions show how far to move your scope on each axis. The top arrow and
+number tell you which way to spin the scope — clockwise or counterclockwise — and how far in
+degrees. The lower arrow tells you whether to move toward the zenith or the horizon, and how
+far in degrees.
 
-While watching the numbers, move your scope and the numbers should change to indicate
-how much closer or further you are from the object.  When you get the numbers near zero, the object should
-be in your eyepiece!
+Watch the numbers as you move the scope; they change to show how much closer or further you
+are from the object. When both are near zero, the object should be in your eyepiece.
 
 .. note::
-   - How close you need to get to 0.00/0.00 depends on your eyepiece.  If you have an eyepiece with a true
-     field of view of 1/2 degree, then a readout below 0.25/0.25 will assure the object is somewhere in your eyepiece FOV
-   - When moving your scope the PiFinder uses it's accelerometer to estimate where your telescope is pointing.  This is 
-     less accurate than a plate solve, so the numbers displayed dim slightly to signal this.  As soon as you stop
-     moving the telescope, the PiFinder will take a new image of the sky and determine exactly where your scope is pointing.
-     The numbers displayed will shift a bit and become brighter indicating a 100% reliable position.
+   - How close to 0.00/0.00 you need to get depends on your eyepiece. With a true field of
+     view of 1/2 degree, a readout below 0.25/0.25 puts the object somewhere in your eyepiece.
+   - While you're moving, the PiFinder estimates position from its accelerometer — less
+     accurate than a plate solve, so the numbers dim slightly. Stop moving and it takes a fresh
+     image, fixes your exact position, and the numbers shift a little and brighten to show a
+     reliable solve.
 
 
 Shutting down the PiFinder
 ---------------------------
 
-Although shutting down is not strictly needed before power-off, the PiFinder is a computer and there is a chance of
-file corruption if you do not.  Some MicroSD cards are more sensitive to this than others.
+Shutting down isn't strictly required before power-off, but the PiFinder is a computer and
+skipping it risks file corruption — some MicroSD cards more than others.
 
-To easily shut down the PiFinder:
+To shut down cleanly:
 
-- Hold the **LEFT** arrow button for more than a second to jump to the main menu
-- Hold the **SQUARE** button to access the Radial menu
+- Hold the **LEFT** arrow for more than a second to jump to the main menu
+- Hold the **SQUARE** button to open the Radial Menu
 
 .. image:: images/quick_start/main_menu_01_docs.png
 .. image:: images/quick_start/main_menu_marking.png
 
 - Press **DOWN** to select the SHUTDOWN option
-- Use the **RIGHT** arrow to confirm, or the **LEFT** arrow to go back
+- Press the **RIGHT** arrow to confirm, or the **LEFT** arrow to go back
 
 .. image:: images/quick_start/shutdown_confirm.png
 
-When you confirm the screen and keypad will turn off after a few seconds and it's then safe to
-turn off the unit using the power switch or unplugging the battery.
+The screen and keypad turn off after a few seconds; it's then safe to switch off the unit
+with the power switch or unplug the battery.
 
-You've now got the basics of using the PiFinder sorted, to learn more you can continue on to the full :doc:`user_guide`
+That's the basics of using your PiFinder sorted. To learn more, continue to the full
+:doc:`user_guide`.

--- a/docs/source/skysafari.rst
+++ b/docs/source/skysafari.rst
@@ -4,81 +4,80 @@ SkySafari
 
 
 Network Setup
-=============
+-------------
 
-Before using this guide, make sure that your device is on the same network as the PiFinder.  See the :ref:`User Guide<user_guide:wifi>` for details on changing WiFi modes and finding the IP address of the PiFinder
+First, make sure your device is on the same network as the PiFinder.  See the :ref:`User Guide<user_guide:wifi>` for changing WiFi modes and finding the PiFinder's IP address.
 
 App Setup
-===============
+---------
 
-Connecting to a telescope requires SkySafari Plus or Pro and the first step is to setup a telescope profile.  Do this via the settings page in the Telescope section:
+Connecting requires SkySafari Plus or Pro.  Start by setting up a telescope profile from the Telescope section of the settings page:
 
 
 .. image:: images/SkySafari/IMG_4792.jpeg
    :alt: Setup
 
 
-After clicking 'Presets', use the + button at the bottom right to add a new profile.
+Click 'Presets', then use the + button at the bottom right to add a new profile.
 
 
 .. image:: images/SkySafari/IMG_4793.jpeg
    :alt: Type
 
 
-Select 'Other' as the telescope type
+Select 'Other' as the telescope type.
 
 
 .. image:: images/SkySafari/IMG_4794.jpeg
    :alt: Setup
 
 
-The 'Alt-Az.' GoTo as the scope type, even if you don't have a GoTo scope.  Selecting GoTo here allows you to send objects from SkySafari to the PiFinder observing list if desired.
+Choose 'Alt-Az. GoTo' as the mount type, even without a GoTo scope — GoTo lets you send objects from SkySafari to the PiFinder observing list.
 
 
 .. image:: images/SkySafari/IMG_4796.jpeg
    :alt: Setup
 
 
-Select 'Meade LX200 Classic' for the scope type and click 'Next'
+Select 'Meade LX200 Classic' for the scope type and click 'Next'.
 
 
 .. image:: images/SkySafari/IMG_4797.jpeg
    :alt: Setup
 
 
-You should be able to use ``pifinder.local`` for the IP address, but if this does not work, check the Status screen for the numeric IP address of the PiFinder.  Port 4030 seems to be the default for SkySafari, but change it to 4030 if there is another value populated.
+Use ``pifinder.local`` for the IP address; if that doesn't work, check the Status screen for the numeric IP.  Set the port to 4030, the SkySafari default.
 
-Click 'Next' to continue
+Click 'Next' to continue.
 
 
 .. image:: images/SkySafari/IMG_4798.jpeg
    :alt: Setup
 
 
-The defaults are good for the Readout rate and Timeout.  Give your profile a name and click the 'Save Preset' button.  This will save your new profile and make it the active one.
+The default Readout rate and Timeout are fine.  Name your profile and click 'Save Preset' to save it and make it active.
 
-Now you should be able to select the Telescope icon on the main SkySafari screen and click the connect button to start requesting position updates from the PiFinder.  If no solution has been obtained yet, the PiFinder will send a default location to SkySafari (0 degrees RA/DEC) until it completes the first exposure/solve.
+Now select the Telescope icon on the main SkySafari screen and click connect to start receiving position updates.  Until the first solve completes, the PiFinder sends a default location (0 degrees RA/DEC).
 
 Using SkySafari
-===============
+---------------
 
 Once connected, SkySafari and the PiFinder work together in two main ways:
 
 * **Follow your scope on the star chart.**  As you move the telescope, the PiFinder reports
-  its solved position and SkySafari keeps your location marked on its chart — a large,
-  zoomable view of where you are pointed.  This is especially handy near the zenith, where
-  the PiFinder's own Push-To numbers become twitchy.
+  its solved position and SkySafari marks it on its chart — a large, zoomable view of where
+  you are pointed.  This is especially handy near the zenith, where the PiFinder's own
+  Push-To numbers become twitchy.
 * **Send targets to the PiFinder.**  Pick an object in SkySafari and send it to the
-  PiFinder's observing list, then use the PiFinder's Push-To guidance to find it.  It is a
-  comfortable alternative to entering objects with the keypad.
+  PiFinder's observing list, then use Push-To guidance to find it — a comfortable
+  alternative to entering objects with the keypad.
 
-A few things are worth knowing about what the connection does today:
+A few things are worth knowing about the connection today:
 
 * SkySafari does **not** command the PiFinder to slew or auto-center a GoTo mount.  The
-  connection is for reading out position and sending targets; GoTo control is in
-  development.
-* Only **one** device can be connected to the PiFinder at a time.  To connect from a
-  different phone or tablet, disconnect the first one.
+  connection reads out position and sends targets; GoTo control is in development.
+* Only **one** device can connect to the PiFinder at a time.  To connect a different phone
+  or tablet, disconnect the first one.
 * The PiFinder cannot talk to SkySafari and a GoTo mount at the same time — choose one.
 * SkySafari 5 Plus, 6, and 7 all work; version 7 is the most reliable.
 
@@ -88,25 +87,24 @@ A few things are worth knowing about what the connection does today:
    the sleep timer (see :ref:`quick_start:adjusting brightness`).
 
 Troubleshooting
-===============
+---------------
 
 **SkySafari won't connect, or the connection keeps dropping.**
 The usual cause is your phone or tablet quietly leaving the ``PiFinderAP`` network.  Because
-that network has no internet access, many devices switch back to cellular or a home network
-in the background, which breaks the link.  Re-select ``PiFinderAP`` in your device's WiFi
-settings, and if it offers a "smart network switching" or "auto-switch to mobile data"
-option, turn that off.
+it has no internet access, many devices switch back to cellular or a home network in the
+background, breaking the link.  Re-select ``PiFinderAP`` in your WiFi settings, and turn off
+any "smart network switching" or "auto-switch to mobile data" option.
 
 **``pifinder.local`` doesn't resolve.**
-Some phones and networks cannot reliably look up the ``.local`` name.  Use the PiFinder's
-numeric IP address instead — you will find it on the Status screen.  In Access Point mode
-that address is ``10.10.10.1``.
+Some phones and networks can't reliably look up the ``.local`` name.  Use the PiFinder's
+numeric IP instead — you'll find it on the Status screen.  In Access Point mode that address
+is ``10.10.10.1``.
 
 **It connects, but the position never updates.**
-Until the PiFinder completes its first plate solve it reports 0°/0°, so give it a moment
-with the camera focused on the sky.  If the position was updating and then froze, the
-PiFinder has most likely entered power-save mode — see the note above.
+Until the first plate solve completes, the PiFinder reports 0°/0°, so give it a moment with
+the camera focused on the sky.  If the position was updating and then froze, the PiFinder has
+most likely entered power-save mode — see the note above.
 
 **The connection is intermittent at a star party.**
-Two nearby PiFinders using the same network name (SSID) can interfere with each other.
-Give each one a distinct network name to avoid this.
+Two nearby PiFinders using the same network name (SSID) can interfere with each other.  Give
+each one a distinct network name to avoid this.

--- a/docs/source/software.rst
+++ b/docs/source/software.rst
@@ -2,22 +2,19 @@
 Software Setup
 ==============
 
-Once you've built or otherwise obtained a PiFinder, here's how to setup a fresh SD card to run it.  The easy and recommended way is to download the current prebuilt release image file and use the Raspberry Pi imager to burn it and configure your wifi settings.  If you prefer, you can build an image from scratch following the instructions below.
+Once you've built or otherwise obtained a PiFinder, here's how to set up a fresh SD card to run it.  The recommended way is to download the current prebuilt release image and use the Raspberry Pi imager to burn it and configure your wifi.  If you prefer, you can build an image from scratch following the instructions below.
 
 Prebuilt Release Image
 ----------------------
 
-The image files on our release pages contain the proper version of the Raspberry Pi OS,
-the installed and configured PiFinder software, and all the catalog images for deep sky 
-objects.  This is the recommended method for getting the PiFinder software on to an SD card
-for using the PiFinder, no matter how you have built/purchased one.
+The image files on our release pages bundle the correct Raspberry Pi OS version, the installed and configured PiFinder software, and all the deep sky catalog images.  This is the recommended way to get PiFinder onto an SD card, however you built or purchased the unit.
 
 
 * Download the latest release image from our `releases page <https://github.com/brickbots/PiFinder/releases>`_
 
 * Install the Raspberry Pi imager: https://www.raspberrypi.com/software/
 
-* Run the imager and click 'Choose OS' and select 'Use Custom' then select the image you downloaded
+* Run the imager, click 'Choose OS', select 'Use Custom', then choose the image you downloaded
 
 .. image:: images/software/rpi_imager_001.png
    :width: 47%
@@ -26,13 +23,13 @@ for using the PiFinder, no matter how you have built/purchased one.
    :width: 47%
 
 
-* If you'd like to set up your network so the PiFinder can connect to it, click the gear icon at the lower left and fill in:
+* To let the PiFinder connect to your network, click the gear icon at the lower left and fill in:
 
   * SSID: The name of your wifi network
   * Password: The password for your wifi network
-  * Wireless LAN Country: Where you live to configure wifi in accordance with local laws
+  * Wireless LAN Country: Where you live, so wifi follows local regulations
 
-* You can also setup your locale and keyboard settings if you like, but these are not used by the PiFinder software and only affect the language of the underlying operating system.
+* You can also set your locale and keyboard, but the PiFinder software ignores these; they only affect the underlying operating system.
 
 .. image:: images/software/rpi_imager_003.png
    :width: 47%
@@ -43,17 +40,17 @@ for using the PiFinder, no matter how you have built/purchased one.
 .. important::
    Do not set the hostname or username/password.  SSH is enabled on this image by default.
 
-* Click the 'Select Storage' button and choose the SD card on your computer
-* Then click the 'Write' button to start.
+* Click 'Select Storage' and choose the SD card on your computer
+* Click 'Write' to start
 
 .. note::
    If the imager reports that the image is **"not a multiple of 512 bytes"** (or otherwise
    refuses to write it), the download was incomplete or corrupted.  Download the release
    image again and retry.
 
-Once the image writing is complete, you can insert the SD card into your PiFinder and power it up.  The first boot will take a bit longer as it will expand the filesystem to fill the entire SD card, so be patient.
+Once writing is complete, insert the SD card into your PiFinder and power it up.  The first boot takes a bit longer as it expands the filesystem to fill the card, so be patient.
 
-Now that you have the software installed, you're ready to hit the :doc:`Quick Start Guide<quick_start>` to get ready for a night of observing!
+With the software installed, you're ready for the :doc:`Quick Start Guide<quick_start>` and a night of observing.
 
 Build From Scratch
 ------------------
@@ -66,7 +63,7 @@ Build From Scratch
    sd card.
 
 
-You can do this completely headless (no monitor / keyboard) if desired.
+You can do this completely headless (no monitor or keyboard) if you like.
 
 General Pi Setup
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,16 +73,16 @@ General Pi Setup
    You must use the specific Raspberry Pi OS version listed here or the PiFinder software will not work.  The software is designed and tested for a specific version with each release.
 
 
-* Create Image:  I'd strongly recommend using the Raspberry Pi imager.  It's available for most platforms and lets you easily setup wifi and SSH for your new image.
+* Create the image using the Raspberry Pi imager.  It's available for most platforms and makes it easy to set up wifi and SSH.
 
   * Select the 64-Bit version of Pi OS (**Legacy**) Lite (No Desktop Environment)
 
     * **Make sure you select the Legacy Bullseye option here**
 
-  * Setup SSH / Wifi / User and Host name using the gear icon.  Below is a screengrab showing the suggested settings.
+  * Set up SSH / Wifi / User and Host name using the gear icon.  Below is a screengrab showing the suggested settings.
 
     * **The username must be** ``pifinder``
-    * The host name, password, network settings and locale should be customized for your needs.
+    * Customize the host name, password, network settings, and locale for your needs.
 
 
 .. image:: ../../images/raspi_imager_settings.png
@@ -93,14 +90,14 @@ General Pi Setup
 
 
 
-* Once the image is burned to an SD card, insert it into the PiFinder and power it up.   It will probably take a few minutes to boot the first time.
-* SSH into the Pifinder using ``pifinder@pifinder.local`` and the password you  setup.
-* Update all packages.  This is not strictly required, but is a good practice.
+* Once the image is burned to an SD card, insert it into the PiFinder and power it up.  The first boot will probably take a few minutes.
+* SSH into the PiFinder using ``pifinder@pifinder.local`` and the password you set up.
+* Update all packages.  This isn't strictly required, but it's good practice.
 
   * ``sudo apt update``
   * ``sudo apt upgrade``
 
-    * Enable SPI / I2C.  The screen and IMU use these to communicate.  
+    * Enable SPI / I2C, which the screen and IMU use to communicate.
     * run ``sudo raspi-config``
     * Select 3 - Interface Options
     * Then I4 - SPI  and choose Enable
@@ -109,24 +106,24 @@ General Pi Setup
 PiFinder Software Install
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Great!  You have a nice fresh install of Raspberry Pi OS ready to go.  The rest of the setup is completed by running the ``pifinder_setup.sh`` script in this repo.  Here's the command to download and run the script in one step:
+You now have a fresh install of Raspberry Pi OS.  The rest of the setup is handled by the ``pifinder_setup.sh`` script in this repo.  Download and run it in one step:
 
  ``wget -O - https://raw.githubusercontent.com/brickbots/PiFinder/release/pifinder_setup.sh | bash``
 
-The script will do the following:
+The script will:
 
 
 * Clone this repo
 * Install the needed packages/dependencies
 * Download some required astronomy data files
-* Setup Wifi access point capabilities
-* Create a samba share for pulling images, and observations logs and adding observing lists
-* Finally, setup the PiFinder service to start on reboot.
+* Set up Wifi access point capabilities
+* Create a samba share for pulling images and observation logs and adding observing lists
+* Set up the PiFinder service to start on reboot
 
-Once the script is done, reboot the PiFinder:
+Once the script finishes, reboot the PiFinder:
 ``sudo shutdown -r now``
 
-It will take up to two minutes to boot, but you should see the startup screen before too long:
+Booting takes up to two minutes, but you should see the startup screen before long:
 
 .. image:: ../../images/screenshots/WELCOME_001_docs.png
    :alt: Startup log
@@ -135,11 +132,11 @@ It will take up to two minutes to boot, but you should see the startup screen be
 Catalog Image Download
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The PiFinder can display images of objects in it's catalogs if they are available on your SD card.  These images take approximately 5gb of space and could potentially take several hours or more to download... but you can cancel and resume the download process at any time.
+The PiFinder can display catalog object images when they're present on your SD card.  These images take about 5gb of space and can take several hours or more to download, but you can cancel and resume at any time.
 
-The :ref:`software:prebuilt release image` already has these images downloaded and is much quicker to download as a single file from your main computer.
+The :ref:`software:prebuilt release image` already includes these images and is much quicker to download as a single file from your main computer.
 
-To download the catalog images, make sure your PiFinder is in WIFI client mode so it can access the internet and SSH into it using the password you setup initially.
+To download the catalog images, put your PiFinder in WIFI client mode so it can reach the internet, then SSH into it using the password you set up initially.
 
 Once connected, type:
 
@@ -148,12 +145,11 @@ Once connected, type:
    cd PiFinder/python
    python -m PiFinder.get_images
 
-The PiFinder will quickly check which images are missing and start the download process.  You can monitor it's progress via the status bar displayed.  
+The PiFinder checks which images are missing and starts downloading.  You can monitor progress on the status bar.
 
 
 .. image:: ../../images/screenshots/Image_download_001.png
-   :alt: Image Download 
+   :alt: Image Download
 
 
-There are 13,000+ images, so it will take a bit of time, but can be done in multiple sessions.  The PiFinder will use whichever images you have on hand each time you observe.
-
+There are 13,000+ images, so it takes a while, but you can do it across multiple sessions.  The PiFinder uses whichever images you have on hand each time you observe.

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -6,30 +6,29 @@ Troubleshooting & FAQ
    older software, updating is often the fix in itself — see
    :ref:`user_guide:update software`.
 
-Most PiFinder hiccups have a quick, known fix, and more often than not the cause is
-something simple — focus, or a settings mismatch — rather than a fault.  This page is
-organised by *symptom*: find the line that matches what you're seeing and follow it to
-the cause and the cure.  If your symptom isn't listed, or a fix doesn't sort it out, the
-PiFinder community on the `Discord server <https://discord.gg/Nk5fHcAtWD>`_ is friendly
-and quick to help.
+Most PiFinder hiccups have a quick fix, and the cause is usually something simple —
+focus, or a settings mismatch — rather than a fault.  This page is organised by
+*symptom*: find the line that matches what you're seeing and follow it to the cure.
+If your symptom isn't listed, or a fix doesn't sort it out, the PiFinder community on
+the `Discord server <https://discord.gg/Nk5fHcAtWD>`_ is quick to help.
 
 
 The PiFinder won't turn on
 --------------------------
 
-The power control is a small white **slide switch** on the top of the unit, above the
-screen — it slides side to side, it is not a push button.  Facing the screen, slide it
-right for on, left for off.  (The **SQUARE** key never controls power.)
+Power is a small white **slide switch** on top of the unit, above the screen — it slides
+side to side, not a push button.  Facing the screen, slide right for on, left for off.
+(The **SQUARE** key never controls power.)
 
-A few things to check:
+Things to check:
 
-- **Is the battery charged?**  There's no battery-level indicator on the screen, so plug
-  in to charge if you're unsure.  The charging light glows blue while charging and turns
-  green when full.
+- **Is the battery charged?**  There's no battery-level indicator on screen, so plug in
+  to charge if you're unsure.  The charging light glows blue while charging, green when
+  full.
 - **Try external power.**  Plug a USB-C cable into the port closest to the keypad.  That
-  port powers the unit *immediately, regardless of the switch position* — so if the
-  PiFinder runs this way but not on battery alone, the trouble is the battery or the
-  switch, not the computer.
+  port powers the unit *immediately, regardless of switch position* — so if the PiFinder
+  runs this way but not on battery, the trouble is the battery or the switch, not the
+  computer.
 - If you built your own unit and it won't power up at all, double-check the PiSugar
   battery board connections.
 
@@ -37,30 +36,29 @@ A few things to check:
 The screen is blank, or it won't finish booting
 -----------------------------------------------
 
-First, rule out the simple explanations:
+Rule out the simple explanations first:
 
 - **Brightness turned all the way down.**  If the PiFinder was last used at a dark site,
-  the screen may simply be dimmed to nothing.  Hold **SQUARE** and tap **+** several
-  times to bring it back.
+  the screen may be dimmed to nothing.  Hold **SQUARE** and tap **+** several times to
+  bring it back.
 - **Give it time on the first boot.**  A normal start-up reaches the welcome screen in
-  about 20 seconds.  The *first* boot after re-imaging takes a minute or two, and the
-  unit will restart itself several times while it sets up — that's expected.  If a unit
-  seems stuck, wait a full five minutes before deciding something is wrong.
+  about 20 seconds.  The *first* boot after re-imaging takes a minute or two and restarts
+  itself several times while it sets up — that's expected.  Wait a full five minutes
+  before deciding something is wrong.
 
-If the screen is still blank, look at the keypad backlight — it tells you where the
-problem is:
+If the screen is still blank, the keypad backlight tells you where the problem is:
 
-- **No keypad light and no screen** (you may see a faint red LED glowing inside the case,
-  meaning the Pi has power but isn't booting): this is almost always **SD card
-  corruption**, the single most common hardware issue.  Re-image the card with the latest
-  release, or request a fresh one.  SD card faults are all-or-nothing — they stop the
-  PiFinder booting rather than causing subtle misbehaviour, so don't reach for a re-image
-  to explain slow solves or the occasional position jump.
-- **Keypad lights up, but the screen is blank or shows garbled characters**: that points
-  to the screen's connection rather than the software.  You can confirm it by connecting
-  through the :ref:`web interface <user_guide:web interface>` — if the remote screen
-  looks correct there, the software is fine and the physical screen connection needs
-  attention (a solder reflow on DIY builds).
+- **No keypad light and no screen** (a faint red LED inside the case means the Pi has
+  power but isn't booting): this is almost always **SD card corruption**, the most common
+  hardware issue.  Re-image the card with the latest release, or request a fresh one.  SD
+  card faults are all-or-nothing — they stop the PiFinder booting rather than causing
+  subtle misbehaviour, so don't re-image to explain slow solves or the occasional position
+  jump.
+- **Keypad lights up, but the screen is blank or garbled**: that points to the screen's
+  connection, not the software.  Confirm it through the
+  :ref:`web interface <user_guide:web interface>` — if the remote screen looks correct
+  there, the software is fine and the physical screen connection needs attention (a solder
+  reflow on DIY builds).
 
 For re-imaging instructions, see :ref:`user_guide:update software` and the
 :doc:`software` page.
@@ -76,12 +74,10 @@ the **Camera Type** setting probably doesn't match the camera in your unit.
   ``imx296``; older v2 cameras are ``imx477``.  It won't hurt to try each.
 - **After changing Camera Type you must fully power the PiFinder off and on** — a software
   restart alone won't apply it.
-- A software update can quietly reset this setting, so it's worth re-checking after you
-  update.
+- A software update can quietly reset this setting, so re-check it after you update.
 
-A healthy camera shows at least some faint noise with the lens cap on, and a brighter
-image in daylight — use that to confirm the camera is alive before chasing focus or
-exposure.
+A healthy camera shows at least faint noise with the lens cap on, and a brighter image in
+daylight — use that to confirm the camera is alive before chasing focus or exposure.
 
 
 It won't plate solve ("can't find stars")
@@ -90,7 +86,7 @@ It won't plate solve ("can't find stars")
 Plate solving is how the PiFinder works out where it's pointed (see
 :ref:`quick_start:setting focus & first solve`).  When it won't solve, **focus is the
 cause far more often than anything else** — and stars that look fine at normal zoom are
-frequently not tight enough.
+often not tight enough.
 
 Work through these in order:
 
@@ -101,10 +97,9 @@ Work through these in order:
   showing — roughly a pencil's width — which is close to in focus.
 - **Lens cap off, and hold still.**  The PiFinder can only solve a sharp, stationary
   image.
-- **Exposure.**  The default of 0.2 s suits most skies.  For bright urban skies try
-  0.4 s; for dark skies 0.1 s works well, or choose **AUTO** to let the PiFinder set it
-  for you.  (Software older than 2.2 doesn't have the AUTO option — another reason to
-  update.)
+- **Exposure.**  The default 0.2 s suits most skies.  For bright urban skies try 0.4 s;
+  for dark skies 0.1 s works well, or choose **AUTO** to let the PiFinder set it for you.
+  (Software older than 2.2 doesn't have the AUTO option — another reason to update.)
 - **High, thin cloud.**  An invisible drifting cloudbank will stop solves at an otherwise
   perfect site.  If solves come and go while the scope is dead still, suspect the sky
   before the hardware.
@@ -117,20 +112,20 @@ Work through these in order:
 An object has "disappeared" from a list (for example, M45)
 ----------------------------------------------------------
 
-Objects are never deleted.  If something you expect is missing from a list, it's being
-hidden by an active **filter** — magnitude, altitude, type, observed status, or which
-catalogs are selected.  To bring everything back, open the Filter menu and choose
-**Reset All**.  See :ref:`user_guide:filters` for what each filter does.
+Objects are never deleted.  If something you expect is missing, it's being hidden by an
+active **filter** — magnitude, altitude, type, observed status, or which catalogs are
+selected.  To bring everything back, open the Filter menu and choose **Reset All**.  See
+:ref:`user_guide:filters` for what each filter does.
 
 
 The chart or Push-To directions look backwards
 ----------------------------------------------
 
 If the star chart appears mirrored, or the Push-To arrows consistently send you the wrong
-way, the most likely cause is the **PiFinder Type** setting not matching how your unit is
+way, the likely cause is the **PiFinder Type** setting not matching how your unit is
 mounted — for example, set to Right when it should be Left.  This setting tells the
-PiFinder its orientation, and it drives both the chart and the Push-To directions.  Set
-it to match your hardware under Settings, as described in
+PiFinder its orientation, driving both the chart and the Push-To directions.  Set it to
+match your hardware under Settings, as described in
 :ref:`Configuration Setup <quick_start:configuration setup>`.
 
 .. note::
@@ -147,41 +142,39 @@ A few PiFinder behaviours surprise people into thinking something is broken.  Th
 all expected:
 
 - **The alignment reticle isn't centred.**  The Telrad-style reticle on the Align screen
-  shows where your scope is pointing *within* the camera's wide 10° view — it is not meant
-  to sit in the middle, and a reticle off to one side is completely normal.  See
+  shows where your scope points *within* the camera's wide 10° view — it isn't meant to
+  sit in the middle, and a reticle off to one side is normal.  See
   :ref:`quick_start:alignment`.
 - **The star chart is "zenith up", not eyepiece-matched.**  The on-screen chart is a
-  naked-eye view, oriented the way you'd see the sky looking up, so it won't match the
-  flipped or rotated view through your eyepiece.  The object *image* previews, by
-  contrast, are rotated to match the eyepiece.
-- **Push-To numbers dim while you move the scope.**  While the scope is moving the
-  PiFinder estimates position from its motion sensor and dims the numbers to say so; the
-  instant you stop, it takes a fresh photo, the numbers brighten, and the position is
-  exact again.  (This is separate from the whole screen dimming in power-save mode.)
+  naked-eye view, oriented as you'd see the sky looking up, so it won't match the flipped
+  or rotated view through your eyepiece.  The object *image* previews, by contrast, are
+  rotated to match the eyepiece.
+- **Push-To numbers dim while you move the scope.**  While moving, the PiFinder estimates
+  position from its motion sensor and dims the numbers to say so; the instant you stop, it
+  takes a fresh photo, the numbers brighten, and the position is exact again.  (This is
+  separate from the whole screen dimming in power-save mode.)
 - **The charging light is slow to turn green.**  Near a full charge the current tapers
-  off, so the final stretch from blue to green takes a while.  That's normal charging
-  behaviour, not a fault.
+  off, so the final stretch from blue to green takes a while.  That's normal, not a fault.
 
 
 Frequently Asked Questions
 --------------------------
 
 **Do I still need a finder scope or Telrad?**
-   Not for finding objects — once the PiFinder is aligned to your scope it replaces a
+   Not for finding objects — once aligned to your scope, the PiFinder replaces a
    traditional finder.  A zero-power finder (a red dot or Telrad) is handy for the
-   *initial* alignment, though, since that step asks you to put a bright star in your
-   eyepiece so you can select it on the PiFinder's chart.
+   *initial* alignment, since that step asks you to put a bright star in your eyepiece to
+   select it on the PiFinder's chart.
 
 **Does it work in light-polluted skies?**
-   Yes — very well.  Bright skies just need a longer exposure: the default is 0.2 s, and
-   for heavy light pollution you can raise it to 0.4 s.  Good focus matters most of all
-   here.
+   Yes — very well.  Bright skies just need a longer exposure: raise the default 0.2 s to
+   0.4 s for heavy light pollution.  Good focus matters most of all here.
 
 **How do I update the software?**
    From the unit, go to Tools → Software Upd while connected to a WiFi network with
-   internet access (Client mode).  If the version reads "unknown", the PiFinder simply
-   can't reach the internet to check — that's a connectivity issue, not a reason to
-   re-image.  Full details are in :ref:`user_guide:update software`.
+   internet access (Client mode).  If the version reads "unknown", the PiFinder can't
+   reach the internet to check — that's a connectivity issue, not a reason to re-image.
+   Full details are in :ref:`user_guide:update software`.
 
 **What's the default password for the web interface?**
    ``solveit`` — all lowercase, one word.  The home screen is viewable without it; other
@@ -190,9 +183,9 @@ Frequently Asked Questions
 **How long does the battery last?**
    Four to five hours, but it's highly activity-dependent: sitting on a single object lets
    the PiFinder drop into a lower-power mode and stretches runtime, while a fast tour
-   through many objects shortens it.  There's no on-screen battery gauge, and the unit
-   shuts off abruptly when empty, so for long sessions keep a USB-C power bank handy — you
-   can hot-plug it while the PiFinder is running.
+   through many objects shortens it.  There's no battery gauge, and the unit shuts off
+   abruptly when empty, so for long sessions keep a USB-C power bank handy — you can
+   hot-plug it while the PiFinder is running.
 
 **Where are my saved observations and images?**
    On the PiFinder's network share, reachable at ``//pifinder.local/shared`` (connect as
@@ -203,32 +196,32 @@ Frequently Asked Questions
    :doc:`skysafari` page for setup.
 
 **Can I enter my own coordinates?**
-   Yes.  You can type in an arbitrary RA/Dec for objects that aren't in the built-in
-   catalogs — handy for asteroids, comets, or newly discovered objects — and you can also
-   send targets to the PiFinder from SkySafari.
+   Yes.  You can type an arbitrary RA/Dec for objects that aren't in the built-in catalogs
+   — handy for asteroids, comets, or newly discovered objects — and you can also send
+   targets from SkySafari.
 
 **Can I use the PiFinder on an EQ mount?**
    Yes — the PiFinder works with any mount, and plate solving behaves the same whatever the
    mount type.  Switch it to EQ mode in the :ref:`user_guide:settings menu` by setting
    "Mount Type" to EQ, which presents Push-To distances in RA/Dec instead of Alt/Az.  On
-   software 2.5.0 and earlier the accelerometer tracking does not work correctly in EQ
-   mode, so the Push-To numbers are unreliable while you move the scope; once you stop and
-   the camera solves, the correct distances appear.  From version 2.6.0 on, EQ mode is
-   fully supported with accelerometer tracking.
+   software 2.5.0 and earlier the accelerometer tracking doesn't work correctly in EQ mode,
+   so the Push-To numbers are unreliable while you move the scope; once you stop and the
+   camera solves, the correct distances appear.  From version 2.6.0 on, EQ mode is fully
+   supported with accelerometer tracking.
 
 **Can I control my motorized (GoTo) mount with the PiFinder?**
    Not yet — this is in active development.  It will rely on INDI support for your mount,
-   so even once the software is ready it may not work with every mount; check INDI's
-   supported-mount list at http://drivers.indilib.org/mounts/.  There is no arrival date
-   yet, as it depends on a planned move to a newer operating-system distribution with a
-   more current version of INDI.
+   so even once the software is ready it may not work with every one; check INDI's
+   supported-mount list at http://drivers.indilib.org/mounts/.  There's no arrival date
+   yet, as it depends on a planned move to a newer OS distribution with a more current
+   version of INDI.
 
 **The operating system clock is wrong — does that matter?**
-   No.  The PiFinder is built to run standalone without internet, and the Raspberry Pi has
-   no real-time clock, so it cannot keep accurate time on its own.  It saves the time at
+   No.  The PiFinder runs standalone without internet, and the Raspberry Pi has no
+   real-time clock, so it can't keep accurate time on its own.  It saves the time at
    shutdown and reads it back at startup as a rough estimate, which can be off by days if
-   the unit has been powered down for a while.  The software does not trust the system
-   clock — it uses GPS time for everything except log-file timestamps.
+   the unit has been powered down for a while.  The software doesn't trust the system clock
+   — it uses GPS time for everything except log-file timestamps.
 
    To sync the system clock to GPS time, run these commands in a terminal on the PiFinder:
 

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -5,96 +5,89 @@ PiFinder™ User Manual
 
 .. note::
    This documentation is for v3 and v2.5 PiFinders running software 2.2.0 or above.
-   You can see what version of software is running by looking in the upper right of
-   the welcome screen. 
+   You can see which version you're running in the upper right of the welcome screen.
 
    If you need docs for a previous version please choose `1.x.x <https://pifinder.readthedocs.io/en/v1.11.2/index.html>`_
    , `2.0.x <https://pifinder.readthedocs.io/en/v2.0.4/index.html>`_
    or `2.1.x <https://pifinder.readthedocs.io/en/v2.1.1/index.html>`_
 
-Thanks for your interest in the PiFinder!  This guide describes how to use a 
-PiFinder but if you want information on building one, please see the :doc
-:`Build Guide <build_guide>` and the :doc:`Bill of Materials <BOM>`.
+Thanks for your interest in the PiFinder!  This guide describes how to use one; if you
+want to build one, see the :doc:`Build Guide <build_guide>` and the
+:doc:`Bill of Materials <BOM>`.
 
-This user manual is divided into several sections which you can access using the links 
-to the left.  Now, let's dig deeper into the various functions of the PiFinder!
+The manual is divided into sections you can reach from the links to the left.  Let's dig
+into what the PiFinder can do.
 
 How It Works
 ===============
 
-The PiFinder is a self-contained telescope positioning device.  It will let you 
-know where your telescope is pointed, provide the ability to choose a particular target 
-(like a Galaxy or other DSO) and direct you on how to move 
-your telescope to find that object.  There are some other nice features along with 
-these core functions, but the PiFinder is designed primarily as a way to get 
-interesting objects into your eyepiece so you can take a look at them.
+The PiFinder is a self-contained telescope positioning device.  It tells you where your
+telescope is pointed, lets you pick a target such as a galaxy or other DSO, and directs
+you on how to move the scope to find it.  There are other nice features alongside these
+core functions, but the PiFinder is designed primarily to get interesting objects into
+your eyepiece for a look.
 
-In order to direct you to wonders of the night sky, the PiFinder needs 
-to know where your telescope is currently pointed.  The primary way it does this 
-is directly, by taking photos of the night sky and examining the star patterns 
-to determine what section of the sky it's seeing.  It can do 
-this incredibly fast (up to 20 times per second!) and very accurately.  
-This only works well if your telescope is not moving, so it couples this 
-very accurate system with an accelerometer to provide an estimate of how far your telescope 
-has moved from the last known position.  This estimate will contain some error, 
-but as soon as you stop moving the scope a new photo will be taken and any inaccuracy will be corrected.
+To direct you, the PiFinder needs to know where your telescope is pointed.  It works this
+out directly, by photographing the night sky and examining the star patterns to determine
+which section of sky it's seeing — incredibly fast (up to 20 times per second!) and very
+accurately.  This only works while the scope is still, so it pairs that camera with an
+accelerometer that estimates how far the scope has moved since the last solve.  The
+estimate carries some error, but the moment you stop, a fresh photo corrects it.
 
-Along with knowing where your telescope is pointing, the PiFinder knows where thousands of 
-interesting objects are located. It can use these two pieces of information to indicate 
-how you should move your telescope to bring any of those thousands of objects into 
-your eyepiece.  Since it's directly observing where your telescope is pointing, 
-you can be assured you are on target!
+Knowing where your scope points and where thousands of interesting objects sit, the
+PiFinder combines the two to show you how to move the scope to bring any of those objects
+into your eyepiece.  Because it observes your actual pointing direction, you can trust
+you're on target.
 
 .. note::
-   If you would like a general overview of how to use the PiFinder, please give the 
-   :doc:`quick_start` a read.  This manual goes more in depth but does not cover some
-   of the first time set-up items in the Quick Start
+   For a general overview of using the PiFinder, read the :doc:`quick_start`.  This manual
+   goes deeper but doesn't cover the first-time set-up steps in the Quick Start.
 
 
 Power & Charging
 =====================================
 
-PiFinders ordered with the optional internal battery will run for an evening on a single
+PiFinders ordered with the optional internal battery run for an evening on a single
 charge, and you can keep one going indefinitely from any USB-C power source.  This section
 covers how the two USB-C ports differ, how charging behaves, how long a charge lasts, and
-how to look after the battery.  For the very first power-on, the :ref:`quick_start:powering the pifinder`
-section of the Quick Start walks through it step by step.
+how to look after the battery.  For the very first power-on, the
+:ref:`quick_start:powering the pifinder` section of the Quick Start walks through it step
+by step.
 
 The two USB-C ports
 -------------------
 
-A battery-equipped PiFinder has two USB-C ports on top of the unit, and they do different
-things:
+A battery-equipped PiFinder has two USB-C ports on top, and they do different things:
 
 .. image:: images/quick_start/power.jpeg
 
 - The port nearest the **back** of the case (marked with the arrow above) both powers the
-  PiFinder **and** charges the internal battery.  This is the one to use for charging.
+  PiFinder **and** charges the battery.  Use this one for charging.
 - The port nearest the **keypad** powers the unit only — it does not charge the battery.
   It is also wired ahead of the power switch, so plugging into it turns the PiFinder on
   immediately *regardless of the switch position*.
 
-During an observing session the keypad-side (power-only) port is the nicer one to run from,
-because the charging port's indicator LED is quite bright in the dark.  A unit without the
-internal battery has only the single power-only port.
+During a session the keypad-side (power-only) port is the nicer one to run from, because
+the charging port's indicator LED is quite bright in the dark.  A unit without the battery
+has only the single power-only port.
 
-The power switch is the small white **slide** switch on top of the unit, above the screen
-(highlighted with a box in the image above).  Facing the screen, slide it right for on and
-left for off.  It is a switch, not a button.
+The power switch is the small white **slide** switch on top, above the screen (boxed in
+the image above).  Facing the screen, slide it right for on and left for off.  It is a
+switch, not a button.
 
 Charging
 --------
 
 Plug a USB-C cable into the charging port (nearest the back).  The indicator LED glows
-**blue** while charging and turns **green** when the battery is full.  From empty, a full
-charge takes roughly three hours, though this varies a good deal with the power source —
-a Power Delivery (PD) charger negotiates more power and fills faster, while a basic 5V
-supply charges more slowly but works fine.
+**blue** while charging and turns **green** when full.  From empty, a full charge takes
+roughly three hours, though this varies with the power source — a Power Delivery (PD)
+charger negotiates more power and fills faster, while a basic 5V supply charges more
+slowly but works fine.
 
-Charge with the power switch in the **off** position.  If the PiFinder is running while
-plugged in, it can draw about as much current as the charger supplies, so the battery may
-barely fill.  A long charge that leaves the battery still flat almost always means the unit
-was switched on the whole time.
+Charge with the power switch **off**.  If the PiFinder runs while plugged in, it can draw
+about as much current as the charger supplies, so the battery may barely fill.  A long
+charge that leaves the battery still flat almost always means the unit was switched on the
+whole time.
 
 .. note::
    The last stretch of charging is slow.  As the battery approaches full the charging
@@ -104,15 +97,15 @@ was switched on the whole time.
 Battery life
 ------------
 
-The internal battery runs the PiFinder for about **four to five hours**, but real runtime
-depends heavily on how hard you work it.  Sitting at the eyepiece on one object, or stepping
-away from the scope, lets the PiFinder drop into power-save mode and stretches the time
-considerably.  A fast tour through many objects — with the camera, motion sensor, and screen
-all busy — draws more power and shortens it.
+The battery runs the PiFinder for about **four to five hours**, but real runtime depends
+heavily on how hard you work it.  Sitting at the eyepiece on one object, or stepping away
+from the scope, lets the PiFinder drop into power-save mode and stretches the time
+considerably.  A fast tour through many objects — camera, motion sensor, and screen all
+busy — draws more power and shortens it.
 
 There is **no battery-level indicator** on the screen and no low-battery warning: when the
 charge is depleted the PiFinder simply shuts off.  For a long night, top up beforehand and
-keep a USB-C power bank handy.  You can plug external power in at any time without restarting
+keep a USB-C power bank handy.  You can add external power at any time without restarting
 (see below).
 
 .. note::
@@ -124,23 +117,23 @@ keep a USB-C power bank handy.  You can plug external power in at any time witho
 Running on external power
 -------------------------
 
-Any USB-C power source rated for at least **2A** will run the PiFinder — a wall charger, a
-USB power bank, or a portable power station's USB output.  As a rough guide, about
-1,000mAh of power-bank capacity runs the PiFinder for an hour, so a 10,000mAh bank is good
-for the better part of a night.
+Any USB-C source rated for at least **2A** will run the PiFinder — a wall charger, a USB
+power bank, or a portable power station's USB output.  As a rough guide, about 1,000mAh of
+power-bank capacity runs the PiFinder for an hour, so a 10,000mAh bank is good for the
+better part of a night.
 
-External power can be plugged in mid-session without a restart.  A useful trick for
-stretching a long night: plug a power bank into the power-only port, then switch the battery
-**off**.  The PiFinder keeps running on the external power while the internal battery is held
-in reserve for after the bank is unplugged.
+External power can be added mid-session without a restart.  A useful trick for stretching
+a long night: plug a power bank into the power-only port, then switch the battery **off**.
+The PiFinder keeps running on the external power while the battery is held in reserve for
+after the bank is unplugged.
 
-If you experience power dropouts, suspect the cable first — some USB-C cables are unreliable
-at the ~2A the PiFinder draws, especially on long runs.
+If you hit power dropouts, suspect the cable first — some USB-C cables are unreliable at
+the ~2A the PiFinder draws, especially on long runs.
 
 .. warning::
-   Feed the PiFinder **5V USB-C power only**.  If you want to run it from a telescope's 12V
-   supply, you must use a 12V-to-5V step-down (DC-DC) converter with a USB-C output.  Never
-   connect 12V directly to the PiFinder — doing so will damage it.
+   Feed the PiFinder **5V USB-C power only**.  To run it from a telescope's 12V supply, you
+   must use a 12V-to-5V step-down (DC-DC) converter with a USB-C output.  Never connect 12V
+   directly to the PiFinder — doing so will damage it.
 
 Battery safety & care
 ---------------------
@@ -159,7 +152,7 @@ years, but like any lithium battery it deserves a little respect.
    the PiSugar power board it sits on.  Keep the unit dry; the battery and electronics are
    not waterproof.
 
-A few habits that keep the cell healthy:
+A few habits keep the cell healthy:
 
 - **Charge from the built-in port only.**  The PiSugar power board manages charging for you;
   just supply 5V USB-C as described above.  There is no need for an external LiPo charger,
@@ -183,117 +176,113 @@ A few habits that keep the cell healthy:
 Adjusting Brightness
 =====================================
 
-The PiFinder is designed to allow you to adjust the brightness of the screen and keypad at any
-time: simply hold down the **SQUARE** button and push **+** for brighter, or **-** for dimmer. In a dark sky 
-site, you can turn the brightness down to preserve your dark-adapted vision.
+You can adjust the brightness of the screen and keypad at any time: hold the **SQUARE**
+button and press **+** for brighter or **-** for dimmer.  At a dark-sky site, turn the
+brightness right down to preserve your dark-adapted vision.
 
 .. note::
-   The PiFinder will dim the screen and reduce the frequency of exposures, solving, and other processes 
-   when it’s been idle for a period of time. This helps save battery power and can also prevent glare 
-   at the eyepiece in especially dark environments. The default is 30 seconds and this can be configured, 
-   or turned off completely, in the :ref:`user_guide:settings menu`
+   The PiFinder dims the screen and slows exposures, solving, and other processes after
+   it's been idle for a while.  This saves battery power and prevents glare at the eyepiece
+   in especially dark environments.  The default is 30 seconds; you can change it, or turn
+   it off completely, in the :ref:`user_guide:settings menu`
 
-   Pressing any button, or moving the PiFinder will wake it from power save mode.
+   Pressing any button, or moving the PiFinder, will wake it from power-save mode.
 
 The Menu System
 =====================================
 
-All the functions of the PiFinder can be accessed via its menu system:
+All of the PiFinder's functions are reached through its menu system:
 
 .. image:: images/quick_start/main_menu_01_docs.png
 
 
-Each menu is a list of items that represent a submenu, screen, or a set of options you can choose from.  You can scroll
-though each menu and make selections using these keys:
+Each menu is a list of items representing a submenu, a screen, or a set of options.  Scroll
+through a menu and make selections with these keys:
 
-- The **UP** and **DOWN** arrows will scroll the current menu
-- The **RIGHT** arrow will activate the current option; selecting it or moving to another menu
-- The **LEFT** arrow will take you back to the previous menu or screen
-- Holding **LEFT** for more than one second will always take you back to the TOP of the menus
+- The **UP** and **DOWN** arrows scroll the current menu
+- The **RIGHT** arrow activates the current option, selecting it or moving to another menu
+- The **LEFT** arrow takes you back to the previous menu or screen
+- Holding **LEFT** for more than a second always returns to the TOP of the menus
 
-The status bar at the top of the screen will show the name of the menu you are currently viewing.  
+The status bar at the top of the screen shows the name of the menu you're viewing.
 
 Screens
 --------
 
-When you choose some menu items, like Camera, these will lead you to a specific screen such as showing the 
-camera preview, a star chart or details about a particular catalog object.  Each one of the screens is
-covered in more detail below.
+Some menu items, like Camera, lead to a specific screen — a camera preview, a star chart,
+or details about a catalog object.  Each screen is covered in more detail below.
 
 Options
 --------
 
-Some menus present a list of options where you can choose one or more items to control how
-the PiFinder operates.  For instance, the Filter menu items take you to a sub-menu of different
-ways you can filter your object lists:
+Some menus present a list of options where you choose one or more items to control how the
+PiFinder operates.  For instance, the Filter menu items take you to a sub-menu of ways to
+filter your object lists:
 
 
 .. image:: images/user_guide/options_menu_01.png
 .. image:: images/user_guide/options_menu_02.png
 
-Selecting Type presents you with various DSO types that 
-you can select to control what objects appear in your object lists.
+Selecting Type presents the DSO types you can choose to control which objects appear in
+your object lists.
 
 .. image:: images/user_guide/options_menu_03.png
 .. image:: images/user_guide/options_menu_04.png
 
-Lists that offer selections will usually have a check-mark next to the one, or many, 
-option selected.  Pressing the **RIGHT** arrow with an option highlighted will select
-or de-select that item.
+Lists that offer selections show a check-mark next to the one or many options selected.
+Pressing the **RIGHT** arrow with an option highlighted selects or de-selects it.
 
 
 .. image:: images/user_guide/options_menu_04.png
 .. image:: images/user_guide/options_menu_05.png
 
-For some menus that only allow a single item to be selected, such as Altitude, selecting
-one item will de-select any others.  Multi-Select menus have options to select or de-select
-all items for ease of use.
+For menus that allow only a single selection, such as Altitude, choosing one item
+de-selects any others.  Multi-Select menus offer options to select or de-select all items
+at once.
 
-When you are done selecting options for a particular setting, you can use the **LEFT** arrow
-key to return to your last menu or screen.
+When you're done, press the **LEFT** arrow to return to your last menu or screen.
 
 
-With this simple set of scroll and select tools you can access all the powerful features of
-the PiFinder.
+With this simple set of scroll-and-select tools you can reach all the PiFinder's powerful
+features.
 
 Quick Menu
 =====================================
 
-Although you can access everything the PiFinder has to offer using just the menu system, we've
-introduced a secondary quick-menu to bring some of those functions into easier reach.  
+You can reach everything through the menu system, but a secondary quick-menu brings some
+functions into easier reach.
 
-Hold down the **SQUARE** key to access the Quick Menu
+Hold the **SQUARE** key to open the Quick Menu
 
 .. image:: images/user_guide/quick_menu_00.png
 
-This menu presents up to four options, one for each arrow button.  Pressing that arrow
-will select that item.  This menu is different depending on what screen you are on, but 
-often has :ref:`HELP<user_guide:help system>` at the UP option.
+This menu presents up to four options, one per arrow button; press the arrow to select its
+item.  The menu changes with the screen you're on, but often has
+:ref:`HELP<user_guide:help system>` at the UP option.
 
-Some Quick Menus have multiple layers like the one above.  Selecting RIGHT will open the 
-Background Subtraction (BG SUB) options.  To indicate a current setting, one option may
-have some subtle shading.  The image below is showing that the BG SUB setting is currently
-HALF.
+Some Quick Menus have multiple layers, like the one above.  Selecting RIGHT opens the
+Background Subtraction (BG SUB) options.  Subtle shading marks the current setting — the
+image below shows BG SUB set to HALF.
 
 .. image:: images/user_guide/quick_menu_01.png
 
-Selecting LEFT would switch this option to FULL.  You can exit the Quick Menu at any time
-by pressing the SQUARE button again.
+Selecting LEFT would switch this to FULL.  Exit the Quick Menu at any time by pressing
+SQUARE again.
 
 
 Help System
 ==============
 
-Many screens offer help with specific button functions and other details about how things 
-work or the purpose of a particular page.  
+Many screens offer help with specific button functions and other details about how things
+work or what a page is for.
 
-When available, HELP will be the UP option in the Quick Menu
+When available, HELP is the UP option in the Quick Menu
 
 .. image:: images/user_guide/quick_menu_00.png
 
-Pressing the UP arrow will select the help option and display one or more pages of help.  There
-will be a prompt at the top or bottom of the screen to show if more pages are available and 
-pressing UP or DOWN will scroll through them
+Pressing the UP arrow selects help and displays one or more pages.  A prompt at the top or
+bottom of the screen shows when more pages are available; press UP or DOWN to scroll
+through them.
 
 .. image:: images/user_guide/camera_help_01.png
 .. image:: images/user_guide/camera_help_02.png
@@ -302,18 +291,18 @@ pressing UP or DOWN will scroll through them
 Settings Menu
 ==============
 
-All of the user configurable items for the PiFinder can be found in the Settings Menu which is near the
-bottom of the main PiFinder menu
+All user-configurable items live in the Settings Menu, near the bottom of the main
+PiFinder menu.
 
 .. image:: images/user_guide/settings_01.png
 
-The top items collect several options together under User Preferences and Chart Screen.   The ellipsis (...) indicates
-that there are more options below.
+The top items collect several options under User Preferences and Chart Screen.  An ellipsis
+(...) indicates more options below.
 
 .. image:: images/user_guide/settings_02.png
 
-Below the general UI options are settings to change which :ref:`user_guide:wifi` mode your PiFinder is in, what its 
-physical configuration is and more physical configuration items.
+Below the general UI options are settings to change which :ref:`user_guide:wifi` mode your
+PiFinder is in and its physical configuration.
 
 .. image:: images/user_guide/settings_03.png
 
@@ -321,47 +310,49 @@ physical configuration is and more physical configuration items.
 Observing with PiFinder
 ========================
 
-When using the PiFinder under the stars to explore the universe, you'll be doing four basic things in various combinations:
+Out under the stars, you'll be doing four basic things in various combinations:
 
-* Curating a list of objects you are interested in
+* Curating a list of objects you're interested in
 * Viewing details about those objects
 * Pushing the scope to bring them into your eyepiece
 * Logging your observations
-  
-Everyone has their own unique way to observe, so the PiFinder offers different ways to use (or not use!) these features
-to facilitate a great night of observing.
+
+Everyone observes their own way, so the PiFinder offers different ways to use (or skip!)
+these features for a great night out.
 
 Object List
 --------------------
 
-The Object list is one of the main features of the PiFinder.  It presents a collection of objects you've selected using 
-catalogs, filters, observing lists and text search tools.  
+The Object List is one of the PiFinder's main features.  It presents a collection of
+objects you've selected using catalogs, filters, observing lists, and text search.
 
-To select a starting point for your observing journey, choose Objects from the main PiFinder menu.  You can then choose
-from one of four options:
+To pick a starting point, choose Objects from the main PiFinder menu, then choose one of
+four options:
 
 .. image:: images/user_guide/objects_menu.png
 
-- **All Filtered**: This will show you all the objects across all catalogs that meet 
-  your :ref:`filter criteria<user_guide:filters>`.  This could be thousands of objects and is most useful with very
-  strict filter settings, such as only looking for globulars above 30 degree altitude and brighter than magnitude 10.
-- **By Catalog**: Shows all objects from a specific catalog that meet your filter criteria.  Great for observing projects
-  and looking for the nearest objects in a particular catalog.
-- **Recent**: This list starts empty and will contain a history of all the objects you've checked out during your current
-  observing session
-- **Name Search**: Using the number keypad and T9 style text entry, you can search for objects by name.  The snowball planetary?
-  Cats-Eye?  This is the way to find them!
+- **All Filtered**: All objects across all catalogs that meet your
+  :ref:`filter criteria<user_guide:filters>`.  This could be thousands of objects and is
+  most useful with strict filters, such as globulars above 30 degrees altitude and brighter
+  than magnitude 10.
+- **By Catalog**: All objects from a specific catalog that meet your filter criteria.  Great
+  for observing projects and finding the nearest objects in a particular catalog.
+- **Recent**: Starts empty and builds a history of the objects you've checked out during
+  the current session.
+- **Name Search**: Using the number keypad and T9-style text entry, search for objects by
+  name.  The Snowball planetary?  Cat's Eye?  This is the way to find them.
 
-No matter how you get objects onto the list, it always displays 
-the same information and allows you to sort and select the same way.
+However you build the list, it always displays the same information and offers the same
+sorting and selection.
 
 .. image:: images/user_guide/object_list_01_docs.png
 
-Along the left side is a symbol showing what sort of object each line represents.  Next to that is the designation of the
-object, usually the catalog abbreviation and index number, then the distance from your current telescope position to this
-object. The brightness of each entry in the list gives a little hint about its magnitude.
+A symbol along the left shows each object's type.  Next to it is the designation — usually
+the catalog abbreviation and index number — then the distance from your current telescope
+position.  Each entry's brightness hints at its magnitude.
 
-Pressing the **SQUARE** key will cycle through additional information for the objects on the list.
+Pressing the **SQUARE** key cycles through additional information for the objects on the
+list.
 
 .. image:: images/user_guide/object_list_02_docs.png
 
@@ -369,169 +360,168 @@ You can see a scrolling list of common names for each object.
 
 .. image:: images/user_guide/object_list_03_docs.png
 
-And the magnitude and size of each object along with a little check mark to indicate if you've observed and logged
-this object previously.
+And the magnitude and size of each object, with a check mark to indicate whether you've
+observed and logged it before.
 
-Holding down the **SQUARE** key will bring up the Quick Menu which allows you to sort and filter this list
+Holding the **SQUARE** key brings up the Quick Menu to sort and filter this list.
 
 .. image:: images/user_guide/object_list_radial_docs.png
 
-Pressing **LEFT** will select SORT
+Pressing **LEFT** selects SORT
 
 .. image:: images/user_guide/object_list_sort_docs.png
 
-By default, lists are sorted in STANDARD order... usually the order they appear in catalogs.  You can choose
-another sort order such as NEAREST by pressing the arrow key indicated.  Sorting by NEAREST puts the object 
-that is closest to your current telescope position at the top of the list.
+By default, lists use STANDARD order — usually the order they appear in catalogs.  Press
+the indicated arrow to choose another order such as NEAREST, which puts the object closest
+to your current telescope position at the top.
 
 .. image:: images/user_guide/object_list_04_docs.png
 
-If you start typing a number, the Object list will jump to the next object with that index number.  You can
-use the **UP/DOWN** down arrows to go to the next/previous match and use the **SQUARE** key to exit the 
-jump mode and select an object.
+If you start typing a number, the Object List jumps to the next object with that index
+number.  Use the **UP/DOWN** arrows to step to the next or previous match, and the
+**SQUARE** key to exit jump mode and select an object.
 
-Pressing the **RIGHT** key will bring you to details for the selected object....
+Pressing the **RIGHT** key brings you to details for the selected object.
 
 Object Details
 --------------------
 
-Pressing the **RIGHT** key from the Object list will bring you to the Object Details screen 
-for the highlighted object. This screen shows large Push-To instructions, :ref:`object images<user_guide:object images>` and 
-catalog details for objects.
+Pressing the **RIGHT** key from the Object List brings up the Object Details screen for the
+highlighted object.  This screen shows large Push-To instructions,
+:ref:`object images<user_guide:object images>`, and catalog details.
 
-Pressing **SQUARE** will cycle through the different information for the object and **UP/DOWN** will move to the next
-or previous object in the list.  **LEFT** will bring you back to the full list and **RIGHT** brings 
-up the :ref:`Logging<user_guide:logging observations>` interface for the current object.
+Pressing **SQUARE** cycles through the object's information and **UP/DOWN** moves to the
+next or previous object in the list.  **LEFT** returns to the full list, and **RIGHT**
+brings up the :ref:`Logging<user_guide:logging observations>` interface for the current
+object.
 
 .. image:: images/user_guide/object_details_01.png
 
-The Push-To info shows which way, and how far, to move your telescope to put the selected object in your 
-eyepiece.  As you move the scope the numbers will dim a bit to indicate that the PiFinder is using the
-accelerometer to provide an estimate of where the telescope is currently pointing.  When you stop, or 
-move slowly enough, the camera will be able to plate solve and provide an absolute position which will
-cause the numbers to brighten again.
+The Push-To info shows which way, and how far, to move your telescope to put the object in
+your eyepiece.  As you move the scope the numbers dim, indicating the PiFinder is using the
+accelerometer to estimate where the telescope is pointing.  When you stop, or move slowly
+enough, the camera plate solves to provide an absolute position and the numbers brighten
+again.
 
-When the numbers are near 0.00 the object should be in your eyepiece.  The numbers indicate the distance
-to the object in degrees.  So if you have an eyepiece with a 0.5 degree true field of view, getting the
-numbers below 0.25 (half the true field of view) should be enough to put the object within the eyepiece.
+When the numbers are near 0.00 the object should be in your eyepiece.  The numbers are the
+distance to the object in degrees, so with an eyepiece offering a 0.5 degree true field of
+view, getting them below 0.25 (half the true field) should put the object in view.
 
-Closer to zero will mean more centered. If you are trying to find a very dim object, knowing it's right in 
-the center of field and consulting the object image can really make a difference.
+Closer to zero means more centered.  For a very dim object, knowing it's dead center and
+consulting the object image can make all the difference.
 
 .. image:: images/user_guide/object_details_02.png
 
-The PiFinder can display images of all the objects in its catalog!  
-See the section on :ref:`object images<user_guide:object images>`
-below for more information
+The PiFinder can display images of every object in its catalog.  See the section on
+:ref:`object images<user_guide:object images>` below for more.
 
 .. image:: images/user_guide/object_details_03.png
 
-Depending on the catalog, the PiFinder may have detailed notes about objects along with Type, constellation,
-magnitude and size.  Use the **+/-** keys to scroll the notes field.  At the bottom of the notes is a counter
-of how many times you've logged this object.
+Depending on the catalog, the PiFinder may have detailed notes along with Type,
+constellation, magnitude, and size.  Use the **+/-** keys to scroll the notes field.  At
+the bottom of the notes is a count of how many times you've logged this object.
 
 Filters
 ----------
 
-All the object lists aside from :ref:`user_guide:name search` and Recent will only show objects that meet
-the filter criteria you have set.  You can always view and adjust your filter settings using the Filter menu
-available from the main PiFinder menu
+Every object list aside from :ref:`user_guide:name search` and Recent shows only objects
+that meet the filter criteria you've set.  View and adjust your filters from the Filter
+menu, available on the main PiFinder menu.
 
 .. image:: images/user_guide/main_filter_option.png
 
-You can also jump to the filter options using the :ref:`user_guide:quick menu` available from the 
-Object List screen
+You can also jump to the filter options from the :ref:`user_guide:quick menu` on the Object
+List screen.
 
 .. image:: images/user_guide/object_list_radial_docs.png
 
-The Filter menu has several ways to limit which objects appear in the object list along with a 
-Reset All option to completely remove all filters.  
+The Filter menu offers several ways to limit which objects appear, plus a Reset All option
+to clear every filter.
 
 .. image:: images/user_guide/filter_menu.png
 
-With no filters set every object available will appear on the object list.  
-For instance the All Filtered list will show over 18,000 objects!  
+With no filters set, every available object appears — the All Filtered list will show over
+18,000 objects!
 
-Some filter types can have a single value, like Altitude, and some allow you to select multiple 
-options, like Object type.  Here's a brief explanation of each:
+Some filter types take a single value, like Altitude, and some allow multiple selections,
+like Object type.  Here's a brief explanation of each:
 
-- **Catalogs**: This allows you to limit which catalogs are included in the All Filtered list.  This 
-  is distinct from the Catalog specific object lists, which are a sort of shortcut to view objects
-  only from one specific catalog.  Using the Catalogs filter you can use the All Filtered list to 
-  see all of the different globular clusters across multiple catalogs.
-- **Type**: Limits by object type.  You can select multiple types of objects to include in your lists.
-- **Altitude**: The current apparent altitude of this object from your observing location.  
-- **Magnitude**: Limit objects displayed to those at least as bright as the selected magnitude.
-- **Observed**: Only include objects you've logged already, never logged, or any logged state.
+- **Catalogs**: Limit which catalogs are included in the All Filtered list.  This is
+  distinct from the catalog-specific object lists, which are a shortcut to one catalog.
+  Using the Catalogs filter, the All Filtered list can show globular clusters across
+  multiple catalogs at once.
+- **Type**: Limit by object type.  You can select multiple types to include.
+- **Altitude**: The current apparent altitude of an object from your observing location.
+- **Magnitude**: Limit to objects at least as bright as the selected magnitude.
+- **Observed**: Include only objects you've logged, never logged, or any logged state.
 
 Catalogs Filter
 ^^^^^^^^^^^^^^^^^
 
-The PiFinder has many different catalogs so this menu groups them by categories.
+The PiFinder has many catalogs, so this menu groups them by category.
 
 .. image:: images/user_guide/filter_catalogs.png
 
-Some common catalogs are listed on the top level for quick reference and less 
-common catalogs are listed in their sub-categories indicated with an ellipsis (...)
+Common catalogs appear at the top level for quick reference; less common ones sit in
+sub-categories marked with an ellipsis (...).
 
 Here's the DSO... category as an example:
 
 .. image:: images/user_guide/filter_catalogs_dso.png
 
-Selected catalogs are indicated with a check box and you may see the same catalog, like Messier,
-listed in multiple spots.  Selecting or de-selecting anywhere will change the state everywhere.
+Selected catalogs show a check box, and you may see the same catalog, like Messier, in
+multiple spots.  Selecting or de-selecting anywhere changes its state everywhere.
 
 
 Name Search
 ------------
 
-A powerful way to search the large database of objects included with the PiFinder is by name.  
-This lets you find objects by their common description, like the Cat's Eye nebula.  To access 
-the Name Search screen select it from the Objects menu:
+A powerful way to search the PiFinder's large object database is by name, letting you find
+objects by their common description, like the Cat's Eye nebula.  To reach the Name Search
+screen, select it from the Objects menu:
 
 .. image:: images/user_guide/name_search_01.png
 
-It uses a T9 style text input, like some popular cellular phones at the dawn of text messages!  
-The on-screen keypad shows the letters that are available by pressing each number key multiple
-times in a row.  
+It uses T9-style text input, like the cellphones from the dawn of text messaging.  The
+on-screen keypad shows the letters available by pressing each number key several times in a
+row.
 
 .. image:: images/user_guide/name_search_02.png
 
-Each number key will generate its number, then the three or four letters displayed
-in turn.  If you pause long enough between key-presses, or press a different key, the cursor
-will move to the next position.
+Each number key generates its number, then the three or four letters shown, in turn.  Pause
+long enough between presses, or press a different key, and the cursor moves to the next
+position.
 
 .. image:: images/user_guide/name_search_cat_01.png
 
-As you enter text, the PiFinder will show you how many objects match your search term to
-the far right of the text you are entering.
+As you type, the PiFinder shows how many objects match your search term, to the far right
+of your text.
 
 .. image:: images/user_guide/name_search_cat_02.png
 
-You can see the number of objects reducing as we add more text....
+The count drops as you add more text.
 
 .. image:: images/user_guide/name_search_cat_03.png
 
-Once you have enough of a search term to limit the list of objects, press the **SQUARE** key
-to see the full list of matching objects.
+Once you've narrowed the list enough, press the **SQUARE** key to see the full list of
+matches.
 
 .. image:: images/user_guide/name_search_results.png
 
 Object Images
 ---------------
 
-If you have used the prebuilt PiFinder image or have :ref:`downloaded<software:catalog image download>`
-the set of catalog images you can view what the selected object looks like via images from sky surveys.  
-These images will display in the background of the :ref:`user_guide:object details` screen and you 
-can see them in full detail by pressing the **SQUARE** key to cycle through various pages of 
-information about each object. 
+If you used the prebuilt PiFinder image or have :ref:`downloaded<software:catalog image download>`
+the set of catalog images, you can see what the selected object looks like via sky-survey
+images.  These display in the background of the :ref:`user_guide:object details` screen,
+and you can view them in full detail by pressing the **SQUARE** key to cycle through the
+pages of information about each object.
 
-The images will be rotated and oriented as they will appear through
-the eyepiece at the position and time you are observing them to help you identify the faintest of 
-targets.
+The images are rotated and oriented as they appear through the eyepiece at your position
+and time, to help you identify the faintest targets.
 
-You can zoom in an out via the **+/-** keys and the FOV will
-be displayed at the bottom of the image so you can match it with your eyepiece FOV.
+Zoom in and out with the **+/-** keys; the FOV is displayed at the bottom of the image so
+you can match it to your eyepiece.
 
 As an example, here are the images available for M57
 
@@ -546,22 +536,21 @@ As an example, here are the images available for M57
    :alt: Catalog Image
 
 
-These images are oriented to match the view through your eyepiece for the
-telescope you're using, pointing at a specific area of the sky from your current
-location.  By default they're oriented for a Newtonian reflector; if you use a
-refractor or an SCT with a star diagonal, set the orientation options for your
-telescope as described in :doc:`equipment`.  You can
-use the **+** and **-** keys to switch between the field of view provided by the different
-eyepieces you configured via the :ref:`user_guide:Web Interface`
+These images are oriented to match the view through your eyepiece for the telescope you're
+using, pointing at a specific area of sky from your current location.  By default they're
+oriented for a Newtonian reflector; if you use a refractor or an SCT with a star diagonal,
+set the orientation options for your telescope as described in :doc:`equipment`.  Use the
+**+** and **-** keys to switch between the fields of view of the eyepieces you configured
+via the :ref:`user_guide:Web Interface`
 
-The bottom left of the screen shows the source of the current image and the left side shows the current FOV information.
+The bottom left of the screen shows the source of the current image, and the left side
+shows the current FOV information.
 
 Logging Observations
 -----------------------
 
-Pressing the **RIGHT** arrow when looking at the details of any object will bring you to the 
-logging interface.  Here you can add a bit of context about your observation and save it to
-your log.
+Pressing the **RIGHT** arrow while viewing any object's details brings up the logging
+interface, where you can add context about your observation and save it to your log.
 
 .. image:: images/user_guide/logging_01_docs.png
 .. image:: images/user_guide/logging_02_docs.png
@@ -569,75 +558,75 @@ your log.
 Use the **UP/DOWN** arrows to select one of the four context items to change:
 
 - **Observability**: How easy is it to spot and recognize this object
-- **Appeal**: Overall rating of this object.. would you refer a friend?
+- **Appeal**: Overall rating — would you refer a friend?
 
-Both of these first two items are set by choosing a number between 1 and 5 to set the rating
-or pressing the **RIGHT** arrow to cycle through the stars.
+Set these first two by choosing a number from 1 to 5, or pressing the **RIGHT** arrow to
+cycle through the stars.
 
 - **Conditions**...
 
-  - **Transparency**: A relative measure of contrast. 
+  - **Transparency**: A relative measure of contrast.
 
-  - **Seeing**: The stillness of the atmosphere. 
+  - **Seeing**: The stillness of the atmosphere.
 
-- **Eyepiece**: You can note which of your eyepieces you are using.
+- **Eyepiece**: Note which of your eyepieces you're using.
 
-When you are done adding context, or if you want to just note that you observed an object 
-without context, use the **UP/DOWN** arrows to select **SAVE LOG** to record your observation.
+When you're done — or if you just want to note that you observed an object without context
+— use the **UP/DOWN** arrows to select **SAVE LOG** and record your observation.
 
 
 Observing Projects
 --------------------
 
-If you are like me, you may enjoy various observing projects, such as observing all the Messier 
-or Herschel objects.  The PiFinder makes these longer term efforts easy by allowing you to log each 
-object and then only showing you objects you have left that are visible during any observing session!
+If you're like me, you may enjoy observing projects, such as working through all the
+Messier or Herschel objects.  The PiFinder makes these long-term efforts easy: log each
+object, and it will then show you only the objects you have left that are visible during
+any session.
 
-Combining the ability to :ref:`filter<user_guide:filters>` a catalog by observation status and sorting the object list 
-by the nearest objects allows you to work your way through a collection of objects easily.
+Combining a :ref:`filter<user_guide:filters>` on observation status with an object list
+sorted by NEAREST lets you work through a collection easily.
 
 Tools
 ==========================
 
-Near the bottom of the main PiFinder menu is an option that brings you to a set of tools.  These are screens
-that are not observing related but provide useful information about the PiFinder or let you perform actions.
+Near the bottom of the main PiFinder menu, the Tools option leads to a set of screens that
+aren't observing-related but provide useful information or let you perform actions.
 
 .. image:: images/user_guide/tools_menu_docs.png
 
-- :ref:`Status<user_guide:status screen>`: General info about about the PiFinder operation.
+- :ref:`Status<user_guide:status screen>`: General info about PiFinder operation.
 - :doc:`Equipment <equipment>`: Choose your active telescope and eyepiece, and see the resulting magnification and field of view.
 - Console: Shows messages from various PiFinder subsystems
-- :ref:`Software Upd<user_guide:update software>`: Updates the software of your PiFinder.  
-- Test Mode: Puts the PiFinder into a demo/debug mode which loads and solves an image from disk.  Will prevent proper operation at night, but allows exploration of PiFinder features during the day.
+- :ref:`Software Upd<user_guide:update software>`: Updates the software of your PiFinder.
+- Test Mode: Puts the PiFinder into a demo/debug mode that loads and solves an image from disk.  It prevents proper operation at night but lets you explore PiFinder features during the day.
 - :ref:`Shutdown<user_guide:shutdown>`: Shuts down the PiFinder
 
 Status Screen
 ----------------------------------
 
-The Status Screen is the central place to get information about the current 
-state and operation of the PiFinder.  
+The Status Screen is the central place to check the PiFinder's current state and operation.
 
 .. image:: images/user_guide/status_screen_docs.png
 
-Some of the key bits of information displayed:
+Some of the key information shown:
 
-- The current solver state displayed as LAST SLV on the top line.  It shows the
-  number of seconds since the last plate solve, the current solve state (i for IMU 
-  or C for camera) and the number of stars matched if the current solve is a camera solve
-- WiFi information is displayed a bit further down including the current WiFi mode, 
-  network name and IP address.
+- The current solver state, as LAST SLV on the top line.  It shows the seconds since the
+  last plate solve, the solve type (i for IMU or C for camera), and, for a camera solve,
+  the number of stars matched.
+- WiFi information a bit further down, including the current WiFi mode, network name, and
+  IP address.
 
 
-Shutdown 
+Shutdown
 ---------------------------
 
-Although shutting down is not strictly needed before power-off, the PiFinder is a 
-computer and there is a chance of file corruption if you do not.  Some MicroSD 
-cards are more sensitive to this than others.
+Shutting down isn't strictly required before power-off, but the PiFinder is a computer and
+there's a chance of file corruption if you skip it.  Some MicroSD cards are more sensitive
+than others.
 
-The Tools menu offers a Shutdown option, and there is a quick way to access this as well.
+The Tools menu offers a Shutdown option, and there's a quick way to reach it too.
 
-To easily shut down the PiFinder:
+To shut down the PiFinder quickly:
 
 - Hold the **LEFT** arrow button for more than a second to jump to the main menu
 - Hold the **SQUARE** button to access the Radial menu
@@ -650,8 +639,8 @@ To easily shut down the PiFinder:
 
 .. image:: images/quick_start/shutdown_confirm.png
 
-When you confirm the screen and keypad will turn off after a few seconds and it's then safe to
-turn off the unit using the power switch or unplugging the battery.
+After you confirm, the screen and keypad turn off within a few seconds; it's then safe to
+turn off the unit with the power switch or by unplugging the battery.
 
 WiFi
 ==========================
@@ -659,50 +648,50 @@ WiFi
 Access Point and Client Mode
 ----------------------------------
 
-The PiFinder can either connect to an existing network via the Client mode, or serve as a 
-wireless access point for other devices to connect to via the Access Point (AP) mode.  Use the 
-:ref:`user_guide:Web Interface` or the :ref:`user_guide:status screen` to switch between these two modes 
-and to see which mode is currently active.
+The PiFinder can connect to an existing network in Client mode, or serve as a wireless
+access point for other devices in Access Point (AP) mode.  Use the
+:ref:`user_guide:Web Interface` or the :ref:`user_guide:status screen` to switch between
+the two modes and see which is active.
 
-Using the PiFinder in Access Point mode creates a network called PiFinderAP with no password to allow 
-easy connection of phones, tablets and other devices in the field.
+In Access Point mode the PiFinder creates a network called PiFinderAP with no password, for
+easy connection of phones, tablets, and other devices in the field.
 
-To use the Client mode, you'll need to add information about the WiFi network you'd like the 
-PiFinder to connect to using the Web Interface as described in :ref:`user_guide:connecting to a new wifi network`
+To use Client mode, add the WiFi network you'd like the PiFinder to connect to using the
+Web Interface, as described in :ref:`user_guide:connecting to a new wifi network`
 
 PiFinder address
 -----------------
 
-In most cases, you can use the name ``pifinder.local`` to connect to the PiFinder.  On older computers 
-or those that don't support zeroconf networking, you can use the IP address provided on the :ref:`Global 
-Options<user_guide:settings menu>` screen to connect.  You can connect to the PiFinder via:
+In most cases you can reach the PiFinder at ``pifinder.local``.  On older computers, or
+those without zeroconf networking, use the IP address shown on the :ref:`Global
+Options<user_guide:settings menu>` screen.  You can connect via:
 
 
-* A web browser to use the :ref:`user_guide:Web Interface` for remote control, setting up access to other WiFi networks and for configuration changes
-* SSH to get shell access for advanced users
-* SMB (Samba) to access saved images, logs and observing lists
-* LX200 protocol to allow updating of a planetarium app, such as :doc:`skysafari` , with the position of the telescope
+* A web browser, for the :ref:`user_guide:Web Interface` — remote control, WiFi setup, and configuration changes
+* SSH, for shell access (advanced users)
+* SMB (Samba), to access saved images, logs, and observing lists
+* LX200 protocol, to update a planetarium app such as :doc:`skysafari` with the telescope's position
 
 Web Interface
 ==============
 
-The PiFinder provides an easy to use web interface which allows you to:
+The PiFinder's web interface lets you:
 
 * See the current PiFinder status
 * Remote control the PiFinder via a virtual screen and keypad
 * Change network settings and connect to new WiFi networks
 * Add and edit your telescopes and eyepieces (see :doc:`equipment`)
-* Backup and restore your observing logs, settings and other data
+* Back up and restore your observing logs, settings, and other data
 * View and download your logged observations
 
-To access the web interface for the first time, make sure the PiFinder is in Access Point mode (see :ref:`user_guide:settings menu`).  This is the default for new PiFinders to make first time set up easier.  Using a phone, tablet or computer, connect to the PiFinder's wireless network called PiFinderAP.  It's an open network with no password required.  Once connected, open your web browser and visit:
+To reach the web interface for the first time, make sure the PiFinder is in Access Point mode (see :ref:`user_guide:settings menu`) — the default for new PiFinders, to ease first-time setup.  From a phone, tablet, or computer, connect to the PiFinder's open wireless network, PiFinderAP (no password), then open your browser and visit:
 ``http://pifinder.local``
 
 
 .. note::
-   If you are connected to the PiFinderAP network and can't load the PiFinder web interface using
-   http://pifinder.local try http://10.10.10.1 as some systems may not support the network features
-   required to resolve local computer names
+   If you're connected to the PiFinderAP network and can't load the web interface at
+   http://pifinder.local, try http://10.10.10.1 — some systems don't support the network
+   features needed to resolve local computer names.
 
 .. list-table::
    :width: 100%
@@ -711,75 +700,76 @@ To access the web interface for the first time, make sure the PiFinder is in Acc
 
      - .. image:: images/user_guide/pf_web_home_hamburger.jpg
 
-The home screen shows the general PiFinder status info and a live view of the screen.  Depending 
-on your screen size you'll either see a navigation bar along the top of the page, or a 'hamburger' menu in the upper-left which contains these same options for smaller screens.
+The home screen shows general PiFinder status and a live view of the screen.  Depending on
+your screen size you'll see either a navigation bar along the top or a 'hamburger' menu in
+the upper-left holding the same options on smaller screens.
 
-While the home screen not require a password, most other functions will.  The password for the web 
-interface is the same as what is used for the ``pifinder`` user and changing one will change 
-the other.  The default password for new images and PiFinders is ``solveit``.  This can be changed using 
-the Tools option in the web interface.
+The home screen needs no password, but most other functions do.  The web interface password
+is the same as the ``pifinder`` user's; changing one changes the other.  The default for new
+images and PiFinders is ``solveit``, and you can change it from the Tools option in the web
+interface.
 
 Connecting to a new WiFi network
 ---------------------------------
 
-The default behavior of the PiFinder is to generate its own WiFi network called ``PiFinderAP`` that you can connect to 
-and configure additional networks. To get the PiFinder to connect to an existing WiFi network with Internet access you
-can follow the steps below:
+By default the PiFinder generates its own WiFi network, ``PiFinderAP``, that you connect to
+in order to configure additional networks.  To have the PiFinder connect to an existing
+WiFi network with Internet access, follow these steps:
 
 1) Make sure the PiFinder is in Access Point mode
 2) Connect your phone, tablet, or computer to the PiFinder's wifi network called PiFinderAP
 3) Visit http://pifinder.local using your web browser
-4) Click the 'Network' link in the top bar, or if you have a smaller screen, click the three stacked horizontal lines in the upper-right corner to access the menu and choose 'Network' from there.
+4) Click the 'Network' link in the top bar, or on a smaller screen click the three stacked horizontal lines in the upper-right corner and choose 'Network'.
     .. image:: images/user_guide/pf_web_net0.png
-5) When prompted enter the password for your PiFinder.  The default is `solveit`.
-6) Scroll down until you see the 'Wifi Networks' section and click the + button to add a new network
+5) When prompted, enter the password for your PiFinder.  The default is `solveit`.
+6) Scroll down to the 'Wifi Networks' section and click the + button to add a network
     .. image:: images/user_guide/pf_web_net1.jpg
-7) Enter the name (SSID) of your network and the password in the form.  If your network does not have a password, leave the Password field blank.
+7) Enter the name (SSID) and password of your network.  If your network has no password, leave the Password field blank.
 8) Click the 'SAVE' button to save the new network
-9)  You should now see the network you added in the 'Wifi Networks' section of the page
-10) Scroll up and change the Wifi mode from 'Access Point' to 'Client' so that the PiFinder will attempt to connect to your network next time it restarts
+9)  The network you added should now appear in the 'Wifi Networks' section
+10) Scroll up and change the Wifi mode from 'Access Point' to 'Client' so the PiFinder connects to your network on its next restart
 11) Click the 'UPDATE AND RESTART' button
 
-To add more WiFi networks for the PiFinder to look for, navigate to the Network Setup page of the :ref:`user_guide:web interface` and click the + button near the list of WiFi networks and repeat the steps above.
+To add more WiFi networks, navigate to the Network Setup page of the :ref:`user_guide:web interface`, click the + button near the WiFi networks list, and repeat the steps above.
 
 
 SkySafari
 ===================
 
-The PiFinder can provide real-time pointing information to a device running SkySafari via the LX200 protocol.  See 
-this :doc:`skysafari` document for complete details, but here is the connection info:
+The PiFinder can provide real-time pointing information to a device running SkySafari via
+the LX200 protocol.  See the :doc:`skysafari` document for full details; here's the
+connection info:
 
 
 * Use 'Other' telescope type
-* Mount Type: Alt-Az, GoTo.. even if your scope is Push-To.  This allows sending of targets from SkySafari to the PiFinder
+* Mount Type: Alt-Az, GoTo — even if your scope is Push-To.  This lets SkySafari send targets to the PiFinder
 * Scope Type: Meade LX200 classic
-* IP Address: ``pifinder.local`` or IP address provides on the Status screen
+* IP Address: ``pifinder.local`` or the IP address shown on the Status screen
 * Port: 4030
 
 Shared Data Access
 ===================
 
-In the course of using the PiFinder several data files are created that may be of interest.  
-These are available via a SMB (samba) network share called ``//pifinder.local/shared``.  Accessing this will depend on your 
-OS, but the PiFinder should be visible in a network browser provided.  There is no password requirement, 
-just connect as ``guest`` with no password provided.
+The PiFinder creates several data files you may want.  They're available via an SMB (samba)
+network share, ``//pifinder.local/shared``.  Access depends on your OS, but the PiFinder
+should appear in a network browser.  No password is required — connect as ``guest`` with no
+password.
 
 Once connected, you'll see:
 
 
-* ``captures/``\ : These are images saved when logging objects.  They are named with the observation ID from the database.
-* ``obslists/``\ : This folder holds observing saved during a PiFinder session or to load for future sessions.
-* ``screenshots/``\ :  It's possible to take screenshots while using the PiFinder (hold down **ENT** and press 
-  *0*\ ).  They are stored here.
-* ``solver_debug_dumps/``\ : If enabled, information about solver performance is stored here as a collection of images 
-  and json files.
-* ``observations.db``\ : This is the SQLite database which holds all the logged observations.
+* ``captures/``\ : Images saved when logging objects, named with the observation ID from the database.
+* ``obslists/``\ : Observing lists saved during a session or kept for future sessions.
+* ``screenshots/``\ : Screenshots taken while using the PiFinder (hold **ENT** and press
+  *0*\ ) are stored here.
+* ``solver_debug_dumps/``\ : If enabled, solver performance information is stored here as a collection of images and json files.
+* ``observations.db``\ : The SQLite database holding all logged observations.
 
 Update Software
 ==================
 
-The PiFinder offers a way to download and install software updates directly from the PiFinder screen and 
-keypad.  To start this process you can choose Software Upd from the :ref:`user_guide:tools`
+The PiFinder can download and install software updates directly from its screen and keypad.
+To start, choose Software Upd from the :ref:`user_guide:tools`
 
 Updates happen right on the device — there is no need to send your PiFinder anywhere.  New
 units often ship a version or two behind the latest release, so running an update is a
@@ -787,11 +777,11 @@ normal part of your first night out.
 
 .. image:: images/user_guide/software_update_01_docs.png
 
-The PiFinder will need to be connected to the internet, so you'll need to have it in Client Mode and connected
-to a WiFi network.  See :ref:`user_guide:connecting to a new wifi network` for more details.
+The PiFinder needs internet access, so put it in Client Mode connected to a WiFi network.
+See :ref:`user_guide:connecting to a new wifi network` for details.
 
-The PiFinder will check to make sure it can access the internet then compare the current release version to
-the version installed.  
+The PiFinder confirms it can reach the internet, then compares the current release version
+to the one installed.
 
 .. image:: images/user_guide/software_update_02_docs.png
 
@@ -803,19 +793,20 @@ the version installed.
    fix for this.  If WiFi is configured but the check still fails, move closer to the
    router or re-enter the network details.
 
-If a new version is available, you can use the presented option to start the update.  This may take several minutes
-and the PiFinder will restart when it's done.  
+If a new version is available, use the presented option to start the update.  This may take
+several minutes, and the PiFinder restarts when it's done.
 
 .. image:: images/user_guide/software_update_04_docs.png
 
 
 .. image:: images/user_guide/software_update_03_docs.png
 
-You can also download a pre-built image of any software release and write it to the PiFinder's SD card.  
-See our `release page <https://github.com/brickbots/PiFinder/releases>`_ to find information about any
-of our releases and a link to download the images.
+You can also download a pre-built image of any software release and write it to the
+PiFinder's SD card.  See our `release page <https://github.com/brickbots/PiFinder/releases>`_
+for information about each release and a download link.
 
-Instructions for writing software release images to an SD card can be found on the :doc:`software setup<software>` page.
+Instructions for writing release images to an SD card are on the :doc:`software setup<software>`
+page.
 
 FAQ
 ====

--- a/docs/source/v25_upgrade.rst
+++ b/docs/source/v25_upgrade.rst
@@ -1,60 +1,56 @@
 Version 2.5 Upgrade Kit Guide
 ================================================
 
-Thanks for ordering a PiFinder v2.5 upgrade kit!  This kit includes everything you need to update
-the camera in your PiFinder to match the capabilities of a v3 and replace the button faceplate
-so you can have the proper labels for the new software.
+Thanks for ordering a PiFinder v2.5 upgrade kit! It contains everything you need to bring your
+PiFinder's camera up to v3 capabilities and swap the button faceplate for one labelled to match
+the new software.
 
-In this guide we show a Right handed PiFinder, but these instructions are generally the same 
-for Left and Flat units as well.
+These photos show a Right-handed PiFinder, but the steps are the same for Left and Flat units.
 
 Get Started
 ------------
 
-Collect your PiFinder v2 and unpack all the parts from the upgrade kit.  Put them all on a messy
-workbench and take an out of focus picture....
+Unpack your PiFinder v2 and all the kit parts. Put them on a messy workbench and take an
+out-of-focus picture....
 
-You'll also need a small philips head screwdriver, and a pair of side cutters to complete the assembly.  
-This whole process should take about 10 minutes and is not tricky, but it's probably a good idea to read through this 
-guide once before diving in.
+You'll also need a small Phillips screwdriver and a pair of side cutters. The whole process takes
+about 10 minutes and isn't tricky, but read through this guide once before diving in.
 
 .. image:: images/v25_upgrade/v25_upgrade_10.jpeg
 
 Camera Prep
 ----------------
 
-The new v3 camera may come with one of two different lens holders already installed. No matter 
-which your camera has you'll be removing and replacing it.
+The new v3 camera ships with one of two lens holders installed. Either way, you'll remove it and
+fit the one from the kit.
 
 .. image:: images/v25_upgrade/v25_upgrade_11.jpeg
 
-Some cameras have pin headers installed, if you have one of these, you'll need to clip them as close
-as reasonable to the board.
+If your camera has pin headers, clip them as close to the board as you reasonably can.
 
 .. image:: images/v25_upgrade/v25_upgrade_12.jpeg
 
 .. image:: images/v25_upgrade/v25_upgrade_13.jpeg
 
-Grab the lens holder and look through it to make sure it's clear of any obstructions.
+Look through the lens holder to confirm it's clear of obstructions.
 
-Place the lens holder on the table with the large side up oriented as in the photo below.  The two screw
-tabs on the lens holder must stick out the opposite sides from the cream-white and dark-grey cable connector on the PCB.
-You'll be removing the two screws (yours might be black) near the center of the green PCB and lifting it gently
-to the new lens holder.  
+Place the lens holder on the table, large side up, oriented as in the photo below. Its two screw
+tabs must stick out the opposite sides from the cream-white and dark-grey cable connector on the
+PCB. Remove the two screws (yours might be black) near the center of the green PCB and lift it
+gently onto the new lens holder.
 
-Mind the sensor surface on the under side of the PCB. It should sit nicely in the square recess of the lens holder.
-Use the same two screws to affix the sensor PCB to the lens holder.  The screws will be cutting their own threads, but
-there are holes there to help get started.  Tighten the screws down against the PCB so nothing is wiggling/moving.
+Mind the sensor surface on the underside of the PCB; it should sit neatly in the square recess of
+the lens holder. Refit the same two screws to fasten the PCB to the lens holder. The screws cut
+their own threads, but the holes help get them started. Tighten them down so nothing wiggles.
 
 .. image:: images/v25_upgrade/v25_upgrade_14.jpeg
 
 .. image:: images/v25_upgrade/v25_upgrade_15.jpeg
 
-Flip the camera assembly over and thread in the lens.  Be slow and careful here.  With gentle force
-the lens should slide in a few MM to get everything aligned and stop.  When it stops, check to make sure it seems
-straight and start screwing it into place.  To get focus about right, You'll want a 6mm gap (pictured below) between the 
-top of the lens holder and the bottom of the lip on the lens.  Don't fret too much about it as you'll do final focus 
-under the stars.
+Flip the camera assembly over and thread in the lens, slowly and carefully. With gentle force it
+slides in a few MM, aligns, and stops. Once it stops, check that it sits straight and screw it into
+place. For a rough focus, leave a 6mm gap (pictured below) between the top of the lens holder and
+the bottom of the lip on the lens. Don't fret over it; you'll do final focus under the stars.
 
 .. image:: images/v25_upgrade/v25_upgrade_16.jpeg
 
@@ -63,16 +59,16 @@ under the stars.
 Installing the Camera
 ----------------------
 
-Grab your PiFinder and remove the four screws holding on the camera.  It may be
-easier to remove the lens first if you have the internal battery installed.
+Grab your PiFinder and remove the four screws holding the camera. If the internal battery is
+installed, it's easier to remove the lens first.
 
 
 .. image:: images/v25_upgrade/v25_upgrade_18.jpeg
 
 .. image:: images/v25_upgrade/v25_upgrade_19.jpeg
 
-Open the cable connector on the camera by gently sliding the dark-grey part of the 
-connector towards the cable.  Once open the cable should come loose easily.
+Open the camera's cable connector by gently sliding the dark-grey part toward the cable. The cable
+then comes loose easily.
 
 Unplug the cable and set the camera aside, saving the four m2.5 8mm screws.
 
@@ -81,33 +77,29 @@ Unplug the cable and set the camera aside, saving the four m2.5 8mm screws.
 .. image:: images/v25_upgrade/v25_upgrade_21.jpeg
 
 
-Remove the four brass stand-offs holding that used to hold the camera, these
-are no longer needed.
+Remove the four brass stand-offs that held the camera; these are no longer needed.
 
 .. image:: images/v25_upgrade/v25_upgrade_22.jpeg
 
-Use the four screws to secure the adaptor to the PiFinder back plate as shown.  The 
-adapter has an opening in one side to allow the cable to exit.  Make sure 
-this is aligned with the direction the cable is coming from.
+Use the four screws to secure the adaptor to the PiFinder back plate as shown. The adapter has an
+opening on one side for the cable to exit; align it with the direction the cable comes from.
 
 .. image:: images/v25_upgrade/v25_upgrade_23.jpeg
 
-Next you'll connect the cable to the new camera module.  Open the connector all the way
-by sliding the dark-grey piece away from the PCB.  Be gentle as this part can break with too
-much force. 
+Next, connect the cable to the new camera module. Open the connector fully by sliding the dark-grey
+piece away from the PCB. Be gentle, as this part breaks with too much force.
 
-Once the connector is open, slide the cable into the connector using gentle force and making 
-sure it's well aligned.  Take your time and watch the
-dark-grey clip.  It should not close as you are inserting the cable, and if it does, you'll need
-to re-open it to get the cable to slide in all the way.
+With the connector open, slide the cable in with gentle force, keeping it well aligned. Take your
+time and watch the dark-grey clip. It should stay open as you insert the cable; if it closes,
+re-open it so the cable can slide all the way in.
 
-Once the cable is seated in the connector, close the dark-grey clip by sliding it shut, this 
-may take a little force to get it completely closed.  Check the photo below if in doubt!
+Once the cable is seated, close the dark-grey clip by sliding it shut. This may take a little force
+to fully close. Check the photo below if in doubt!
 
 .. image:: images/v25_upgrade/v25_upgrade_24.jpeg
 
-Situate the camera in the adapter and use the two new screws to secure it.  They are 
-the same size as the other four, if they get mixed up.
+Situate the camera in the adapter and secure it with the two new screws. They match the other four,
+in case they get mixed up.
 
 .. image:: images/v25_upgrade/v25_upgrade_25.jpeg
 
@@ -118,10 +110,9 @@ the same size as the other four, if they get mixed up.
 Swapping the Faceplate
 -----------------------
 
-Not a whole lot to say here.. except to ignore the well-used state of my development 
-PiFinder here.  
+Not much to say here, except to ignore the well-used state of my development PiFinder.
 
-Remove the three screws, swap the plate and screw it back on
+Remove the three screws, swap the plate, and screw it back on.
 
 .. image:: images/v25_upgrade/v25_upgrade_28.jpeg
 
@@ -134,34 +125,31 @@ Remove the three screws, swap the plate and screw it back on
 Software and Camera Set Up
 ----------------------------
 
-To use the new camera, you'll need to update to the latest PiFinder software.  Check the 
-`Version 1.x software update guide <https://pifinder.readthedocs.io/en/v1.11.2/user_guide.html#update-software>`_ 
-for details on different ways to update your software.  If you PiFinder is very old, you 
-may need to write a new SD card.
+To use the new camera, update to the latest PiFinder software. See the
+`Version 1.x software update guide <https://pifinder.readthedocs.io/en/v1.11.2/user_guide.html#update-software>`_
+for the different ways to update. If your PiFinder is very old, you may need to write a new SD card.
 
-Once you have the new software running, you'll need to switch camera types to one of the
-sensors used in the v3.  PiFinder upgrade kits currently shipping will include the Sony
-imx462 or imx296 sensor. The box your camera module came in should indicate the 
-type.  From the main PiFinder menu:
+With the new software running, switch the camera type to one of the v3 sensors. Upgrade kits
+currently ship with the Sony imx462 or imx296 sensor; the box your camera module came in indicates
+which. From the main PiFinder menu:
 
 * Scroll down and choose Settings
 
 .. image:: images/v25_upgrade/v25_upgrade_41.png
 
-* Then choose Camera Type near the bottom
+* Choose Camera Type near the bottom
 
 .. image:: images/v25_upgrade/v25_upgrade_42.png
 
-* Finally, choose either v3 - imx462 or v3 - imx296
+* Choose either v3 - imx462 or v3 - imx296
 
 .. image:: images/v25_upgrade/v25_upgrade_44.png
 
-Your PiFinder will reboot and you should be able to see a bright image or static from the 
-camera preview screen depending on lighting conditions and such.  You might want to use the
-settings menu to set your exposure to 0.4 or 0.2 at a maximum with the new camera and I'd 
-encourage you to try lower once you are out under the stars.
+Your PiFinder reboots, and the camera preview screen shows a bright image or static, depending on
+lighting. Set your exposure to 0.4 or 0.2 at most with the new camera, and try lower once you're
+out under the stars.
 
-And you are DONE!  Congratulations on your new PiFinder v2.5
+That's it; congratulations on your new PiFinder v2.5.
 
-Check out the :doc:`quick_start` for details on focusing and a primer on the new 
-software interface.
+Check out the :doc:`quick_start` for details on focusing and a primer on the new software
+interface.


### PR DESCRIPTION
## What

A "warm but lean" pass across all nine reader-facing documentation pages, plus an update to the docs skill's house-voice guidance that codifies the new direction.

The goal: keep the manual's warm, direct "you" voice, but cut the padding so it reads tighter at the eyepiece. **~14% fewer words (≈3,100 cut)** with every image, cross-reference, note, and caveat preserved.

## Pages leaned

| Page | Words |
|------|-------|
| quick_start | 4075 → 3265 (20%) |
| user_guide | 6114 → 5312 (13%) |
| build_guide | 6247 → 5604 (10%) |
| catalogs | 488 → 422 (14%) |
| v25_upgrade | 1056 → 880 (17%) |
| software | 1036 → 936 (10%) |
| skysafari | 740 → 641 (13%) |
| equipment | 1078 → 1003 (7%) |
| troubleshooting | 2098 → 2008 (4%) |

Lighter trims (build_guide, software, troubleshooting, equipment) are expected — those pages are mostly steps, measurements, commands, and symptom→fix checks, so only prose padding came out.

## Kinds of changes

- **Cuts:** throat-clearing ("In order to…", "It is important to note…"), redundant restatement, and hedging. The *why* is kept but compressed to a clause; longer asides moved into `.. note::`.
- **Structure:** multi-step procedures became numbered lists where images don't interleave the steps (kept as bullets where they do, since rST restarts numbering after each image).
- **Tone guidance:** added a **"Be succinct"** principle and reframed **"explain the why"** → **"compress the why"** in `.claude/skills/docs/SKILL.md`.

## Bonus fixes caught along the way

- Repaired a broken `:doc:` cross-reference in `user_guide.rst` that was split across a line break (rendered as literal text).
- Fixed `skysafari.rst` heading hierarchy — sections were all top-level siblings of the title; now proper subsections.
- Assorted `its`/`it's`, `philips`→`Phillips`, `PCB's`→`PCBs`, a port-value self-contradiction in skysafari, double spaces.

## Notes for reviewers

- The `user_guide` pass was re-run on top of the newly merged **Power & Charging / LiPo safety** section (#447) — that section and its safety warnings are preserved in full and leaned alongside the rest.
- No toctree or page renames; heading levels and underline characters unchanged (except the intentional skysafari fix).

## Verification

- `sphinx-build -b html -n -E` is clean — no warnings on any touched page (only the pre-existing repo-wide `_static` path warning remains).
- Image/figure/`:ref:`/`:doc:` counts verified equal to `origin/main` for every page (the single `:doc:` delta in user_guide is the broken-link repair above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)