### PR TITLE
Fix IMU process memory leak + CPU spin (and guard contrast-reserve log spam)

### DIFF
--- a/python/PiFinder/imu_pi.py
+++ b/python/PiFinder/imu_pi.py
@@ -190,7 +190,15 @@ def imu_monitor(shared_state, console_queue, log_queue):
         moving=False,
     )
 
+    # update() already throttles the I2C reads to imu_sample_frequency (30 Hz),
+    # but the loop body still runs every iteration — publishing the sample via
+    # set_imu(), a Manager-proxy pickle. Without pacing this spins thousands/sec
+    # (~19% CPU) and the per-publish pickle leaks. Capture the period once; the
+    # fake-IMU fallback has no such attr (and self-throttles), hence the default.
+    sample_period = getattr(imu, "imu_sample_frequency", 1 / 30)
+
     while True:
+        loop_start = time.monotonic()
         imu.update()
         imu_sample.status = imu.calibration
 
@@ -223,6 +231,15 @@ def imu_monitor(shared_state, console_queue, log_queue):
 
         if shared_state is not None and imu_calibrated:
             shared_state.set_imu(imu_sample)
+
+        # Pace the loop to the IMU sample rate: sleep only the remainder of the
+        # sample period (period minus the work already done this iteration), so
+        # the publish cadence tracks the sample rate instead of drifting to
+        # period + work. The guard keeps the fake-IMU fallback (whose update()
+        # already sleeps 0.1s) from sleeping a second time.
+        sleep_remaining = sample_period - (time.monotonic() - loop_start)
+        if sleep_remaining > 0:
+            time.sleep(sleep_remaining)
 
 
 if __name__ == "__main__":

--- a/python/PiFinder/types/positioning.py
+++ b/python/PiFinder/types/positioning.py
@@ -51,9 +51,14 @@ Design notes
   :class:`ImuDeadReckoning`. Bridge via :meth:`Pointing.as_radecroll`.
 
 * All structures must remain picklable so they can ride on
-  ``multiprocessing.Queue`` and ``SharedStateObj`` proxies.
-  ``numpy.quaternion`` already pickles and dataclasses pickle by default;
-  we avoid lambdas/closures in defaults.
+  ``multiprocessing.Queue`` and ``SharedStateObj`` proxies. Dataclasses
+  pickle by default and we avoid lambdas/closures in defaults — but a bare
+  ``numpy.quaternion`` must **not** be pickled directly: it leaks in
+  numpy-quaternion 2023.0.4 (see ``_quat_to_floats`` and
+  ``memory/imu-quaternion-pickle-leak``). The dataclasses carrying a
+  quaternion field (:class:`ImuSample`, :class:`PointingEstimate`,
+  :class:`SuccessfulSolve`) override ``__getstate__``/``__setstate__`` to
+  pickle it as 4 floats; the in-process attribute stays a quaternion.
 """
 
 from __future__ import annotations
@@ -66,6 +71,36 @@ from typing import List, Optional, Tuple, Union
 import quaternion
 
 from PiFinder.types.coordinates import RaDecRoll
+
+
+# =====================================================================
+# Pickle helpers: never serialise a bare numpy.quaternion
+# =====================================================================
+#
+# ``pickle.dumps(numpy.quaternion)`` leaks memory in numpy-quaternion
+# 2023.0.4 (~16 MB/min when a hot loop publishes one across a multiprocessing
+# Manager proxy — see ``memory/imu-quaternion-pickle-leak``). A tuple of plain
+# floats pickles cleanly. Dataclasses that carry a bare quaternion field
+# therefore override ``__getstate__``/``__setstate__`` to round-trip it through
+# these helpers: the in-process attribute stays a real ``numpy.quaternion``
+# (zero consumer changes), only the pickled form is 4 floats. The float
+# round-trip is bit-exact.
+
+
+def _quat_to_floats(q):
+    """Scalar-first ``(w, x, y, z)`` floats for pickling, or ``None``."""
+    if q is None:
+        return None
+    return (float(q.w), float(q.x), float(q.y), float(q.z))
+
+
+def _floats_to_quat(v):
+    """Inverse of :func:`_quat_to_floats`: rebuild a ``numpy.quaternion``.
+
+    Idempotent and ``None``-safe — only a 4-tuple is converted, so an
+    already-rebuilt value (or ``None``) passes through unchanged.
+    """
+    return quaternion.quaternion(*v) if isinstance(v, tuple) else v
 
 
 # =====================================================================
@@ -344,6 +379,18 @@ class PointingEstimate:
     def is_imu_solve(self) -> bool:
         return self.solve_source == SolveSource.IMU
 
+    # Pickle the ``imu_anchor`` quaternion as floats (see _quat_to_floats):
+    # the integrator publishes a deepcopy of this estimate across the proxy
+    # via ``set_solution`` on every cycle.
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["imu_anchor"] = _quat_to_floats(state["imu_anchor"])
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        state["imu_anchor"] = _floats_to_quat(state.get("imu_anchor"))
+        self.__dict__.update(state)
+
 
 # =====================================================================
 # SolveResult — the solver → integrator message (rides solver_queue)
@@ -389,6 +436,17 @@ class SuccessfulSolve:
     matched_centroids: Optional[List[Tuple[float, float]]] = None
     matched_stars: Optional[list] = None
 
+    # Pickle the ``imu_anchor`` quaternion as floats (see _quat_to_floats):
+    # this message rides ``solver_queue``, a pickle boundary.
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["imu_anchor"] = _quat_to_floats(state["imu_anchor"])
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        state["imu_anchor"] = _floats_to_quat(state.get("imu_anchor"))
+        self.__dict__.update(state)
+
 
 @dataclass
 class FailedSolve:
@@ -427,7 +485,10 @@ class ImuSample:
     ``move_start`` / ``move_end`` keys were dropped in the migration).
 
     ``quat`` is scalar-first ``(w, x, y, z)``, as produced by
-    ``quaternion.from_float_array(imu.avg_quat)``.
+    ``quaternion.from_float_array(imu.avg_quat)``. It pickles as 4 plain
+    floats (see ``__getstate__``) to dodge the numpy-quaternion leak — the
+    IMU loop publishes this sample across the proxy every cycle; keep those
+    hooks.
 
     ``timestamp`` is the wall-clock (``time.time()``) instant the IMU
     process sampled this orientation — the IMU-side input to
@@ -462,6 +523,17 @@ class ImuSample:
             "gyro": list(self.gyro) if self.gyro is not None else None,
             "accel": list(self.accel) if self.accel is not None else None,
         }
+
+    # Pickle ``quat`` as floats (see _quat_to_floats): the IMU loop publishes
+    # this sample across the proxy via ``set_imu`` on every cycle.
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["quat"] = _quat_to_floats(state["quat"])
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        state["quat"] = _floats_to_quat(state.get("quat"))
+        self.__dict__.update(state)
 
 
 # =====================================================================

--- a/python/tests/test_pointing_estimate.py
+++ b/python/tests/test_pointing_estimate.py
@@ -201,6 +201,44 @@ class TestPicklability:
         for msg in (success, failure):
             assert pickle.loads(pickle.dumps(msg)) == msg
 
+    def test_imu_sample_round_trips_with_quaternion(self):
+        import pickle
+
+        original = ImuSample(
+            quat=quaternion.quaternion(0.1, 0.2, 0.3, 0.4),
+            timestamp=12345.6789,
+            status=3,
+            moving=True,
+            gyro=(0.01, 0.02, 0.03),
+            accel=(0.1, 0.2, 0.3),
+        )
+        roundtripped = pickle.loads(pickle.dumps(original))
+        assert roundtripped == original
+        # quat must come back as a real numpy.quaternion — consumers rely on
+        # quaternion math / .w/.x/.y/.z — not the 4-float pickle form.
+        assert isinstance(roundtripped.quat, quaternion.quaternion)
+        assert roundtripped.quat == original.quat
+        # __getstate__ must not mutate the live object in place.
+        assert isinstance(original.quat, quaternion.quaternion)
+
+    def test_none_quaternion_anchor_round_trips(self):
+        import pickle
+
+        # A solve on a frame with no IMU sample carries imu_anchor=None; the
+        # float round-trip must preserve None (the helpers are None-safe).
+        est = PointingEstimate()  # imu_anchor defaults to None
+        assert est.imu_anchor is None
+        assert pickle.loads(pickle.dumps(est)).imu_anchor is None
+
+        solve = SuccessfulSolve(
+            camera=Pointing(RA=1.0, Dec=2.0, Roll=3.0),
+            aligned=Pointing(RA=1.5, Dec=2.5, Roll=3.0),
+            imu_anchor=None,
+            last_solve_attempt=1.0,
+            last_solve_success=1.0,
+        )
+        assert pickle.loads(pickle.dumps(solve)).imu_anchor is None
+
 
 # ---------------------------------------------------------------------
 # Solver builder semantics


### PR DESCRIPTION
## Summary

Two fixes found by the **real-hardware endurance test that followed #470**. #470 fixed the comet CPU hog; this PR fixes a **second, distinct failure mode** the endurance test then surfaced — and that mode (a memory leak) is the more likely driver of the actual OOM/freeze. See *Relationship to #470* below.

## 1. IMU process memory leak + CPU spin (primary)

The `imu_monitor` loop (`imu_pi.py`) had no sleep. `imu.update()` throttles the I²C reads to 30 Hz, but the loop *body* still ran thousands/sec, calling `shared_state.set_imu()` every iteration. `set_imu` crosses a multiprocessing **Manager proxy**, so each call pickles the `ImuSample` — and **pickling a `numpy.quaternion` leaks** (~25 MB/200k dumps, numpy-quaternion 2023.0.4). On real hardware the IMU child leaked **~16 MB/min** and spun **~19 % CPU**; on a 2 GB Pi that exhausts RAM → swap-thrash → OOM/freeze. Invisible to the fake-IMU headless harness (its `update()` self-throttles with `sleep(0.1)`), which is why earlier headless profiling never caught it.

- **Throttle** the loop to the sample rate — sleep only the *remainder* of the period (`period − work`), so publishing tracks 30 Hz instead of drifting to `period + work`. The `> 0` guard keeps the fake-IMU fallback from double-sleeping. 19 % → ~2.4 % CPU.
- **Stop pickling the quaternion** — `__getstate__`/`__setstate__` on `ImuSample.quat`, `PointingEstimate.imu_anchor`, and `SuccessfulSolve.imu_anchor` (the same quaternion also rides `set_solution`'s `deepcopy` + `solver_queue`). Pickles 4 plain floats, rebuilt on unpickle; the in-process attribute stays a real `numpy.quaternion`, so consumers are unchanged.

## 2. Contrast-reserve log spam (rider)

`pydeepskylog.contrast_reserve()` logs `logger.error(...)` and **returns** (doesn't raise) when an object diameter is `None`, so the surrounding `except` can't suppress it. `object_details` calls it per redraw with `diameter=None` for sizeless objects → steady ERROR-level spam that bypasses the `root=ERROR` filter. Guard: skip the call when a diameter is `None` (same blank-contrast result, minus the error).

## Verification

- **A/B `pickle.dumps` RSS**: bare quaternion **+24.8 MB/200k**; all three patched dataclasses **+0.0 MB**.
- **Unit/smoke**: 440 pass (incl. new `ImuSample` / `None`-anchor round-trip tests in `TestPicklability`); ruff + mypy clean; `test_ui_modules` 211 pass.
- **50-min real-hardware endurance** (real BNO055, Test Mode, IMU child watched directly): anonymous heap **flat 113.8 → 113.8 MB (slope −0.000 MB/min)**, CPU mean **2.35 %**, RSS +6.4 MB one-time COW step then plateau. Prior baseline: **134 → 545 MB / 19 % in 28 min**.

## Relationship to #470

#470 ("Vectorize comet propagation") fixed the **CPU hog** — `calc_comets` pegging a core whenever locked. That is a real pathology (UI starvation, heat), but a CPU hog alone doesn't typically hard-crash the OS. This PR fixes a **memory leak** that does: ~16 MB/min on a 2 GB Pi exhausts RAM in well under an hour → swap-death / OOM, which presents as the field "hang." The endurance test that found this leak ran *after* the comet fix, with the hog already gone — so the two are independent.

**Best current understanding: the field freeze was primarily this memory leak, with the comet CPU hog a compounding factor. Both fixes are needed for a healthy long observing session.** #470's description has been updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
