### PR TITLE
fix(state): graceful worker shutdown when shared-state manager dies

### DIFF
--- a/python/PiFinder/camera_interface.py
+++ b/python/PiFinder/camera_interface.py
@@ -674,5 +674,9 @@ class CameraInterface:
             logger.info(
                 f"CameraInterface: Camera loop exited with command: '{command}'"
             )
-        except (BrokenPipeError, EOFError, FileNotFoundError):
+        except FileNotFoundError:
             logger.exception("Error in Camera Loop")
+        except Exception as e:
+            if not state_utils.is_dead_manager_error(e):
+                raise
+            logger.error("Shared-state manager gone; stopping camera loop: %s", e)

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -200,8 +200,10 @@ def integrator(
 
             telemetry.flush()
 
-    except EOFError:
-        logger.error("Main no longer running for integrator")
+    except Exception as e:
+        if not state_utils.is_dead_manager_error(e):
+            raise
+        logger.error("Shared-state manager gone; stopping integrator: %s", e)
     finally:
         if telemetry is not None:
             telemetry.stop()

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -434,9 +434,9 @@ def solver(
                 # which might be from the IMU
                 try:
                     last_image_metadata = shared_state.last_image_metadata()
-                except (BrokenPipeError, ConnectionResetError) as e:
-                    logger.error(f"Lost connection to shared state manager: {e}")
-                    continue
+                except state_utils.DEAD_MANAGER_EXCEPTIONS as e:
+                    logger.error("Shared-state manager gone; stopping Solver: %s", e)
+                    return
 
                 # Check if we should process this image
                 is_new_image = last_image_metadata["exposure_end"] > last_solve_attempt
@@ -592,13 +592,10 @@ def solver(
                             t_extract_ms=0.0,
                         )
                     )
-        except EOFError as eof:
-            logger.error(f"Main process no longer running for solver: {eof}")
-            logger.exception(eof)
-            logger.error(
-                f"Last solve attempt: {last_solve_attempt}, last success: {last_solve_success}"
-            )
         except Exception as e:
+            if state_utils.is_dead_manager_error(e):
+                logger.error("Shared-state manager gone; stopping Solver: %s", e)
+                return
             logger.error(f"Exception in Solver: {e.__class__.__name__}: {str(e)}")
             logger.exception(e)
             logger.error(f"Current process ID: {os.getpid()}")

--- a/python/PiFinder/state_utils.py
+++ b/python/PiFinder/state_utils.py
@@ -7,11 +7,39 @@ import time
 _TARGET_PERIOD = 1.0 / 30.0
 _last_wake: Optional[float] = None
 
+# Exceptions raised on a SharedStateObj proxy call when the multiprocessing
+# Manager process that owns the shared state has died. The proxy connection is
+# then permanently broken, so a worker that sees one of these can never recover
+# by retrying -- it should log once and stop its loop instead of spinning.
+DEAD_MANAGER_EXCEPTIONS = (BrokenPipeError, ConnectionResetError, EOFError)
+
+
+class SharedStateLost(RuntimeError):
+    """The shared-state Manager process is gone; the worker should stop.
+
+    Raised by :func:`sleep_for_framerate` so the documented spin site surfaces
+    a single, intentional signal rather than a raw connection error.
+    """
+
+
+def is_dead_manager_error(exc: BaseException) -> bool:
+    """Return True when *exc* signals the shared-state Manager process is gone.
+
+    Worker loops should treat this as terminal: log once and exit the loop
+    cleanly instead of retrying forever (which floods the logs).
+    """
+    return isinstance(exc, DEAD_MANAGER_EXCEPTIONS + (SharedStateLost,))
+
 
 def sleep_for_framerate(shared_state: SharedStateObj, limit_framerate=True) -> bool:
     global _last_wake
 
-    if shared_state.power_state() <= 0:
+    try:
+        powered = shared_state.power_state() > 0
+    except DEAD_MANAGER_EXCEPTIONS as e:
+        raise SharedStateLost(str(e)) from e
+
+    if not powered:
         time.sleep(0.5)
         _last_wake = time.monotonic()
         return True

--- a/python/tests/test_state_utils.py
+++ b/python/tests/test_state_utils.py
@@ -1,0 +1,77 @@
+"""Tests for shared-state dead-manager detection and graceful shutdown.
+
+When the multiprocessing Manager that owns SharedStateObj dies, worker
+proxy calls raise BrokenPipeError / ConnectionResetError / EOFError. Workers
+must treat this as terminal (log once, stop) instead of retrying forever.
+"""
+
+import pytest
+
+from PiFinder import state_utils
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "exc",
+    [
+        BrokenPipeError(32, "Broken pipe"),
+        ConnectionResetError(104, "Connection reset by peer"),
+        EOFError(),
+        state_utils.SharedStateLost("manager gone"),
+    ],
+)
+def test_dead_manager_errors_detected(exc):
+    assert state_utils.is_dead_manager_error(exc) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("exc", [ValueError(), RuntimeError(), KeyError(), OSError()])
+def test_live_manager_errors_not_flagged(exc):
+    assert state_utils.is_dead_manager_error(exc) is False
+
+
+class _Healthy:
+    def power_state(self):
+        return 1
+
+
+class _PoweredOff:
+    def power_state(self):
+        return 0
+
+
+class _DeadManager:
+    def __init__(self, exc):
+        self._exc = exc
+
+    def power_state(self):
+        raise self._exc
+
+
+@pytest.mark.unit
+def test_sleep_for_framerate_awake_when_powered():
+    state_utils._last_wake = None
+    assert state_utils.sleep_for_framerate(_Healthy(), limit_framerate=False) is False
+
+
+@pytest.mark.unit
+def test_sleep_for_framerate_sleeps_when_powered_off():
+    assert state_utils.sleep_for_framerate(_PoweredOff()) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "exc",
+    [
+        BrokenPipeError(32, "Broken pipe"),
+        ConnectionResetError(104, "reset"),
+        EOFError(),
+    ],
+)
+def test_sleep_for_framerate_translates_dead_manager(exc):
+    with pytest.raises(state_utils.SharedStateLost) as info:
+        state_utils.sleep_for_framerate(_DeadManager(exc))
+    # The original connection error is preserved as the cause and is still
+    # recognised by the shared detector.
+    assert info.value.__cause__ is exc
+    assert state_utils.is_dead_manager_error(info.value) is True


### PR DESCRIPTION
## Problem

When the `multiprocessing` Manager process that owns `SharedStateObj` dies, every worker that holds a proxy (Solver, Camera, Integrator, ...) gets a `BrokenPipeError` / `ConnectionResetError` / `EOFError` on its next `shared_state.*` call. The proxy connection is then permanently broken — there is no recovery by retrying.

On a real device this manifested as the **solver spinning forever, logging "Broken pipe" every ~2 s** (70k+ such lines in `pifinder.log`, going back to 2026-03; not caused by the cedar solver). Representative trace:

```
solver.py  -> state_utils.sleep_for_framerate(shared_state)
           -> shared_state.power_state()
           -> manager conn.send(...)
           -> BrokenPipeError: [Errno 32] Broken pipe
```

## Investigation / root cause

`SharedStateObj` is a `multiprocessing` Manager proxy created in the main process; each worker process inherits a proxy. When the manager process is gone, proxy calls raise connection errors.

The flood comes specifically from the **solver's nested loop structure** (`solver.py`):

- An **outer** `while True:` "restart" loop recreates the cedar client and re-enters an **inner** `while True:` work loop.
- `sleep_for_framerate()` is the first call in the inner loop and calls `shared_state.power_state()` — the documented spin site.
- When it raised `BrokenPipeError`, the exception was **not** caught locally; it propagated to the outer `except Exception`, which logged and then **fell through to the bottom of the outer `while True`** — restarting the loop. Re-creating the cedar client takes ~2 s, then `power_state()` immediately fails again. Infinite ~2 s spin.
- The inner `except (BrokenPipeError, ConnectionResetError)` around `last_image_metadata()` used `continue`, which fed the same loop, and `except EOFError` likewise fell through to a restart.

The other workers were inconsistent: the integrator caught only `EOFError` (a `BrokenPipeError` from `sleep_for_framerate` would propagate uncaught and crash the process); the camera caught `(BrokenPipeError, EOFError, FileNotFoundError)` but not `ConnectionResetError`, and logged a full traceback.

**The exact event that kills the manager (main-process crash, manager subprocess exit, or shutdown ordering) is not determinable from the logs alone** — it predates the cedar work and reproducing it needs a running device. This PR does not try to keep the manager alive; it makes workers **degrade gracefully** when it is gone. See the open question below.

## Fix

Add a small shared helper in `state_utils.py` and apply it consistently:

- `DEAD_MANAGER_EXCEPTIONS = (BrokenPipeError, ConnectionResetError, EOFError)` — the proxy errors that mean "manager is gone".
- `SharedStateLost` — a named signal that `sleep_for_framerate()` now raises (from the original error) so the documented spin site surfaces one intentional exception instead of a raw connection error.
- `is_dead_manager_error(exc)` — detector used by worker loops; matches the tuple and `SharedStateLost`.

Applied in the worker loops so a dead manager is **logged once and the loop exits cleanly** instead of retrying:

- `solver.py` — both the inner `last_image_metadata()` handler and the outer handler now `return` on a dead-manager error (no more outer-loop restart); the redundant `except EOFError` block is folded into the unified check.
- `integrator.py` — broadened from `EOFError`-only to any dead-manager error; other exceptions still propagate as before.
- `camera_interface.py` — added `ConnectionResetError` / `SharedStateLost`; `FileNotFoundError` handling preserved; other exceptions still propagate.
- `state_utils.sleep_for_framerate` — translates a dead-manager error from `power_state()` into `SharedStateLost`.

Behaviour is unchanged while the manager is healthy (same return values, same framerate limiting, same power-off sleep).

## Tests

- New `tests/test_state_utils.py` (13 cases): detector matches the dead-manager set and rejects ordinary errors; `sleep_for_framerate` returns the same awake/sleep values when healthy and translates dead-manager errors into `SharedStateLost` (preserving `__cause__`).
- Full suite green: `pytest -m unit` (453 passed), `pytest -m smoke` (5 passed), plus `test_solver_shmem.py` / `test_integrator_drift.py`. `ruff check`/`format` and `mypy` clean on changed files.

## Open question

Why the manager process dies in the first place is still unknown and likely needs runtime reproduction on a device (candidates: a main-process exception, the manager subprocess being reaped, or teardown ordering during shutdown). This PR ships the graceful-degradation fix regardless, so a dead manager can no longer flood the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)