### PR TITLE
Don't let a hung V4L2 capture freeze the camera process

### DIFF
--- a/python/PiFinder/camera_interface.py
+++ b/python/PiFinder/camera_interface.py
@@ -50,6 +50,11 @@ class CameraInterface:
     # Native (camera-driver) auto-exposure, distinct from the solver-driven
     # auto-exposure above. Enabled for daytime alignment via `set_exp:native`.
     _native_ae_enabled = False
+    # Handle to an in-flight capture thread (see _capture_with_timeout). A
+    # wedged V4L2 capture can outlive its timeout; tracking it lets the next
+    # frame decline to start a second, concurrent capture on a camera that is
+    # not thread-safe.
+    _capture_thread: Optional[threading.Thread] = None
 
     def set_native_ae(self, enabled: bool) -> bool:
         """Enable/disable the camera's native (driver) auto-exposure.
@@ -79,13 +84,27 @@ class CameraInterface:
         return Image.new("L", (512, 512), 0)  # Black 512x512 image
 
     def _capture_with_timeout(self, timeout=10) -> Optional[Image.Image]:
-        """Run capture() with a timeout.
+        """Run capture() with a timeout, never overlapping two captures.
 
         A V4L2 capture can hang indefinitely (e.g. the sensor wedges), which
         would otherwise freeze the whole camera process. Run the capture on a
         daemon thread and give up after ``timeout`` seconds, returning None so
         the caller can recover instead of blocking forever.
+
+        A timed-out capture cannot be cancelled (picamera2/V4L2 exposes no such
+        API), so the daemon thread stays stuck inside the driver until it
+        eventually returns. To avoid piling concurrent capture_request() calls
+        onto a camera that is not thread-safe -- and racing on shared camera
+        state -- we keep a handle to the in-flight thread and refuse to launch a
+        second capture while it is still alive. At most one capture is ever
+        running; the caller just gets blank frames until the stuck one clears.
         """
+        # A previous capture is still wedged in the driver -- don't start a
+        # second one. Returning None lets the caller fall back to a blank frame
+        # while we wait for the stuck capture to clear.
+        if self._capture_thread is not None and self._capture_thread.is_alive():
+            return None
+
         result: list = [None]
         exc: list = [None]
 
@@ -96,11 +115,18 @@ class CameraInterface:
                 exc[0] = e
 
         thread = threading.Thread(target=_do_capture, daemon=True)
+        self._capture_thread = thread
         thread.start()
         thread.join(timeout)
 
         if thread.is_alive():
+            # Still running: leave it tracked so the next call sees it and
+            # declines to start an overlapping capture.
             return None
+
+        # Finished within the timeout -- clear the handle so the next frame
+        # starts a fresh capture.
+        self._capture_thread = None
         if exc[0]:
             raise exc[0]
         return result[0]

--- a/python/PiFinder/camera_interface.py
+++ b/python/PiFinder/camera_interface.py
@@ -16,6 +16,7 @@ import time
 import datetime
 import numpy as np
 import queue
+import threading
 import logging
 
 from PiFinder import state_utils, utils
@@ -76,6 +77,33 @@ class CameraInterface:
         Returns a properly formated black frame
         """
         return Image.new("L", (512, 512), 0)  # Black 512x512 image
+
+    def _capture_with_timeout(self, timeout=10) -> Optional[Image.Image]:
+        """Run capture() with a timeout.
+
+        A V4L2 capture can hang indefinitely (e.g. the sensor wedges), which
+        would otherwise freeze the whole camera process. Run the capture on a
+        daemon thread and give up after ``timeout`` seconds, returning None so
+        the caller can recover instead of blocking forever.
+        """
+        result: list = [None]
+        exc: list = [None]
+
+        def _do_capture():
+            try:
+                result[0] = self.capture()
+            except Exception as e:  # propagate to the caller's thread
+                exc[0] = e
+
+        thread = threading.Thread(target=_do_capture, daemon=True)
+        thread.start()
+        thread.join(timeout)
+
+        if thread.is_alive():
+            return None
+        if exc[0]:
+            raise exc[0]
+        return result[0]
 
     def capture_bias(self):
         """
@@ -167,7 +195,14 @@ class CameraInterface:
                 image_start_time = time.time()
                 if self._camera_started:
                     if not debug:
-                        base_image = self.capture()
+                        base_image = self._capture_with_timeout()
+                        if base_image is None:
+                            # Capture hung; fall back to a blank frame so the
+                            # loop keeps running and stays responsive to
+                            # commands instead of freezing. The blank frame
+                            # simply fails to solve.
+                            logger.warning("Camera capture timed out; blank frame")
+                            base_image = self._blank_capture()
                         base_image = base_image.convert("L")
 
                         rotate_amount = 0

--- a/python/tests/test_camera_interface.py
+++ b/python/tests/test_camera_interface.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python
+# -*- coding:utf-8 -*-
+"""
+Unit tests for CameraInterface._capture_with_timeout - the hot-path capture
+guard that keeps a wedged V4L2 capture from freezing the camera process
+without ever overlapping two captures on a non-thread-safe camera.
+"""
+
+import threading
+from typing import Optional
+
+import pytest
+from PIL import Image
+
+from PiFinder.camera_interface import CameraInterface
+
+
+class _ScriptedCamera(CameraInterface):
+    """A CameraInterface whose capture() behaviour the test drives.
+
+    capture() optionally blocks on ``gate`` (simulating a wedged driver) and
+    counts how many times it was actually entered, so tests can assert that the
+    guard never launches an overlapping capture.
+    """
+
+    def __init__(self):
+        self.capture_calls = 0
+        self.gate = threading.Event()  # capture() waits on this when blocking
+        self.blocking = False
+        self.raise_exc: Optional[Exception] = None
+
+    def capture(self) -> Image.Image:
+        self.capture_calls += 1
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        if self.blocking:
+            # Simulate a hung capture. The safety timeout means a misbehaving
+            # test can never wedge pytest itself.
+            self.gate.wait(timeout=5)
+        return Image.new("L", (512, 512), 1)
+
+
+@pytest.mark.unit
+class TestCaptureWithTimeout:
+    """Tests for the hot-path capture timeout + overlap guard."""
+
+    def test_returns_image_when_capture_completes(self):
+        """A capture that returns in time is passed straight through."""
+        cam = _ScriptedCamera()
+        image = cam._capture_with_timeout(timeout=1)
+        assert isinstance(image, Image.Image)
+        assert cam.capture_calls == 1
+        # Handle is cleared so the next frame starts fresh.
+        assert cam._capture_thread is None
+
+    def test_propagates_capture_exception(self):
+        """A real capture error surfaces in the caller's thread, not swallowed."""
+        cam = _ScriptedCamera()
+        cam.raise_exc = ValueError("sensor boom")
+        with pytest.raises(ValueError, match="sensor boom"):
+            cam._capture_with_timeout(timeout=1)
+        # The worker finished (it raised), so nothing is left tracked.
+        assert cam._capture_thread is None
+
+    def test_returns_none_on_timeout(self):
+        """A wedged capture times out to None (caller uses a blank frame)."""
+        cam = _ScriptedCamera()
+        cam.blocking = True
+        try:
+            assert cam._capture_with_timeout(timeout=0.25) is None
+            # The stuck capture is kept tracked and still running.
+            assert cam._capture_thread is not None
+            assert cam._capture_thread.is_alive()
+        finally:
+            cam.gate.set()
+            if cam._capture_thread is not None:
+                cam._capture_thread.join(timeout=5)
+
+    def test_guard_prevents_overlapping_capture(self):
+        """While one capture is wedged, a second call must not start another.
+
+        This is the core fix: piling concurrent capture_request() calls onto a
+        non-thread-safe camera is worse than the freeze the timeout avoids.
+        """
+        cam = _ScriptedCamera()
+        cam.blocking = True
+        try:
+            # First frame wedges and times out.
+            assert cam._capture_with_timeout(timeout=0.25) is None
+            wedged_thread = cam._capture_thread
+            assert wedged_thread is not None and wedged_thread.is_alive()
+            assert cam.capture_calls == 1
+
+            # Second frame, still wedged: returns None immediately WITHOUT
+            # entering capture() again (no overlap) and without spawning a
+            # new thread.
+            assert cam._capture_with_timeout(timeout=0.25) is None
+            assert cam.capture_calls == 1
+            assert cam._capture_thread is wedged_thread
+        finally:
+            cam.gate.set()
+            if cam._capture_thread is not None:
+                cam._capture_thread.join(timeout=5)
+
+    def test_recovers_after_stuck_capture_clears(self):
+        """Once the wedged capture returns, normal captures resume."""
+        cam = _ScriptedCamera()
+        cam.blocking = True
+        # Wedge, time out, then let the stuck capture finish.
+        assert cam._capture_with_timeout(timeout=0.25) is None
+        wedged_thread = cam._capture_thread
+        cam.gate.set()
+        assert wedged_thread is not None
+        wedged_thread.join(timeout=5)
+
+        # gate is now set, so a fresh capture returns immediately. The guard
+        # sees the old thread is no longer alive and starts a new capture.
+        image = cam._capture_with_timeout(timeout=1)
+        assert isinstance(image, Image.Image)
+        assert cam.capture_calls == 2
+        assert cam._capture_thread is not wedged_thread
+        assert cam._capture_thread is None


### PR DESCRIPTION
## Problem

`CameraInterface.get_image_loop()` calls `self.capture()` on the hot path. A
V4L2 capture can hang indefinitely when the sensor/driver wedges, and because
the call never returns the whole camera process freezes: no new frames, no
solving, and the command-handling loop is never reached — so the camera can't
even be stopped/restarted short of killing the process.

## Change

Run the hot-path capture on a daemon thread with a timeout
(`_capture_with_timeout`). If it doesn't return in time, log and fall back to a
blank frame so the loop keeps running and stays responsive to commands. A
wedged capture now degrades to failed solves instead of a frozen process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)