### PR TITLE
Guard contrast-reserve calc for sizeless objects (stop ERROR log spam)

### DIFF
--- a/python/PiFinder/ui/object_details.py
+++ b/python/PiFinder/ui/object_details.py
@@ -255,15 +255,23 @@ class UIObjectDetails(UIModule):
                     else:
                         diameter1 = diameter2 = None
 
-                    self.contrast = pds.contrast_reserve(
-                        sqm=sqm,
-                        telescope_diameter=self.config_object.equipment.active_telescope.aperture_mm,
-                        magnification=magnification,
-                        surf_brightness=None,
-                        magnitude=magnitude,
-                        object_diameter1=diameter1,
-                        object_diameter2=diameter2,
-                    )
+                    if diameter1 is None or diameter2 is None:
+                        # No usable object size: pydeepskylog can't compute a
+                        # contrast reserve without diameters — it logs an ERROR
+                        # and *returns* (doesn't raise), so the except below
+                        # can't suppress it. Skip the call and leave the
+                        # contrast line blank.
+                        self.contrast = ""
+                    else:
+                        self.contrast = pds.contrast_reserve(
+                            sqm=sqm,
+                            telescope_diameter=self.config_object.equipment.active_telescope.aperture_mm,
+                            magnification=magnification,
+                            surf_brightness=None,
+                            magnitude=magnitude,
+                            object_diameter1=diameter1,
+                            object_diameter2=diameter2,
+                        )
                 except (ValueError, TypeError, InvalidParameterError) as e:
                     # mag_str / size are not always plain numbers: double stars
                     # carry component mags like "7.0/9.5", asterisms a size like


### PR DESCRIPTION
## Summary

Guard the contrast-reserve calculation against objects with no usable size, to stop steady ERROR-level log spam.

`pydeepskylog.contrast_reserve()` logs `logger.error(...)` and **returns** (it does *not* raise) when an object diameter is `None`, so the surrounding `except (ValueError, TypeError, InvalidParameterError)` in `object_details.update_object_info()` cannot suppress it. That method calls `contrast_reserve()` on every redraw, and for objects that have a magnitude but no usable size it passes `diameter=None` — producing steady ERROR-level log spam (~1–2/sec while that object's detail screen is open) that bypasses the `root=ERROR` log filter.

## Fix

Skip the call when either diameter is `None` (the library can't compute a contrast reserve without diameters anyway) and leave the contrast line blank. This is the **same end result as before** — `contrast` was ultimately set to `""` on the `None` return — minus the error log.

## Notes

Split out of #472 (IMU memory-leak fix) so it can be reviewed and merged independently; the two changes are unrelated and touch disjoint files (this one is `object_details.py` only). Complements the Contrast Reserve documentation work in #471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
