### PR TITLE
Replace T9 Search toggle with a Search Input method choice

### DIFF
--- a/.claude/skills/docs/references/product-knowledge-base.md
+++ b/.claude/skills/docs/references/product-knowledge-base.md
@@ -237,7 +237,7 @@ The PiFinder has a digital alignment system that maps where within its 10° fiel
 - **Physical alignment vs digital alignment**: When a customer reports alignment problems, first verify they understand the alignment procedure (especially the SQUARE button press). If the camera is physically pointed too far from the telescope's optical axis (>5 degrees), no amount of digital alignment will help — the star won't be in the camera's FOV at all.
 
 ### Finding Objects & Push-To Guidance
-- Access objects via main menu → **Objects** → choose **By Catalog**, **All Filtered**, **Recent** (session history), or **Name Search** (T9-style text entry).
+- Access objects via main menu → **Objects** → choose **By Catalog**, **All Filtered**, **Recent** (session history), or **Name Search** (keypad text entry — multi-tap by default, or T9 via the Search Input setting).
 - In object lists, pressing **SQUARE** cycles through info displays: catalog designation → common names → magnitude/size with observation checkmarks.
 - **Push-to guidance** (from Object Details screen):
   - **Top number**: Rotational direction (CW/CCW) and degrees to move
@@ -403,7 +403,7 @@ The PiFinder connects to SkySafari (and other planetarium apps) via WiFi using t
 - PiFinder initially sends 0° RA/DEC until the first plate solve completes
 - Works with **SkySafari 5 Plus, 6, and 7** (7 is most reliable)
 - SkySafari can lock the view to the scope's position
-- SkySafari can send objects to PiFinder's observing list (useful alternative to T9 keypad entry)
+- SkySafari can send objects to PiFinder's observing list (useful alternative to keypad text entry)
 - **Single connection limit**: Only one device/app can connect to the PiFinder's LX200 server at a time. If SkySafari is connected on an iPhone, it must be disconnected before connecting from an iPad (or vice versa).
 - **SkySafari cannot connect to PiFinder and a GoTo mount simultaneously** — choose one
 - **Sleep mode warning**: If PiFinder enters sleep mode, it stops sending position updates. Extend or disable the sleep timer if using SkySafari continuously.

--- a/default_config.json
+++ b/default_config.json
@@ -6,7 +6,7 @@
     "auto_exposure_zero_star_handler": "sweep",
     "menu_anim_speed": 0.1,
     "text_scroll_speed": "Med",
-    "t9_search": false,
+    "search_input_method": "multi_tap",
     "screen_direction": "right",
     "mount_type": "Alt/Az",
     "solver_debug": 0,

--- a/docs/ax/catalog/CONTEXT.md
+++ b/docs/ax/catalog/CONTEXT.md
@@ -149,12 +149,12 @@ _Avoid_: catalog state (the enum is `CatalogState`; the wrapper is `CatalogStatu
 ### Search
 
 **Text search** (`search_by_text`):
-Lower-case substring match against every name in every catalog. Selection and filter state are ignored.
+Lower-case substring match against every name in every catalog. Selection and filter state are ignored. Backs the UI context's **multi-tap** search input method.
 _Avoid_: name search, full-text search.
 
 **T9 search** (`search_by_t9`):
-Substring search after translating names to PiFinder's non-standard keypad-digit form (`KEYPAD_DIGIT_TO_CHARS` — `7→abc`, `1→tuv`, …). Backed by `_t9_cache` keyed on `(catalog_code, sequence)`.
-_Avoid_: keypad search, digit search (use T9 search for the public concept).
+Substring search after translating names to PiFinder's non-standard keypad-digit form (`KEYPAD_DIGIT_TO_CHARS` — `7→abc`, `1→tuv`, …). Backed by `_t9_cache` keyed on `(catalog_code, sequence)`. Backs the UI context's **T9** search input method; reserve "T9 search" for this algorithm — the user-facing setting is the **search input method**.
+_Avoid_: keypad search, digit search.
 
 ### UI helpers
 

--- a/docs/ax/ui/CONTEXT.md
+++ b/docs/ax/ui/CONTEXT.md
@@ -111,7 +111,7 @@ _Avoid_: cached, singleton, persistent.
 ### Marking menus
 
 **Marking menu**:
-The four-direction radial overlay (`MarkingMenu`) drawn over the current screen, toggled by long-press of square. Each direction is a `MarkingMenuOption`.
+The four-direction radial overlay (`MarkingMenu`) drawn over the current screen, toggled by long-press of square. Each direction is a `MarkingMenuOption`. In user-facing prose (user guide, on-device help) this is the **Quick Menu**; "marking menu" is the code/architecture term.
 _Avoid_: radial menu, context menu, pie menu (the rendering is a pie, but the concept is "marking menu").
 
 **Marking-menu option** (`MarkingMenuOption`):
@@ -121,6 +121,28 @@ _Avoid_: marking item, menu button.
 **Marking-menu stack**:
 `MenuManager.marking_menu_stack` — the stack of currently-open (possibly nested) marking menus. Non-empty means the UI is in marking-menu mode and direction keys select options instead of reaching the active module.
 _Avoid_: overlay stack.
+
+### Text entry
+
+**Name Search**:
+The Objects-menu feature for finding objects by name: `UITextEntry` in its search personality, re-querying the catalog collection as the user types. Which system interprets the number keys is the **search input method**.
+_Avoid_: text search (reserve for the catalog-side algorithm), object search.
+
+**Search input method** (`search_input_method`):
+The user-selectable system that turns number-key presses into a Name Search query: **multi-tap** (the default) or **T9**. Chosen at Settings → User Pref → Search Input, jumpable from the Name Search marking menu. Applies to Name Search only — **free-text mode** is always multi-tap.
+_Avoid_: input mode, text entry method, T9 search on/off (the retired boolean framing).
+
+**Multi-tap**:
+The default search input method: pressing a number key cycles through that key's characters (`7` → `7 a b c`…); pausing, or pressing a different key, commits the character and moves on. Produces a text query backed by the catalog context's **text search**. Spelled "multi-tap" in prose, "Multi-Tap" as the menu option.
+_Avoid_: T9 (a long-standing misnomer for this system — T9 is the other one), multitap.
+
+**T9** (as input method):
+The opt-in search input method: each key press appends its digit — one press per letter — and the digit string is matched against object names translated to keypad digits, backed by the catalog context's **T9 search**. Matching uses PiFinder's own key layout (`7→abc`, `1→tuv`), not the standard phone layout.
+_Avoid_: predictive text (it matches catalog names, not a language dictionary).
+
+**Free-text mode** (`text_entry_mode`):
+`UITextEntry`'s other personality: editing an arbitrary string (e.g. a location name) returned via callback, with no live search. Always multi-tap — T9 cannot apply because there is no name list to match against.
+_Avoid_: text entry mode in prose (ambiguous with the screen's own name; the code flag is `text_entry_mode`).
 
 ### Dynamic menus
 

--- a/docs/source/menu_map.rst
+++ b/docs/source/menu_map.rst
@@ -122,8 +122,8 @@ Custom
    Enter a right ascension and declination by hand to make a one-off target you
    can push to.  See :ref:`user_guide:custom targets`.
 Name Search
-   Find objects by common name using T9-style text entry.  See
-   :ref:`user_guide:name search`.
+   Find objects by common name using the keypad — multi-tap or T9 text entry.
+   See :ref:`user_guide:name search`.
 
 
 Filter
@@ -197,8 +197,9 @@ User Pref...
       Menu scrolling animation speed — Off, Fast, Medium, or Slow.
    Scroll Speed
       How fast long lines of text scroll — Off, Fast, Medium, or Slow.
-   T9 Search
-      Turn T9 predictive text in Name Search on or off.
+   Search Input
+      How Name Search reads the keypad — Multi-Tap (cycle through each key's
+      letters) or T9 (one press per letter).
    Az Arrows
       Direction of the azimuth Push-To arrows — Default or Reverse, to match how
       you read them at the scope.

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -341,8 +341,8 @@ five options:
   the current session.
 - **Custom**: Enter a right ascension and declination by hand to make a one-off target.
   See :ref:`user_guide:custom targets`.
-- **Name Search**: Using the number keypad and T9-style text entry, search for objects by
-  name.  The Snowball planetary?  Cat's Eye?  This is the way to find them.
+- **Name Search**: Using the number keypad, search for objects by name.  The Snowball
+  planetary?  Cat's Eye?  This is the way to find them.
 
 However you build the list, it always displays the same information and offers the same
 sorting and selection.
@@ -484,7 +484,7 @@ screen, select it from the Objects menu:
 
 .. image:: images/user_guide/name_search_01.png
 
-It uses T9-style text input, like the cellphones from the dawn of text messaging.  The
+It uses multi-tap text input, like the cellphones from the dawn of text messaging.  The
 on-screen keypad shows the letters available by pressing each number key several times in a
 row.
 
@@ -493,6 +493,12 @@ row.
 Each number key generates its number, then the three or four letters shown, in turn.  Pause
 long enough between presses, or press a different key, and the cursor moves to the next
 position.
+
+If you'd rather press each key just once, switch the search input to T9: every press enters
+its digit, and the PiFinder matches the digit sequence against the letters of each object
+name — ``1897`` finds Vega.  Choose between Multi-Tap and T9 under Search Input in the
+:ref:`user_guide:settings menu`, or hold **SQUARE** here and pick Input from the
+:ref:`user_guide:quick menu` to jump straight to the setting.
 
 .. image:: images/user_guide/name_search_cat_01.png
 
@@ -505,7 +511,7 @@ The count drops as you add more text.
 
 .. image:: images/user_guide/name_search_cat_03.png
 
-Once you've narrowed the list enough, press the **SQUARE** key to see the full list of
+Once you've narrowed the list enough, press the **RIGHT** key to see the full list of
 matches.
 
 .. image:: images/user_guide/name_search_results.png

--- a/python/PiFinder/ui/menu_structure.py
+++ b/python/PiFinder/ui/menu_structure.py
@@ -710,18 +710,19 @@ pifinder_menu = {
                             ],
                         },
                         {
-                            "name": _("T9 Search"),
+                            "name": _("Search Input"),
                             "class": UITextMenu,
                             "select": "single",
-                            "config_option": "t9_search",
+                            "config_option": "search_input_method",
+                            "label": "search_input_method",
                             "items": [
                                 {
-                                    "name": _("Off"),
-                                    "value": False,
+                                    "name": _("Multi-Tap"),
+                                    "value": "multi_tap",
                                 },
                                 {
-                                    "name": _("On"),
-                                    "value": True,
+                                    "name": _("T9"),
+                                    "value": "t9",
                                 },
                             ],
                         },
@@ -1090,23 +1091,25 @@ pifinder_menu = {
                     "post_callback": callbacks.restart_pifinder,
                     "items": [
                         {
-                            "name": _("Off"), # TRANSLATORS: IMU sensitivity setting
+                            "name": _("Off"),  # TRANSLATORS: IMU sensitivity setting
                             "value": 100,
                         },
                         {
-                            "name": _("Very Low"), # TRANSLATORS: IMU sensitivity setting
+                            "name": _(
+                                "Very Low"
+                            ),  # TRANSLATORS: IMU sensitivity setting
                             "value": 3,
                         },
                         {
-                            "name": _("Low"), # TRANSLATORS: IMU sensitivity setting
+                            "name": _("Low"),  # TRANSLATORS: IMU sensitivity setting
                             "value": 2,
                         },
                         {
-                            "name": _("Medium"), # TRANSLATORS: IMU sensitivity setting
+                            "name": _("Medium"),  # TRANSLATORS: IMU sensitivity setting
                             "value": 1,
                         },
                         {
-                            "name": _("High"), # TRANSLATORS: IMU sensitivity setting
+                            "name": _("High"),  # TRANSLATORS: IMU sensitivity setting
                             "value": 0.5,
                         },
                     ],

--- a/python/PiFinder/ui/textentry.py
+++ b/python/PiFinder/ui/textentry.py
@@ -2,6 +2,7 @@ from PIL import Image, ImageDraw
 from PiFinder.composite_object import CompositeObject
 from PiFinder.ui.base import UIModule
 from PiFinder.db.objects_db import ObjectsDatabase
+from PiFinder.ui.marking_menus import MarkingMenu, MarkingMenuOption
 from PiFinder.ui.object_list import UIObjectList
 from PiFinder.ui.ui_utils import format_number
 import time
@@ -102,6 +103,13 @@ class UITextEntry(UIModule):
         # Only initialize database if we're in search mode
         if not self.text_entry_mode:
             self.db: ObjectsDatabase = ObjectsDatabase()
+            self.marking_menu = MarkingMenu(
+                left=MarkingMenuOption(),
+                down=MarkingMenuOption(),
+                right=MarkingMenuOption(
+                    label=_("Input"), menu_jump="search_input_method"
+                ),
+            )
 
         self.last_key = None
         self.KEYPRESS_TIMEOUT = 1
@@ -124,9 +132,14 @@ class UITextEntry(UIModule):
         self._results_updated = False  # Flag to trigger UI refresh
         self.SEARCH_DEBOUNCE_MS = 250  # milliseconds
 
+        # Input method the current text was typed with; if the user jumps
+        # to the Search Input setting and changes it, the pending entry is
+        # meaningless in the other system and gets cleared on return
+        self._text_input_method = self.search_input_method
+
     @property
-    def t9_search_enabled(self) -> bool:
-        return bool(self.config_object.get_option("t9_search", False))
+    def search_input_method(self) -> str:
+        return str(self.config_object.get_option("search_input_method", "multi_tap"))
 
     def draw_text_entry(self):
         line_text_y = self.text_y + self.bold.height + 2
@@ -286,7 +299,7 @@ class UITextEntry(UIModule):
             # Priority catalogs (NGC, IC, M) are loaded first, WDS loads in background
             # So search will work immediately with those, WDS results appear when loading completes
             logger.info(f"Starting search for '{search_text}'")
-            if self.t9_search_enabled:
+            if self.search_input_method == "t9":
                 results = self.catalogs.search_by_t9(search_text)
             else:
                 results = self.catalogs.search_by_text(search_text)
@@ -353,7 +366,7 @@ class UITextEntry(UIModule):
     def key_number(self, number):
         current_time = time.time()
         number_key = str(number)
-        if not self.text_entry_mode and self.t9_search_enabled:
+        if not self.text_entry_mode and self.search_input_method == "t9":
             # In T9 mode we simply append the pressed digit
             self.last_key_press_time = current_time
             self.last_key = number
@@ -382,6 +395,17 @@ class UITextEntry(UIModule):
             self.add_char(char)
         else:
             print("didn't find key", number_key)
+
+    def active(self):
+        """Clear any entry typed with a different input method"""
+        if not self.text_entry_mode:
+            if (
+                self.current_text
+                and self.search_input_method != self._text_input_method
+            ):
+                self.current_text = ""
+                self.update_search_results()
+            self._text_input_method = self.search_input_method
 
     def inactive(self):
         """Cancel/invalidate any in-flight searches when screen becomes inactive"""

--- a/python/tests/website/test_web_remote_settings.py
+++ b/python/tests/website/test_web_remote_settings.py
@@ -29,7 +29,7 @@ User Pref submenu (0-indexed):
   1: Sleep Time    (not tested: hardware display)
   2: Menu Anim     (not tested: animation param)
   3: Scroll Speed  (not tested: animation param)
-  4: T9 Search     (not tested: input method)
+  4: Search Input  (not tested: input method)
   5: Az Arrows     (not tested: hardware keypad)
   6: Language      (testable: software language switch)
 


### PR DESCRIPTION
## Summary

Follow-up to the discussion on #458: instead of removing T9, Name Search's two keypad input systems are now presented as a single user choice — **Multi-Tap** (press a key repeatedly to cycle its letters; the default) or **T9** (one press per letter, digits matched against object names). The old **T9 Search** On/Off toggle and its boolean `t9_search` config key are gone.

## Changes

- **Config**: `t9_search` (bool) → `search_input_method` (`"multi_tap"` | `"t9"`, default `"multi_tap"`). No migration: a leftover `t9_search` key is ignored, and former T9 users re-select T9 once in the menu.
- **Menu**: **Settings → User Pref → Search Input** replaces T9 Search *in place* (no sibling index shifts), with options Multi-Tap / T9. The item carries `"label": "search_input_method"` for `jump_to_label`.
- **Quick Menu**: the Name Search screen gains a marking menu — RIGHT: **Input** jumps straight to the Search Input setting (mirrors Object List's RIGHT: Filter convention); UP stays HELP.
- **UITextEntry**: `t9_search_enabled` becomes the `search_input_method` property; both behavior branches compare against `"t9"`. New `active()` hook clears a pending entry when the input method changed while away, since text typed in one system is meaningless to the other.
- **Glossary** (`docs/ax`): `ui/CONTEXT.md` gains a *Text entry* section defining **Name Search**, **search input method**, **multi-tap**, **T9** (as input method), and **free-text mode**, and records **Quick Menu** as the user-facing name for the marking menu. `catalog/CONTEXT.md`'s *text search* / *T9 search* entries now cross-reference the input methods they back.
- **User docs**: `user_guide.rst` and `menu_map.rst` stop calling multi-tap entry "T9-style" (the long-standing misnomer — T9 is the press-once system), document the new setting and the Quick Menu jump, and fix a stale key reference (results open with **RIGHT**, not SQUARE).
- **Tests**: `test_web_remote_settings.py` comment updated; no index changes needed since the menu item was replaced in place. `test_t9_search.py` is untouched — `search_by_t9` and the catalog-side machinery are unchanged.

## Notes

- New UI strings (`Search Input`, `Multi-Tap`, `T9`, `Input`) are wrapped for i18n; the locale catalogs are left for the next periodic `nox -s babel` sync, per convention.
- Closes the question #458 raised; that PR can be closed unmerged.

## Testing

- `pytest -m "smoke or unit"` → **299 passed**.
- `ruff check` / `ruff format` clean; `mypy` reports no errors in the changed modules.
- Sphinx `-n` build of the docs: no warnings.
- Verified end-to-end on a headless run: Search Input menu shows Multi-Tap ✓/T9; Quick Menu RIGHT: Input jumps to the setting and LEFT returns to the search; with T9 active, `7479685` finds Albireo (name translation, not designation match); switching methods clears the pending entry; Multi-Tap still cycles `7` → `a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)