### PR TITLE
fix(solver): clear leaked cedar_detect shmem segment on startup

### DIFF
--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -370,6 +370,12 @@ def main(
     integrator_logqueque: Queue = log_helper.get_queue()
     imu_logqueue: Queue = log_helper.get_queue()
 
+    # Refuse to start if another instance is already running. A second copy
+    # would otherwise boot and let its subsystems (web/pos-server ports, cedar
+    # shmem, hardware devices) silently collide with the live one.
+    if not utils.acquire_single_instance_lock():
+        return
+
     # Start log consolidation process first.
     log_helper.start()
 

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -17,6 +17,7 @@ import sys
 from time import perf_counter as precision_timestamp
 import os
 import threading
+from multiprocessing import shared_memory
 import grpc
 
 from PiFinder import state_utils
@@ -168,6 +169,13 @@ class CedarConnectionError(Exception):
     pass
 
 
+# Must match the hard-coded segment name in
+# tetra3/cedar_detect_client.py:_alloc_shmem(). The segment is unlinked on a
+# clean close(), but a solver process that is killed (or crashes) leaves it in
+# /dev/shm, so the next run's create=True fails with FileExistsError.
+_CEDAR_DETECT_SHMEM_NAME = "/cedar_detect_image"
+
+
 class PFCedarDetectClient(cedar_detect_client.CedarDetectClient):
     def __init__(self, port=50551):
         """Set up the client without spawning the server as we
@@ -183,6 +191,26 @@ class PFCedarDetectClient(cedar_detect_client.CedarDetectClient):
         self._shmem_size = 0
         # Try shared memory, fall back if an error occurs.
         self._use_shmem = True
+        # A killed solver leaves its shmem segment behind; clear any stale one
+        # so this run can re-create it instead of dying on FileExistsError.
+        self._clear_stale_shmem()
+
+    def _clear_stale_shmem(self):
+        """Unlink a leaked cedar_detect_image segment from a prior solver.
+
+        Makes solver restarts self-healing. Safe because PiFinder runs a
+        single solver process, so any existing segment is necessarily stale.
+        """
+        try:
+            stale = shared_memory.SharedMemory(_CEDAR_DETECT_SHMEM_NAME)
+        except FileNotFoundError:
+            return
+        stale.close()
+        stale.unlink()
+        logger.warning(
+            "Cleared stale %s shared memory segment from a prior solver",
+            _CEDAR_DETECT_SHMEM_NAME,
+        )
 
     def _get_stub(self):
         if self._stub is None:

--- a/python/PiFinder/utils.py
+++ b/python/PiFinder/utils.py
@@ -1,8 +1,11 @@
 import os
+import errno
+import fcntl
 import time
 import logging
 import json
 from pathlib import Path
+from typing import Optional
 import importlib
 
 
@@ -24,6 +27,86 @@ def create_dir(adir: str):
 
 def create_path(apath: Path):
     os.makedirs(apath, exist_ok=True)
+
+
+# Held open for the whole process lifetime: the flock lives on this open file
+# description, so the kernel drops it the moment the process exits.
+_instance_lock_file = None
+
+
+def runtime_lock_dir() -> Optional[Path]:
+    """RAM-backed dir for the single-instance lock, or None if none exists.
+
+    Prefer /dev/shm (tmpfs on Linux/Raspberry Pi OS, already used for the cedar
+    image buffer) so the lock never wears the SD card and is cleared on reboot.
+    We deliberately do NOT fall back to the SD-card data dir: if no writable
+    tmpfs is available we skip locking entirely (see
+    :func:`acquire_single_instance_lock`) rather than wear the card.
+    """
+    shm = Path("/dev/shm")
+    if shm.is_dir() and os.access(shm, os.W_OK):
+        return shm
+    return None
+
+
+def acquire_single_instance_lock(
+    lock_name: str = "pifinder.lock", lock_dir: Optional[Path] = None
+) -> bool:
+    """Best-effort guard so only one PiFinder runs at a time.
+
+    Uses an advisory ``fcntl.flock`` on a tmpfs lock file (see
+    :func:`runtime_lock_dir`), so it costs no SD-card writes. The kernel
+    releases the lock when this process exits for ANY reason — clean shutdown,
+    crash, ``kill -9``, or power loss — so an unclean stop never leaves a stale
+    lock that blocks the next boot. A leftover lock *file* is harmless; only a
+    live lock-holder blocks.
+
+    The guard fails OPEN: it returns False (caller should not start) ONLY when
+    another instance is confirmed to be holding the lock. Anything that breaks
+    the locking mechanism itself — no tmpfs, an unopenable file, flock
+    unsupported on the filesystem — is logged and treated as success, so a
+    missing lock can never stop PiFinder from starting.
+    """
+    global _instance_lock_file
+    log = logging.getLogger("utils")
+    if lock_dir is None:
+        lock_dir = runtime_lock_dir()
+    if lock_dir is None:
+        log.warning("No tmpfs lock dir available; starting without instance lock.")
+        return True
+
+    try:
+        lock_file = open(lock_dir / lock_name, "a+")
+    except OSError as e:
+        log.warning("Could not open instance lock (%s); starting without it.", e)
+        return True
+
+    try:
+        fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as e:
+        if e.errno in (errno.EWOULDBLOCK, errno.EAGAIN):
+            # Held by a live process -> a genuine second instance.
+            lock_file.seek(0)
+            holder = lock_file.read().strip() or "unknown"
+            lock_file.close()
+            log.error(
+                "Another PiFinder instance is already running (pid %s); not starting.",
+                holder,
+            )
+            return False
+        # Any other error means the lock mechanism is unavailable, not that a
+        # duplicate is running -> fail open so startup is never hindered.
+        log.warning("Instance lock unavailable (%s); starting without it.", e)
+        lock_file.close()
+        return True
+
+    # Record our pid so a later blocked instance can name the holder.
+    lock_file.seek(0)
+    lock_file.truncate(0)
+    lock_file.write(f"{os.getpid()}\n")
+    lock_file.flush()
+    _instance_lock_file = lock_file
+    return True
 
 
 def serialize_solution(solution) -> str:

--- a/python/tests/test_single_instance.py
+++ b/python/tests/test_single_instance.py
@@ -1,0 +1,82 @@
+"""Single-instance lock tests.
+
+Verifies the flock-based guard: a second acquirer is refused, and — crucially
+for field use — a lock left behind by a dead holder does NOT block a fresh
+start (the kernel released it when the holder's fd closed). Tests pass an
+isolated lock_dir so they never touch the real tmpfs lock.
+"""
+
+import errno
+import fcntl
+import os
+from pathlib import Path
+
+import pytest
+
+from PiFinder import utils
+
+
+@pytest.mark.unit
+def test_second_acquire_is_refused(tmp_path, monkeypatch):
+    monkeypatch.setattr(utils, "_instance_lock_file", None)
+
+    assert utils.acquire_single_instance_lock(lock_dir=tmp_path) is True
+    # A second acquisition uses a fresh fd, exactly like another process would,
+    # and flock denies it while the first holder is alive.
+    assert utils.acquire_single_instance_lock(lock_dir=tmp_path) is False
+    # The lock file records the holder pid for diagnostics.
+    assert (tmp_path / "pifinder.lock").read_text().strip().isdigit()
+
+
+@pytest.mark.unit
+def test_stale_lock_file_does_not_block(tmp_path, monkeypatch):
+    monkeypatch.setattr(utils, "_instance_lock_file", None)
+
+    # Simulate a crashed run: a lock file with a dead pid and NO live flock.
+    (tmp_path / "pifinder.lock").write_text("999999\n")
+
+    # A fresh start must acquire cleanly — a leftover file alone never blocks.
+    assert utils.acquire_single_instance_lock(lock_dir=tmp_path) is True
+
+
+@pytest.mark.unit
+def test_lock_released_when_holder_fd_closes(tmp_path, monkeypatch):
+    lock_path = tmp_path / "pifinder.lock"
+
+    # Hold the lock on an independent fd, then close it (mimics a process dying).
+    holder = open(lock_path, "a+")
+    fcntl.flock(holder, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    holder.close()
+
+    monkeypatch.setattr(utils, "_instance_lock_file", None)
+    assert utils.acquire_single_instance_lock(lock_dir=tmp_path) is True
+
+
+@pytest.mark.unit
+def test_runtime_lock_dir_prefers_tmpfs_or_none():
+    # RAM-backed /dev/shm when available, else None (never the SD-card data dir).
+    d = utils.runtime_lock_dir()
+    shm = Path("/dev/shm")
+    if shm.is_dir() and os.access(shm, os.W_OK):
+        assert d == shm
+    else:
+        assert d is None
+
+
+@pytest.mark.unit
+def test_no_lock_dir_fails_open(monkeypatch):
+    # No tmpfs available -> skip locking, never block startup.
+    monkeypatch.setattr(utils, "runtime_lock_dir", lambda: None)
+    monkeypatch.setattr(utils, "_instance_lock_file", None)
+    assert utils.acquire_single_instance_lock() is True
+
+
+@pytest.mark.unit
+def test_flock_mechanism_error_fails_open(tmp_path, monkeypatch):
+    # A flock failure that is NOT "already locked" must not block startup.
+    def boom(*_args, **_kwargs):
+        raise OSError(errno.ENOLCK, "no locks available")
+
+    monkeypatch.setattr(fcntl, "flock", boom)
+    monkeypatch.setattr(utils, "_instance_lock_file", None)
+    assert utils.acquire_single_instance_lock(lock_dir=tmp_path) is True

--- a/python/tests/test_solver_shmem.py
+++ b/python/tests/test_solver_shmem.py
@@ -1,0 +1,40 @@
+"""Regression test for stale cedar_detect shared-memory cleanup.
+
+A solver process that is killed leaks its POSIX shmem segment; the next
+PFCedarDetectClient must clear it at startup instead of dying on
+FileExistsError on every solve.
+"""
+
+from multiprocessing import shared_memory
+
+import pytest
+
+import PiFinder.solver as solver_mod
+from PiFinder.solver import PFCedarDetectClient
+
+
+@pytest.mark.unit
+def test_clear_stale_shmem_unlinks_leaked_segment(monkeypatch):
+    # Unique name so the test never touches a real/live cedar_detect_image.
+    name = "/cedar_detect_image_pftest"
+    monkeypatch.setattr(solver_mod, "_CEDAR_DETECT_SHMEM_NAME", name)
+
+    # Simulate a leak: created but never unlinked, as a killed solver leaves it.
+    leaked = shared_memory.SharedMemory(name, create=True, size=16)
+    leaked.close()
+
+    client = object.__new__(PFCedarDetectClient)
+    client._shmem = None  # __del__ inspects this attribute
+    try:
+        client._clear_stale_shmem()
+        with pytest.raises(FileNotFoundError):
+            shared_memory.SharedMemory(name)
+        # Idempotent: clearing again when nothing is present must not raise.
+        client._clear_stale_shmem()
+    finally:
+        try:
+            stray = shared_memory.SharedMemory(name)
+            stray.close()
+            stray.unlink()
+        except FileNotFoundError:
+            pass


### PR DESCRIPTION
A solver process that is killed (or crashes) never runs the cedar client's close(), leaving the POSIX shared-memory segment /cedar_detect_image in /dev/shm. The next run's _alloc_shmem() then calls SharedMemory(create=True) on the same name and dies with FileExistsError on every solve, so plate solving never recovers until the segment is removed by hand.

PFCedarDetectClient now unlinks any pre-existing segment when constructed, making solver restarts self-healing. Safe because PiFinder runs a single solver process, so any existing segment is necessarily stale.

==> I've seen this mysterious error on various dev runs and 'in-the-field', and if it happens in the field your session is over. Seems like a safe fix.