### PR TITLE
docs: reorganize user guide; split out Connecting to Your PiFinder (review §6)

### DIFF
--- a/.claude/skills/docs/SKILL.md
+++ b/.claude/skills/docs/SKILL.md
@@ -38,14 +38,28 @@ The page set (registered in `docs/source/index.rst`):
 | File | Covers |
 |------|--------|
 | `quick_start.rst` | First-night, get-observing walkthrough |
-| `user_guide.rst` | Full reference for every menu, screen, and setting |
+| `user_guide.rst` | Workflow reference for operating & observing — the printable core; defers enumeration to `menu_map`, deep topics to satellite pages |
+| `menu_map.rst` | Every menu item in the tree, one entry each |
+| `equipment.rst` | Telescopes & eyepieces: gear setup, magnification/TFOV, flip/flop |
 | `catalogs.rst` | Object catalogs included |
+| `connectivity.rst` | Reaching the device from another device: WiFi modes, web interface, SMB share |
+| `skysafari.rst` | SkySafari / planetarium integration |
+| `troubleshooting.rst` | Symptom-led fixes and FAQ |
 | `build_guide.rst` | Assembling the hardware |
 | `v25_upgrade.rst` | Upgrading a v2 unit |
 | `software.rst` | Flashing / updating the software image |
-| `skysafari.rst` | SkySafari / planetarium integration |
+| `sd_card.rst` | Swapping / re-imaging the SD card |
 | `dev_guide.rst`, `dev_arch.rst` | Contributor / architecture docs |
+| `api.rst` | HTTP API reference |
 | `BOM.rst` | Bill of materials |
+
+**Section in `user_guide` vs standalone page** — a topic earns its own page only
+when readers *arrive at it directly* with a task in hand (search, a Discord
+answer, a cross-page link) **and** it is *separable* from the guide's
+operate-and-observe storyline (a sentence + link suffices in its place).
+Otherwise it's a `user_guide` section. Standalone page URLs get linked from the
+wild — don't merge or rename pages casually. Rationale and worked examples:
+`docs/adr/0010-user-docs-page-granularity.md`.
 
 **Before writing a single line, read the page you're about to touch (or the
 closest sibling).** The fastest way to match the house style is to mirror the

--- a/docs/adr/0010-user-docs-page-granularity.md
+++ b/docs/adr/0010-user-docs-page-granularity.md
@@ -1,0 +1,22 @@
+# User docs page granularity: arrival + separability
+
+The user-facing doc set (`docs/source/`, the "Using your PiFinder" toctree group) needs a rule for whether a topic lives as a **section inside `user_guide.rst`** or as a **standalone page**. The historical split was accidental — `equipment` and `skysafari` were standalone while WiFi/Web Interface/Shared Data sat inside the user guide — and every reorganization re-litigated it. Decision: a topic gets a standalone page when **both** hold:
+
+1. **Direct arrival** — readers land on it with a task in hand (from search, a Discord answer, or a cross-page link) rather than encountering it by reading the guide through. "How do I connect SkySafari?", "why is the image flipped?", "what catalogs are included?" are arrival questions.
+2. **Separability** — cutting it leaves no gap in the user guide's operate-and-observe storyline; a one-sentence summary plus a link suffices in its place.
+
+Everything else stays in `user_guide.rst`, whose charter is correspondingly narrowed: it is the **workflow reference** for operating and observing with the device — deeper than the Quick Start, deliberately not exhaustive (per-item enumeration belongs to `menu_map`), and **printable**: someone who prints only the user guide should get through a night of observing, so field-critical facts (power, shutdown, the WiFi-mode switch, `pifinder.local`) must at least be summarized there even when their full treatment lives elsewhere.
+
+Applying the rule (June 2026): `equipment`, `skysafari`, `catalogs`, `menu_map`, `troubleshooting` stay standalone — each passes both tests. The connectivity block (WiFi modes, PiFinder address, Web Interface, Shared Data Access) **moves out** of the user guide into `connectivity.rst` ("Connecting to Your PiFinder"); the guide keeps a short Connectivity at-a-glance. `Power & Charging` and `Update Software` stay in-guide — both fail separability (core to operating; the update runs from the on-device Tools menu).
+
+## Considered Options
+
+- **Fold `equipment` and `skysafari` into the user guide** (the consolidation instinct that prompted this ADR). Rejected: both pass the arrival test, the merged guide would grow past 7k words against its printable-workflow charter, and `equipment.html` / `skysafari.html` URLs have been pasted into Discord answers for years — merging breaks them unless Read the Docs redirects are added and maintained.
+- **External-boundary rule** ("standalone = the PiFinder's relationship to things outside itself"). Rejected: it splits the connectivity story mid-topic — the Web Interface is the device's own feature and would stay in-guide while SkySafari leaves, though both serve the same "reach the device from my phone" moment.
+- **Content-type rule** (workflows in-guide; lookups and recipes standalone). Rejected: it cuts pages in half instead of placing them — `equipment`'s conceptual halves (magnification, flip/flop) would land in-guide while its CRUD steps went standalone.
+
+## Consequences
+
+- Standalone page URLs are treated as stable, linked-from-the-wild artifacts; merging a standalone page back into the guide carries a redirect cost and should be a deliberate, ADR-revising act.
+- Moving a *section* between pages changes its anchor (`user_guide.html#wifi` → `connectivity.html#...`); old deep links degrade to page-top loads. Acceptable for sections, which is why the rule is applied at page grain.
+- The docs skill's page table (`.claude/skills/docs/SKILL.md`) carries the operational one-liner of this rule and the per-page charters; keep the two in sync.

--- a/docs/ax/positioning/CONTEXT.md
+++ b/docs/ax/positioning/CONTEXT.md
@@ -172,7 +172,7 @@ Deadband (0.06° ≈ 1.05 mrad) below which IMU motion is treated as noise and n
 _Avoid_: jitter threshold, IMU noise.
 
 **Screen direction** (`screen_direction`):
-Configuration field that tells `ImuDeadReckoning` how the display/IMU is physically mounted relative to the optical axis. Used to bake in axis conventions on initialisation.
+Configuration field that tells `ImuDeadReckoning` how the display/IMU is physically mounted relative to the optical axis. Used to bake in axis conventions on initialisation. Surfaced to users as the **PiFinder Type** setting (Settings → Advanced); the user docs call the physical build variants *configurations* (Left/Right/Straight/Flat). The setting's value list is wider than any one product generation — it includes legacy variants (Flat v2, AS Bloom) — so user docs must scope claims like "there are N configurations" to a generation (DIY v2.5 builds: Left/Right/Flat; assembled v3 units: Left/Right/Straight/Flat).
 _Avoid_: orientation, mount direction.
 
 ### Alignment

--- a/docs/source/connectivity.rst
+++ b/docs/source/connectivity.rst
@@ -1,0 +1,123 @@
+===========================
+Connecting to Your PiFinder
+===========================
+
+The PiFinder doesn't need another device to do its job, but connecting your phone, tablet,
+or computer opens up a lot: a web interface for remote control and configuration,
+planetarium apps that follow your telescope, and direct access to your logged observations
+and images.  This page covers how the PiFinder's WiFi works and each way to connect.
+
+WiFi
+==========================
+
+Access Point and Client Mode
+----------------------------------
+
+The PiFinder can connect to an existing network in Client mode, or serve as a wireless
+access point for other devices in Access Point (AP) mode.  Use the
+:ref:`connectivity:web interface` or the :ref:`user_guide:status screen` to switch between
+the two modes and see which is active.
+
+In Access Point mode the PiFinder creates a network called PiFinderAP with no password, for
+easy connection of phones, tablets, and other devices in the field.
+
+To use Client mode, add the WiFi network you'd like the PiFinder to connect to using the
+Web Interface, as described in :ref:`connectivity:connecting to a new wifi network`
+
+PiFinder address
+-----------------
+
+In most cases you can reach the PiFinder at ``pifinder.local``.  On older computers, or
+those without zeroconf networking, use the IP address shown on the
+:ref:`Status<user_guide:status screen>` screen.  You can connect via:
+
+
+* A web browser, for the :ref:`connectivity:web interface` — remote control, WiFi setup, and configuration changes
+* SSH, for shell access (advanced users)
+* SMB (Samba), to access saved images, logs, and observing lists
+* LX200 protocol, to update a planetarium app such as :doc:`skysafari` with the telescope's position
+
+Web Interface
+==============
+
+The PiFinder's web interface lets you:
+
+* See the current PiFinder status
+* Remote control the PiFinder via a virtual screen and keypad
+* Change network settings and connect to new WiFi networks
+* Add and edit your telescopes and eyepieces (see :doc:`equipment`)
+* Back up and restore your observing logs, settings, and other data
+* View and download your logged observations
+
+To reach the web interface for the first time, make sure the PiFinder is in Access Point mode (see :ref:`user_guide:settings menu`) — the default for new PiFinders, to ease first-time setup.  From a phone, tablet, or computer, connect to the PiFinder's open wireless network, PiFinderAP (no password), then open your browser and visit:
+``http://pifinder.local``
+
+
+.. note::
+   If you're connected to the PiFinderAP network and can't load the web interface at
+   http://pifinder.local, try http://10.10.10.1 — some systems don't support the network
+   features needed to resolve local computer names.
+
+.. list-table::
+   :width: 100%
+
+   * - .. image:: images/user_guide/pf_web_home_fullnav.jpg
+
+     - .. image:: images/user_guide/pf_web_home_hamburger.jpg
+
+The home screen shows general PiFinder status and a live view of the screen.  Depending on
+your screen size you'll see either a navigation bar along the top or a 'hamburger' menu in
+the upper-left holding the same options on smaller screens.
+
+The home screen needs no password, but most other functions do.  The web interface password
+is the same as the ``pifinder`` user's; changing one changes the other.  The default for new
+images and PiFinders is ``solveit``, and you can change it from the Tools option in the web
+interface.
+
+Connecting to a new WiFi network
+---------------------------------
+
+By default the PiFinder generates its own WiFi network, ``PiFinderAP``, that you connect to
+in order to configure additional networks.  To have the PiFinder connect to an existing
+WiFi network with Internet access, follow these steps:
+
+1) Make sure the PiFinder is in Access Point mode
+2) Connect your phone, tablet, or computer to the PiFinder's wifi network called PiFinderAP
+3) Visit http://pifinder.local using your web browser
+4) Click the 'Network' link in the top bar, or on a smaller screen click the three stacked horizontal lines in the upper-right corner and choose 'Network'.
+    .. image:: images/user_guide/pf_web_net0.png
+5) When prompted, enter the password for your PiFinder.  The default is `solveit`.
+6) Scroll down to the 'Wifi Networks' section and click the + button to add a network
+    .. image:: images/user_guide/pf_web_net1.jpg
+7) Enter the name (SSID) and password of your network.  If your network has no password, leave the Password field blank.
+8) Click the 'SAVE' button to save the new network
+9)  The network you added should now appear in the 'Wifi Networks' section
+10) Scroll up and change the Wifi mode from 'Access Point' to 'Client' so the PiFinder connects to your network on its next restart
+11) Click the 'UPDATE AND RESTART' button
+
+To add more WiFi networks, navigate to the Network Setup page of the :ref:`connectivity:web interface`, click the + button near the WiFi networks list, and repeat the steps above.
+
+SkySafari and Planetarium Apps
+==============================
+
+The PiFinder can provide real-time pointing information to SkySafari and other planetarium
+apps via the LX200 protocol, and accept targets they send back.  The :doc:`skysafari` page
+has the connection settings and walks through the setup step by step.
+
+Shared Data Access
+===================
+
+The PiFinder creates several data files you may want.  They're available via an SMB (samba)
+network share, ``//pifinder.local/shared``.  Access depends on your OS, but the PiFinder
+should appear in a network browser.  No password is required — connect as ``guest`` with no
+password.
+
+Once connected, you'll see:
+
+
+* ``captures/``\ : Images saved when logging objects, named with the observation ID from the database.
+* ``obslists/``\ : Observing lists saved during a session or kept for future sessions.
+* ``screenshots/``\ : Screenshots taken while using the PiFinder (hold **SQUARE** and
+  press **0**) are stored here.
+* ``solver_debug_dumps/``\ : If enabled, solver performance information is stored here as a collection of images and json files.
+* ``observations.db``\ : The SQLite database holding all logged observations.

--- a/docs/source/equipment.rst
+++ b/docs/source/equipment.rst
@@ -8,7 +8,7 @@ pairing, sizes and orients the survey images on the
 :ref:`user_guide:object details` screen to match the eyepiece view, and lets
 the push-to arrows follow the way your setup moves.
 
-You manage equipment from two places: the :ref:`user_guide:web interface` is
+You manage equipment from two places: the :ref:`connectivity:web interface` is
 where you add and edit telescopes and eyepieces, and the Equipment screen on the
 PiFinder is where you pick which ones are active for tonight's session.
 
@@ -27,7 +27,7 @@ Store as many of each as you like and switch between them as the night goes on.
 Adding and editing your gear
 ----------------------------
 
-Add telescopes and eyepieces through the :ref:`user_guide:web interface`.
+Add telescopes and eyepieces through the :ref:`connectivity:web interface`.
 Connect to the PiFinder as described there, then open the Equipment page from
 the navigation menu. You'll find a list of telescopes and a list of eyepieces,
 each with buttons to add, edit, or remove an item.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,6 +72,7 @@ Join the `PiFinder Discord server <https://discord.gg/Nk5fHcAtWD>`_ for support 
    menu_map
    equipment
    catalogs
+   connectivity
    skysafari
    troubleshooting
 

--- a/docs/source/menu_map.rst
+++ b/docs/source/menu_map.rst
@@ -224,7 +224,7 @@ Camera Exp
    exposures catch fainter stars but blur sooner as the scope moves.
 WiFi Mode
    Switch between Client Mode (join an existing network) and AP Mode (the
-   PiFinder serves its own PiFinderAP network).  See :ref:`user_guide:wifi`.
+   PiFinder serves its own PiFinderAP network).  See :ref:`connectivity:wifi`.
 Mount Type
    Tell the PiFinder whether your scope is Alt/Az or Equatorial.  Changing this
    restarts the PiFinder.

--- a/docs/source/skysafari.rst
+++ b/docs/source/skysafari.rst
@@ -6,7 +6,7 @@ SkySafari
 Network Setup
 -------------
 
-First, make sure your device is on the same network as the PiFinder.  See the :ref:`User Guide<user_guide:wifi>` for changing WiFi modes and finding the PiFinder's IP address.
+First, make sure your device is on the same network as the PiFinder.  See :doc:`connectivity` for changing WiFi modes and finding the PiFinder's IP address.
 
 App Setup
 ---------

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -56,7 +56,7 @@ If the screen is still blank, the keypad backlight tells you where the problem i
   jump.
 - **Keypad lights up, but the screen is blank or garbled**: that points to the screen's
   connection, not the software.  Confirm it through the
-  :ref:`web interface <user_guide:web interface>` — if the remote screen looks correct
+  :ref:`web interface <connectivity:web interface>` — if the remote screen looks correct
   there, the software is fine and the physical screen connection needs attention (a solder
   reflow on DIY builds).
 
@@ -189,7 +189,7 @@ Frequently Asked Questions
 
 **Where are my saved observations and images?**
    On the PiFinder's network share, reachable at ``//pifinder.local/shared`` (connect as
-   guest, no password).  See :ref:`user_guide:shared data access`.
+   guest, no password).  See :ref:`connectivity:shared data access`.
 
 **Can I connect SkySafari?**
    Yes — the PiFinder talks to SkySafari and other planetarium apps over WiFi.  See the

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -1,4 +1,3 @@
-
 ======================
 PiFinder™ User Manual
 ======================
@@ -43,137 +42,6 @@ you're on target.
 .. note::
    For a general overview of using the PiFinder, read the :doc:`quick_start`.  This manual
    goes deeper but doesn't cover the first-time set-up steps in the Quick Start.
-
-
-Power & Charging
-=====================================
-
-PiFinders ordered with the optional internal battery run for an evening on a single
-charge, and you can keep one going indefinitely from any USB-C power source.  This section
-covers how the two USB-C ports differ, how charging behaves, how long a charge lasts, and
-how to look after the battery.  For the very first power-on, the
-:ref:`quick_start:powering the pifinder` section of the Quick Start walks through it step
-by step.
-
-The two USB-C ports
--------------------
-
-A battery-equipped PiFinder has two USB-C ports on top, and they do different things:
-
-.. image:: images/quick_start/power.jpeg
-
-- The port nearest the **back** of the case (marked with the arrow above) both powers the
-  PiFinder **and** charges the battery.  Use this one for charging.
-- The port nearest the **keypad** powers the unit only — it does not charge the battery.
-  It is also wired ahead of the power switch, so plugging into it turns the PiFinder on
-  immediately *regardless of the switch position*.
-
-During a session the keypad-side (power-only) port is the nicer one to run from, because
-the charging port's indicator LED is quite bright in the dark.  A unit without the battery
-has only the single power-only port.
-
-The power switch is the small white **slide** switch on top, above the screen (boxed in
-the image above).  Facing the screen, slide it right for on and left for off.  It is a
-switch, not a button.
-
-Charging
---------
-
-Plug a USB-C cable into the charging port (nearest the back).  The indicator LED glows
-**blue** while charging and turns **green** when full.  From empty, a full charge takes
-roughly three hours, though this varies with the power source — a Power Delivery (PD)
-charger negotiates more power and fills faster, while a basic 5V supply charges more
-slowly but works fine.
-
-Charge with the power switch **off**.  If the PiFinder runs while plugged in, it can draw
-about as much current as the charger supplies, so the battery may barely fill.  A long
-charge that leaves the battery still flat almost always means the unit was switched on the
-whole time.
-
-.. note::
-   The last stretch of charging is slow.  As the battery approaches full the charging
-   current tapers off, so the change from blue to green can take a while even though the
-   battery is nearly there.  This is normal and not a fault.
-
-Battery life
-------------
-
-The battery runs the PiFinder for about **four to five hours**, but real runtime depends
-heavily on how hard you work it.  Sitting at the eyepiece on one object, or stepping away
-from the scope, lets the PiFinder drop into power-save mode and stretches the time
-considerably.  A fast tour through many objects — camera, motion sensor, and screen all
-busy — draws more power and shortens it.  Turning the brightness down helps too: hold
-**SQUARE** and press **+** or **-** to adjust the screen and keypad at any time.
-
-There is **no battery-level indicator** on the screen and no low-battery warning: when the
-charge is depleted the PiFinder simply shuts off.  For a long night, top up beforehand and
-keep a USB-C power bank handy.  You can add external power at any time without restarting
-(see below).
-
-.. note::
-   The PiFinder drops into power-save mode after it has been idle for a while, dimming the
-   screen and slowing the camera to save power.  Any button press or movement of the scope
-   wakes it.  The idle time can be changed, or turned off entirely, in the
-   :ref:`user_guide:settings menu`.
-
-Running on external power
--------------------------
-
-Any USB-C source rated for at least **2A** will run the PiFinder — a wall charger, a USB
-power bank, or a portable power station's USB output.  As a rough guide, about 1,000mAh of
-power-bank capacity runs the PiFinder for an hour, so a 10,000mAh bank is good for the
-better part of a night.
-
-External power can be added mid-session without a restart.  A useful trick for stretching
-a long night: plug a power bank into the power-only port, then switch the battery **off**.
-The PiFinder keeps running on the external power while the battery is held in reserve for
-after the bank is unplugged.
-
-If you hit power dropouts, suspect the cable first — some USB-C cables are unreliable at
-the ~2A the PiFinder draws, especially on long runs.
-
-.. warning::
-   Feed the PiFinder **5V USB-C power only**.  To run it from a telescope's 12V supply, you
-   must use a 12V-to-5V step-down (DC-DC) converter with a USB-C output.  Never connect 12V
-   directly to the PiFinder — doing so will damage it.
-
-Battery safety & care
----------------------
-
-The internal battery is a lithium-polymer (LiPo) cell.  Treated sensibly it will last for
-years, but like any lithium battery it deserves a little respect.
-
-.. warning::
-   Stop using the battery and disconnect power if it ever becomes **swollen, damaged,
-   unusually hot, or develops an odour**.  A puffed-up or punctured LiPo cell can vent or
-   catch fire.  Do not continue to charge or use a cell in this condition — contact us about
-   a replacement.
-
-.. warning::
-   Do not **puncture, crush, drop, or open** the battery, and do not attempt to disassemble
-   the PiSugar power board it sits on.  Keep the unit dry; the battery and electronics are
-   not waterproof.
-
-A few habits keep the cell healthy:
-
-- **Charge from the built-in port only.**  The PiSugar power board manages charging for you;
-  just supply 5V USB-C as described above.  There is no need for an external LiPo charger,
-  and you should not connect one.
-- **Charge where you can keep an eye on it,** and not on or near anything flammable.  Avoid
-  charging or leaving the unit in extreme heat — a closed car on a sunny day is the classic
-  way to cook a battery.
-- **Mind the temperature.**  The PiFinder has been used from about -15°C (5°F) to 40°C
-  (100°F).  Capacity drops in the cold, though the computer's own heat keeps the cell warm
-  enough to work in most conditions.  Avoid charging a battery that is below freezing.
-- **For long-term storage,** leave the cell partly charged rather than full or empty and keep
-  it somewhere cool and dry.  Top it up every few months so it does not discharge completely.
-- **Dispose of it responsibly.**  A worn-out lithium battery should go to a battery-recycling
-  drop-off, not the household rubbish.
-
-.. note::
-   If you ever need to replace the battery, the only compatible part is the **PiSugar S Plus
-   5000mAh**.  Other PiSugar models share the I2C bus with the PiFinder's motion sensor and
-   will cause problems, so make sure you fit the S Plus.
 
 The Menu System
 =====================================
@@ -239,7 +107,7 @@ With this simple set of scroll-and-select tools you can reach all the PiFinder's
 features.
 
 Quick Menu
-=====================================
+-------------------------------------
 
 You can reach everything through the menu system, but a secondary quick-menu brings some
 functions into easier reach.
@@ -264,9 +132,8 @@ marking the current one.
 
 Pick a sort order to apply it.  Exit the Quick Menu at any time by pressing SQUARE again.
 
-
 Help System
-==============
+--------------
 
 Many screens offer help with specific button functions and other details about how things
 work or what a page is for.
@@ -281,31 +148,6 @@ through them.
 
 .. image:: images/user_guide/camera_help_01.png
 .. image:: images/user_guide/camera_help_02.png
-
-
-Settings Menu
-==============
-
-All user-configurable items live in the Settings Menu, near the bottom of the main
-PiFinder menu.
-
-.. image:: images/user_guide/settings_01.png
-
-The top items collect several options under User Preferences and Chart Screen.  An ellipsis
-(...) indicates more options below.
-
-.. image:: images/user_guide/settings_02.png
-
-Below the general UI options are settings to change which :ref:`user_guide:wifi` mode your
-PiFinder is in and its physical configuration.
-
-.. image:: images/user_guide/settings_03.png
-
-Hardware setup that's normally configured once — PiFinder Type, Camera Type, and GPS
-Settings (type and baud rate) — lives under the Advanced submenu near the bottom of the
-Settings Menu.  Opening it shows a brief "Options for DIY PiFinders" reminder, since on a
-fully built unit these are already set to match your hardware.
-
 
 Observing with PiFinder
 ========================
@@ -572,7 +414,7 @@ using, pointing at a specific area of sky from your current location.  By defaul
 oriented for a Newtonian reflector; if you use a refractor or an SCT with a star diagonal,
 set the orientation options for your telescope as described in :doc:`equipment`.  Use the
 **+** and **-** keys to switch between the fields of view of the eyepieces you configured
-via the :ref:`user_guide:Web Interface`
+via the :ref:`Web Interface <connectivity:web interface>`
 
 The bottom left of the screen shows the source of the current image, and the left side
 shows the current FOV information.
@@ -617,6 +459,169 @@ any session.
 Combining a :ref:`filter<user_guide:filters>` on observation status with an object list
 sorted by NEAREST lets you work through a collection easily.
 
+Power & Charging
+=====================================
+
+PiFinders ordered with the optional internal battery run for an evening on a single
+charge, and you can keep one going indefinitely from any USB-C power source.  This section
+covers how the two USB-C ports differ, how charging behaves, how long a charge lasts, and
+how to look after the battery.  For the very first power-on, the
+:ref:`quick_start:powering the pifinder` section of the Quick Start walks through it step
+by step.
+
+The two USB-C ports
+-------------------
+
+A battery-equipped PiFinder has two USB-C ports on top, and they do different things:
+
+.. image:: images/quick_start/power.jpeg
+
+- The port nearest the **back** of the case (marked with the arrow above) both powers the
+  PiFinder **and** charges the battery.  Use this one for charging.
+- The port nearest the **keypad** powers the unit only — it does not charge the battery.
+  It is also wired ahead of the power switch, so plugging into it turns the PiFinder on
+  immediately *regardless of the switch position*.
+
+During a session the keypad-side (power-only) port is the nicer one to run from, because
+the charging port's indicator LED is quite bright in the dark.  A unit without the battery
+has only the single power-only port.
+
+The power switch is the small white **slide** switch on top, above the screen (boxed in
+the image above).  Facing the screen, slide it right for on and left for off.  It is a
+switch, not a button.
+
+Charging
+--------
+
+Plug a USB-C cable into the charging port (nearest the back).  The indicator LED glows
+**blue** while charging and turns **green** when full.  From empty, a full charge takes
+roughly three hours, though this varies with the power source — a Power Delivery (PD)
+charger negotiates more power and fills faster, while a basic 5V supply charges more
+slowly but works fine.
+
+Charge with the power switch **off**.  If the PiFinder runs while plugged in, it can draw
+about as much current as the charger supplies, so the battery may barely fill.  A long
+charge that leaves the battery still flat almost always means the unit was switched on the
+whole time.
+
+.. note::
+   The last stretch of charging is slow.  As the battery approaches full the charging
+   current tapers off, so the change from blue to green can take a while even though the
+   battery is nearly there.  This is normal and not a fault.
+
+Battery life
+------------
+
+The battery runs the PiFinder for about **four to five hours**, but real runtime depends
+heavily on how hard you work it.  Sitting at the eyepiece on one object, or stepping away
+from the scope, lets the PiFinder drop into power-save mode and stretches the time
+considerably.  A fast tour through many objects — camera, motion sensor, and screen all
+busy — draws more power and shortens it.  Turning the brightness down helps too: hold
+**SQUARE** and press **+** or **-** to adjust the screen and keypad at any time.
+
+There is **no battery-level indicator** on the screen and no low-battery warning: when the
+charge is depleted the PiFinder simply shuts off.  For a long night, top up beforehand and
+keep a USB-C power bank handy.  You can add external power at any time without restarting
+(see below).
+
+.. note::
+   The PiFinder drops into power-save mode after it has been idle for a while, dimming the
+   screen and slowing the camera to save power.  Any button press or movement of the scope
+   wakes it.  The idle time can be changed, or turned off entirely, in the
+   :ref:`user_guide:settings menu`.
+
+Running on external power
+-------------------------
+
+Any USB-C source rated for at least **2A** will run the PiFinder — a wall charger, a USB
+power bank, or a portable power station's USB output.  As a rough guide, about 1,000mAh of
+power-bank capacity runs the PiFinder for an hour, so a 10,000mAh bank is good for the
+better part of a night.
+
+External power can be added mid-session without a restart.  A useful trick for stretching
+a long night: plug a power bank into the power-only port, then switch the battery **off**.
+The PiFinder keeps running on the external power while the battery is held in reserve for
+after the bank is unplugged.
+
+If you hit power dropouts, suspect the cable first — some USB-C cables are unreliable at
+the ~2A the PiFinder draws, especially on long runs.
+
+.. warning::
+   Feed the PiFinder **5V USB-C power only**.  To run it from a telescope's 12V supply, you
+   must use a 12V-to-5V step-down (DC-DC) converter with a USB-C output.  Never connect 12V
+   directly to the PiFinder — doing so will damage it.
+
+Battery safety & care
+---------------------
+
+The internal battery is a lithium-polymer (LiPo) cell.  Treated sensibly it will last for
+years, but like any lithium battery it deserves a little respect.
+
+.. warning::
+   Stop using the battery and disconnect power if it ever becomes **swollen, damaged,
+   unusually hot, or develops an odour**.  A puffed-up or punctured LiPo cell can vent or
+   catch fire.  Do not continue to charge or use a cell in this condition — contact us about
+   a replacement.
+
+.. warning::
+   Do not **puncture, crush, drop, or open** the battery, and do not attempt to disassemble
+   the PiSugar power board it sits on.  Keep the unit dry; the battery and electronics are
+   not waterproof.
+
+A few habits keep the cell healthy:
+
+- **Charge from the built-in port only.**  The PiSugar power board manages charging for you;
+  just supply 5V USB-C as described above.  There is no need for an external LiPo charger,
+  and you should not connect one.
+- **Charge where you can keep an eye on it,** and not on or near anything flammable.  Avoid
+  charging or leaving the unit in extreme heat — a closed car on a sunny day is the classic
+  way to cook a battery.
+- **Mind the temperature.**  The PiFinder has been used from about -15°C (5°F) to 40°C
+  (100°F).  Capacity drops in the cold, though the computer's own heat keeps the cell warm
+  enough to work in most conditions.  Avoid charging a battery that is below freezing.
+- **For long-term storage,** leave the cell partly charged rather than full or empty and keep
+  it somewhere cool and dry.  Top it up every few months so it does not discharge completely.
+- **Dispose of it responsibly.**  A worn-out lithium battery should go to a battery-recycling
+  drop-off, not the household rubbish.
+
+.. note::
+   If you ever need to replace the battery, the only compatible part is the **PiSugar S Plus
+   5000mAh**.  Other PiSugar models share the I2C bus with the PiFinder's motion sensor and
+   will cause problems, so make sure you fit the S Plus.
+
+Settings Menu
+==============
+
+All user-configurable items live in the Settings Menu, near the bottom of the main
+PiFinder menu.
+
+.. image:: images/user_guide/settings_01.png
+
+The top items collect several options under User Preferences and Chart Screen.  An ellipsis
+(...) indicates more options below.
+
+.. image:: images/user_guide/settings_02.png
+
+Below the general UI options are settings to change which :ref:`connectivity:wifi` mode your
+PiFinder is in and its physical configuration.
+
+.. image:: images/user_guide/settings_03.png
+
+Hardware setup that's normally configured once — PiFinder Type, Camera Type, and GPS
+Settings (type and baud rate) — lives under the Advanced submenu near the bottom of the
+Settings Menu.  Opening it shows a brief "Options for DIY PiFinders" reminder, since on a
+fully built unit these are already set to match your hardware.
+
+Connectivity
+==============
+
+The PiFinder hosts its own WiFi network, ``PiFinderAP`` (no password), so your phone or
+tablet can join it anywhere; it can also join your home network instead.  Switch between
+the two modes from the :ref:`user_guide:settings menu`, and check the current mode and
+address on the :ref:`user_guide:status screen` — from a connected device the PiFinder
+answers at ``http://pifinder.local``.  The web interface, SkySafari and other planetarium
+apps, and the shared data folder are all covered in :doc:`connectivity`.
+
 Tools
 ==========================
 
@@ -630,7 +635,7 @@ checking the PiFinder's :ref:`status<user_guide:status screen>`, choosing your a
 .. image:: images/user_guide/tools_menu_docs.png
 
 For the full tree and a note on what every item does, see the
-:ref:`Tools section of the Menu Map<menu_map:tools>`.  The two screens you'll reach for
+:ref:`Tools section of the Menu Map<menu_map:tools>`.  The screens you'll reach for
 most often are covered below.
 
 Status Screen
@@ -648,6 +653,48 @@ Some of the key information shown:
 - WiFi information a bit further down, including the current WiFi mode, network name, and
   IP address.
 
+Update Software
+------------------
+
+The PiFinder can download and install software updates directly from its screen and keypad.
+To start, choose Software Upd from the :ref:`user_guide:tools`
+
+Updates happen right on the device — there is no need to send your PiFinder anywhere.  New
+units often ship a version or two behind the latest release, so running an update is a
+normal part of your first night out.
+
+.. image:: images/user_guide/software_update_01_docs.png
+
+The PiFinder needs internet access, so put it in Client Mode connected to a WiFi network.
+See :ref:`connectivity:connecting to a new wifi network` for details.
+
+The PiFinder confirms it can reach the internet, then compares the current release version
+to the one installed.
+
+.. image:: images/user_guide/software_update_02_docs.png
+
+.. note::
+   If the release version shows as **unknown**, the PiFinder cannot reach the internet to
+   check — it is either in Access Point mode or its WiFi is not configured.  Put it in
+   Client mode on a network with internet access (see
+   :ref:`connectivity:connecting to a new wifi network`); re-imaging the SD card is not the
+   fix for this.  If WiFi is configured but the check still fails, move closer to the
+   router or re-enter the network details.
+
+If a new version is available, use the presented option to start the update.  This may take
+several minutes, and the PiFinder restarts when it's done.
+
+.. image:: images/user_guide/software_update_04_docs.png
+
+
+.. image:: images/user_guide/software_update_03_docs.png
+
+You can also download a pre-built image of any software release and write it to the
+PiFinder's SD card.  See our `release page <https://github.com/brickbots/PiFinder/releases>`_
+for information about each release and a download link.
+
+Instructions for writing release images to an SD card are on the :doc:`software setup<software>`
+page.
 
 Shutdown
 ---------------------------
@@ -674,162 +721,3 @@ To shut down the PiFinder quickly:
 
 After you confirm, the screen and keypad turn off within a few seconds; it's then safe to
 turn off the unit with the power switch or by unplugging the battery.
-
-WiFi
-==========================
-
-Access Point and Client Mode
-----------------------------------
-
-The PiFinder can connect to an existing network in Client mode, or serve as a wireless
-access point for other devices in Access Point (AP) mode.  Use the
-:ref:`user_guide:Web Interface` or the :ref:`user_guide:status screen` to switch between
-the two modes and see which is active.
-
-In Access Point mode the PiFinder creates a network called PiFinderAP with no password, for
-easy connection of phones, tablets, and other devices in the field.
-
-To use Client mode, add the WiFi network you'd like the PiFinder to connect to using the
-Web Interface, as described in :ref:`user_guide:connecting to a new wifi network`
-
-PiFinder address
------------------
-
-In most cases you can reach the PiFinder at ``pifinder.local``.  On older computers, or
-those without zeroconf networking, use the IP address shown on the
-:ref:`Status<user_guide:status screen>` screen.  You can connect via:
-
-
-* A web browser, for the :ref:`user_guide:Web Interface` — remote control, WiFi setup, and configuration changes
-* SSH, for shell access (advanced users)
-* SMB (Samba), to access saved images, logs, and observing lists
-* LX200 protocol, to update a planetarium app such as :doc:`skysafari` with the telescope's position
-
-Web Interface
-==============
-
-The PiFinder's web interface lets you:
-
-* See the current PiFinder status
-* Remote control the PiFinder via a virtual screen and keypad
-* Change network settings and connect to new WiFi networks
-* Add and edit your telescopes and eyepieces (see :doc:`equipment`)
-* Back up and restore your observing logs, settings, and other data
-* View and download your logged observations
-
-To reach the web interface for the first time, make sure the PiFinder is in Access Point mode (see :ref:`user_guide:settings menu`) — the default for new PiFinders, to ease first-time setup.  From a phone, tablet, or computer, connect to the PiFinder's open wireless network, PiFinderAP (no password), then open your browser and visit:
-``http://pifinder.local``
-
-
-.. note::
-   If you're connected to the PiFinderAP network and can't load the web interface at
-   http://pifinder.local, try http://10.10.10.1 — some systems don't support the network
-   features needed to resolve local computer names.
-
-.. list-table::
-   :width: 100%
-
-   * - .. image:: images/user_guide/pf_web_home_fullnav.jpg
-
-     - .. image:: images/user_guide/pf_web_home_hamburger.jpg
-
-The home screen shows general PiFinder status and a live view of the screen.  Depending on
-your screen size you'll see either a navigation bar along the top or a 'hamburger' menu in
-the upper-left holding the same options on smaller screens.
-
-The home screen needs no password, but most other functions do.  The web interface password
-is the same as the ``pifinder`` user's; changing one changes the other.  The default for new
-images and PiFinders is ``solveit``, and you can change it from the Tools option in the web
-interface.
-
-Connecting to a new WiFi network
----------------------------------
-
-By default the PiFinder generates its own WiFi network, ``PiFinderAP``, that you connect to
-in order to configure additional networks.  To have the PiFinder connect to an existing
-WiFi network with Internet access, follow these steps:
-
-1) Make sure the PiFinder is in Access Point mode
-2) Connect your phone, tablet, or computer to the PiFinder's wifi network called PiFinderAP
-3) Visit http://pifinder.local using your web browser
-4) Click the 'Network' link in the top bar, or on a smaller screen click the three stacked horizontal lines in the upper-right corner and choose 'Network'.
-    .. image:: images/user_guide/pf_web_net0.png
-5) When prompted, enter the password for your PiFinder.  The default is `solveit`.
-6) Scroll down to the 'Wifi Networks' section and click the + button to add a network
-    .. image:: images/user_guide/pf_web_net1.jpg
-7) Enter the name (SSID) and password of your network.  If your network has no password, leave the Password field blank.
-8) Click the 'SAVE' button to save the new network
-9)  The network you added should now appear in the 'Wifi Networks' section
-10) Scroll up and change the Wifi mode from 'Access Point' to 'Client' so the PiFinder connects to your network on its next restart
-11) Click the 'UPDATE AND RESTART' button
-
-To add more WiFi networks, navigate to the Network Setup page of the :ref:`user_guide:web interface`, click the + button near the WiFi networks list, and repeat the steps above.
-
-
-SkySafari
-===================
-
-The PiFinder can provide real-time pointing information to SkySafari and other planetarium
-apps via the LX200 protocol, and accept targets they send back.  The :doc:`skysafari` page
-has the connection settings and walks through the setup step by step.
-
-Shared Data Access
-===================
-
-The PiFinder creates several data files you may want.  They're available via an SMB (samba)
-network share, ``//pifinder.local/shared``.  Access depends on your OS, but the PiFinder
-should appear in a network browser.  No password is required — connect as ``guest`` with no
-password.
-
-Once connected, you'll see:
-
-
-* ``captures/``\ : Images saved when logging objects, named with the observation ID from the database.
-* ``obslists/``\ : Observing lists saved during a session or kept for future sessions.
-* ``screenshots/``\ : Screenshots taken while using the PiFinder (hold **SQUARE** and
-  press **0**) are stored here.
-* ``solver_debug_dumps/``\ : If enabled, solver performance information is stored here as a collection of images and json files.
-* ``observations.db``\ : The SQLite database holding all logged observations.
-
-Update Software
-==================
-
-The PiFinder can download and install software updates directly from its screen and keypad.
-To start, choose Software Upd from the :ref:`user_guide:tools`
-
-Updates happen right on the device — there is no need to send your PiFinder anywhere.  New
-units often ship a version or two behind the latest release, so running an update is a
-normal part of your first night out.
-
-.. image:: images/user_guide/software_update_01_docs.png
-
-The PiFinder needs internet access, so put it in Client Mode connected to a WiFi network.
-See :ref:`user_guide:connecting to a new wifi network` for details.
-
-The PiFinder confirms it can reach the internet, then compares the current release version
-to the one installed.
-
-.. image:: images/user_guide/software_update_02_docs.png
-
-.. note::
-   If the release version shows as **unknown**, the PiFinder cannot reach the internet to
-   check — it is either in Access Point mode or its WiFi is not configured.  Put it in
-   Client mode on a network with internet access (see
-   :ref:`user_guide:connecting to a new wifi network`); re-imaging the SD card is not the
-   fix for this.  If WiFi is configured but the check still fails, move closer to the
-   router or re-enter the network details.
-
-If a new version is available, use the presented option to start the update.  This may take
-several minutes, and the PiFinder restarts when it's done.
-
-.. image:: images/user_guide/software_update_04_docs.png
-
-
-.. image:: images/user_guide/software_update_03_docs.png
-
-You can also download a pre-built image of any software release and write it to the
-PiFinder's SD card.  See our `release page <https://github.com/brickbots/PiFinder/releases>`_
-for information about each release and a download link.
-
-Instructions for writing release images to an SD card are on the :doc:`software setup<software>`
-page.


### PR DESCRIPTION
Continues the documentation review ([§6 of the recommendations](https://github.com/brickbots/PiFinder/pull/460)): reorganizes `user_guide.rst` and applies a now-explicit rule for what lives in the guide vs. on a standalone page.

## The rule (new ADR 0010)

A topic earns a **standalone page** only when **both** hold:
1. **Direct arrival** — readers land on it with a task in hand (search, Discord answer, cross-page link) rather than by reading the guide through; and
2. **Separability** — cutting it leaves no gap in the guide's operate-and-observe storyline.

By this rule `equipment`, `skysafari`, `catalogs`, `menu_map`, and `troubleshooting` stay standalone (their URLs are linked from the wild), while the connectivity block moves **out** of the user guide. `user_guide`'s charter narrows to: the **workflow reference for operating & observing** — deeper than the Quick Start, deliberately not exhaustive, and printable.

## Changes

- **New page `connectivity.rst` — "Connecting to Your PiFinder"**: the WiFi / Web Interface / SkySafari-pointer / Shared Data Access sections move there verbatim. The guide keeps a 4-sentence *Connectivity* at-a-glance (mode switch in Settings, `PiFinderAP`, `pifinder.local`) so the printed guide still answers the field questions.
- **`user_guide.rst` reordered per §6**: How It Works → The Menu System (Quick Menu + Help System now nest under it) → Observing → Power & Charging → Settings → Connectivity → Tools (Status Screen, Update Software, Shutdown now nest under it). 8 top-level sections, down from 13.
- **No section renamed** — all 33 inbound `autosectionlabel` refs keep resolving; the 6 refs to moved sections are retargeted (`equipment`, `skysafari`, `menu_map`, `troubleshooting`).
- **ADR 0010** records the rule and the rejected alternatives; the docs skill's page table now carries the per-page charters.
- Rider: commits the §3-era `docs/ax/positioning/CONTEXT.md` scoping note that missed PR #460.

## Verification

`sphinx-build -n` (nitpicky) is warning-clean against the pinned `docs/source/requirements.txt` environment; rendered HTML checked for the new sidebar entry and heading order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)