### PR TITLE
feat: modernize the gen_images catalog-image fetcher

### DIFF
--- a/python/PiFinder/gen_images.py
+++ b/python/PiFinder/gen_images.py
@@ -1,42 +1,61 @@
 #!/usr/bin/python
 # -*- coding:utf-8 -*-
 """
-This module fetches images from sky survey sources on the internet
-and prepares them for PiFinder use.
+Fetch images from sky survey sources (NASA SkyView POSS, SDSS DR18)
+and prepare them for PiFinder use.
+
+Usage:
+    python -m PiFinder.gen_images                  # Fetch missing images
+    python -m PiFinder.gen_images --force           # Re-fetch ALL images
+    python -m PiFinder.gen_images --force --poss    # Re-fetch POSS only
+    python -m PiFinder.gen_images --force --sdss    # Re-fetch SDSS only
+    python -m PiFinder.gen_images --workers 20      # More concurrency
 """
 
-import requests
+import argparse
 import os
-from tqdm import tqdm
+import sqlite3
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from io import BytesIO
+from typing import Dict, List, Tuple, cast
+
+import requests
 from PIL import Image, ImageOps
-from PiFinder.db.objects_db import ObjectsDatabase
-from PiFinder.catalogs import CompositeObject
-from PiFinder.composite_object import SizeObject, MagnitudeObject
+from tqdm import tqdm
 
-BASE_IMAGE_PATH = "/Users/rich/Projects/Astronomy/PiFinder/astro_data/catalog_images"
+from PiFinder import utils
 
-CATALOG_PATH = "/Users/rich/Projects/Astronomy/PiFinder/astro_data/pifinder_objects.db"
+BASE_IMAGE_PATH = f"{utils.data_dir}/catalog_images"
+
+# Catalogs that are excluded from image fetching (no meaningful survey images)
+EXCLUDED_CATALOGS = {"WDS"}
+
+SKYVIEW_URL = (
+    "https://skyview.gsfc.nasa.gov/current/cgi/runquery.pl"
+    "?Survey=digitized+sky+survey&position={ra},{dec}"
+    "&Return=JPEG&size=1&pixels=1024"
+)
+
+SDSS_URL = (
+    "https://skyserver.sdss.org/dr18/SkyServerWS/ImgCutout/getjpeg"
+    "?ra={ra}&dec={dec}&scale=3.515&width=1024&height=1024&opt="
+)
 
 
-def resolve_image_name(catalog_object, source):
-    """
-    returns the image path for this objects
-    """
-    return f"{BASE_IMAGE_PATH}/{str(catalog_object.image_name)[-1]}/{catalog_object.image_name}_{source}.jpg"
+def resolve_image_path(image_name: str, source: str) -> str:
+    last_char = str(image_name)[-1]
+    return f"{BASE_IMAGE_PATH}/{last_char}/{image_name}_{source}.jpg"
 
 
-def check_image(image):
-    """
-    Checks for defects....
-    """
-    # out of range message
+def check_sdss_image(image: Image.Image) -> bool:
+    """Check SDSS image for defects (blank/out-of-range)."""
     blank = True
     for y in range(0, 24):
-        if image.getpixel((0, y + 50)) > 0:
+        if cast(int, image.getpixel((0, y + 50))) > 0:
             blank = False
             break
     if blank:
-        print("\tSDSS Out of range")
         return False
 
     black_pixel_count = 0
@@ -44,76 +63,213 @@ def check_image(image):
         if pixel == 0:
             black_pixel_count += 1
             if black_pixel_count > 120000:
-                print("\tToo many black pixels")
                 return False
-
     return True
 
 
-def fetch_object_image(_obj, low_cut=10):
-    """
-    Check if image exists
-    or fetch it.
+def fetch_poss(
+    session: requests.Session, ra: float, dec: float, image_name: str, low_cut: int = 10
+) -> Tuple[bool, str]:
+    """Fetch POSS image from NASA SkyView."""
+    path = resolve_image_path(image_name, "POSS")
+    url = SKYVIEW_URL.format(ra=ra, dec=dec)
+    try:
+        resp = session.get(url, timeout=60)
+        if resp.status_code != 200:
+            return False, f"HTTP {resp.status_code}"
+        img: Image.Image = Image.open(BytesIO(resp.content))
+        img = img.convert("L")
+        img = ImageOps.autocontrast(img, cutoff=(low_cut, 0))
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        img.save(path)
+        return True, ""
+    except Exception as e:
+        return False, str(e)
 
-    Returns image path
-    """
-    obj_dict = dict(_obj)
-    obj_dict["size"] = SizeObject.from_json(obj_dict.get("size", ""))
-    obj_dict["mag"] = MagnitudeObject.from_json(obj_dict.get("mag", ""))
-    catalog_object = CompositeObject.from_dict(obj_dict)
-    ra = catalog_object.ra
-    dec = catalog_object.dec
 
-    object_image_path = resolve_image_name(catalog_object, "POSS")
-    if not os.path.exists(object_image_path):
-        print(f"Fetching {object_image_path}")
-        # POSS
-        # this url has less contrast and requires a low-cut on the autoconstrast
-        fetch_url = f"https://skyview.gsfc.nasa.gov/current/cgi/runquery.pl?Survey=digitized+sky+survey&position={ra},{dec}&Return=JPEG&size=1&pixels=1024"
+def fetch_sdss(
+    session: requests.Session, ra: float, dec: float, image_name: str
+) -> Tuple[bool, str]:
+    """Fetch SDSS DR18 image."""
+    path = resolve_image_path(image_name, "SDSS")
+    url = SDSS_URL.format(ra=ra, dec=dec)
+    try:
+        resp = session.get(url, timeout=60)
+        if resp.status_code != 200:
+            return False, f"HTTP {resp.status_code}"
+        img: Image.Image = Image.open(BytesIO(resp.content))
+        img = img.convert("L")
+        if not check_sdss_image(img):
+            return False, "out of range"
+        img = ImageOps.autocontrast(img)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        img.save(path)
+        return True, ""
+    except Exception as e:
+        return False, str(e)
 
-        fetched_image = Image.open(requests.get(fetch_url, stream=True).raw)
-        fetched_image = fetched_image.convert("L")
-        fetched_image = ImageOps.autocontrast(fetched_image, cutoff=(low_cut, 0))
-        fetched_image.save(object_image_path)
-        print("\tPOSS Good!")
 
-        # SDSS DR18
-        object_image_path = resolve_image_name(catalog_object, "SDSS")
-        fetch_url = f"https://skyserver.sdss.org/dr18/SkyServerWS/ImgCutout/getjpeg?ra={ra}&dec={dec}&scale=3.515&width=1024&height=1024&opt="
-        fetched_image = Image.open(requests.get(fetch_url, stream=True).raw)
-        fetched_image = fetched_image.convert("L")
+def fetch_object(
+    session: requests.Session,
+    ra: float,
+    dec: float,
+    image_name: str,
+    do_poss: bool,
+    do_sdss: bool,
+    force: bool,
+) -> Tuple[str, Dict[str, Tuple[bool, str]]]:
+    """Fetch survey images for one object."""
+    results: Dict[str, Tuple[bool, str]] = {}
 
-        # check to see if it's black (i.e. out of SDSS coverage area)
-        if check_image(fetched_image):
-            print("\tSDSS Good!")
-            fetched_image = ImageOps.autocontrast(fetched_image)
-            fetched_image.save(object_image_path)
+    if do_poss:
+        path = resolve_image_path(image_name, "POSS")
+        if force or not os.path.exists(path):
+            results["POSS"] = fetch_poss(session, ra, dec, image_name)
         else:
-            print("\tSDSS BAD!")
-            return False
+            results["POSS"] = (True, "exists")
 
-    return True
+    if do_sdss:
+        path = resolve_image_path(image_name, "SDSS")
+        if force or not os.path.exists(path):
+            results["SDSS"] = fetch_sdss(session, ra, dec, image_name)
+        else:
+            results["SDSS"] = (True, "exists")
+
+    return image_name, results
+
+
+def get_objects_to_fetch() -> List[Tuple[float, float, str]]:
+    """Get all non-WDS objects with their coordinates and image names."""
+    db_path = utils.pifinder_db
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+
+    excluded_placeholders = ",".join("?" for _ in EXCLUDED_CATALOGS)
+    cursor.execute(
+        f"""
+        SELECT DISTINCT o.ra, o.dec, oi.image_name
+        FROM objects o
+        JOIN object_images oi ON oi.object_id = o.id
+        JOIN catalog_objects co ON co.object_id = o.id
+        WHERE co.catalog_code NOT IN ({excluded_placeholders})
+          AND oi.image_name != ''
+        """,
+        list(EXCLUDED_CATALOGS),
+    )
+    rows = [(r["ra"], r["dec"], r["image_name"]) for r in cursor.fetchall()]
+    conn.close()
+    return rows
 
 
 def create_catalog_image_dirs():
-    """
-    Checks for and creates catalog_image dirs
-    """
     if not os.path.exists(BASE_IMAGE_PATH):
         os.makedirs(BASE_IMAGE_PATH)
-
     for i in range(0, 10):
-        _image_dir = f"{BASE_IMAGE_PATH}/{i}"
-        if not os.path.exists(_image_dir):
-            os.makedirs(_image_dir)
+        d = f"{BASE_IMAGE_PATH}/{i}"
+        if not os.path.exists(d):
+            os.makedirs(d)
 
 
 def main():
-    objects_db = ObjectsDatabase()
+    parser = argparse.ArgumentParser(
+        description="Fetch survey images for PiFinder objects"
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Re-fetch even if image exists"
+    )
+    parser.add_argument("--poss", action="store_true", help="Fetch POSS only")
+    parser.add_argument("--sdss", action="store_true", help="Fetch SDSS only")
+    parser.add_argument(
+        "--workers", type=int, default=10, help="Concurrent workers (default: 10)"
+    )
+    args = parser.parse_args()
+
+    do_poss = True
+    do_sdss = True
+    if args.poss and not args.sdss:
+        do_sdss = False
+    elif args.sdss and not args.poss:
+        do_poss = False
+
     create_catalog_image_dirs()
-    all_objects = objects_db.get_objects()
-    for catalog_object in tqdm(all_objects):
-        fetch_object_image(catalog_object)
+
+    print("Querying objects from database...")
+    objects = get_objects_to_fetch()
+    print(f"Found {len(objects)} objects (excluding {', '.join(EXCLUDED_CATALOGS)})")
+
+    if args.force:
+        to_fetch = objects
+        print(f"Force mode: will re-fetch all {len(to_fetch)} objects")
+    else:
+        to_fetch = []
+        for ra, dec, name in objects:
+            poss_missing = do_poss and not os.path.exists(
+                resolve_image_path(name, "POSS")
+            )
+            sdss_missing = do_sdss and not os.path.exists(
+                resolve_image_path(name, "SDSS")
+            )
+            if poss_missing or sdss_missing:
+                to_fetch.append((ra, dec, name))
+        print(f"Missing images: {len(to_fetch)} of {len(objects)}")
+
+    if not to_fetch:
+        print("Nothing to fetch!")
+        return
+
+    sources = []
+    if do_poss:
+        sources.append("POSS")
+    if do_sdss:
+        sources.append("SDSS")
+    print(f"Fetching: {', '.join(sources)} with {args.workers} workers")
+
+    session = requests.Session()
+    session.headers.update({"User-Agent": "PiFinder-ImageGenerator/2.0"})
+
+    failed: List[Tuple[str, str]] = []
+    fetched = 0
+    skipped = 0
+    t_start = time.time()
+
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = {
+            executor.submit(
+                fetch_object, session, ra, dec, name, do_poss, do_sdss, args.force
+            ): name
+            for ra, dec, name in to_fetch
+        }
+
+        for future in tqdm(
+            as_completed(futures), total=len(futures), desc="Downloading"
+        ):
+            name = futures[future]
+            try:
+                _, results = future.result()
+                for source, (ok, err) in results.items():
+                    if err == "exists":
+                        skipped += 1
+                    elif ok:
+                        fetched += 1
+                    else:
+                        failed.append((f"{name}_{source}", err))
+            except Exception as e:
+                failed.append((name, str(e)))
+
+    elapsed = time.time() - t_start
+    print(
+        f"\nDone in {elapsed:.0f}s: {fetched} fetched, {skipped} skipped, {len(failed)} failed"
+    )
+
+    if failed:
+        print(f"\nFailed ({len(failed)}):")
+        for name, err in failed[:20]:
+            print(f"  {name}: {err}")
+        if len(failed) > 20:
+            print(f"  ... and {len(failed) - 20} more")
+
+    session.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Peeled out of #394 (observing-list import), which had bundled this unrelated change.

`PiFinder.gen_images` is the offline tool that fetches catalog object thumbnails from sky surveys (NASA SkyView POSS, SDSS DR18). This reworks it without changing the fetched output format:

- **Configurable paths** — replaces hardcoded `/Users/rich/Projects/...` absolute paths with `utils.data_dir`, so it runs anywhere.
- **CLI** — `python -m PiFinder.gen_images` with `--force`, `--poss`, `--sdss`, `--workers`.
- **Concurrency** — fetches with a `ThreadPoolExecutor` instead of serially.
- **Tidy-up** — SkyView/SDSS endpoints pulled into named URL constants, helper renames (`resolve_image_path`, `check_sdss_image`), debug prints removed, `EXCLUDED_CATALOGS = {"WDS"}`.

Self-contained: the only PiFinder import is `PiFinder.utils`; no dependency on the observing-list work.

Note: verified for syntax / import / lint, but not exercised against a live survey fetch in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
