### PR TITLE
fix(ui): scroll long status values (IP) instead of truncating

### DIFF
--- a/python/PiFinder/ui/status.py
+++ b/python/PiFinder/ui/status.py
@@ -10,7 +10,7 @@ import time
 from PiFinder.ui.base import UIModule
 from PiFinder import calc_utils
 from PiFinder import utils
-from PiFinder.ui.ui_utils import TextLayouter, SpaceCalculatorFixed
+from PiFinder.ui.ui_utils import TextLayouter, TextLayouterScroll, SpaceCalculatorFixed
 from PiFinder.ui.layout import rows_below_titlebar
 
 sys_utils = utils.get_sys_utils()
@@ -27,6 +27,10 @@ class UIStatus(UIModule):
         super().__init__(*args, **kwargs)
         self._draw_pos = (0, self.display_class.titlebar_height)
         self.spacecalc = SpaceCalculatorFixed(self.fonts.base.line_length)
+        # Horizontal scrollers for values too long for their column (e.g. a long
+        # IP address), keyed by status_dict key. Created lazily on overflow so
+        # the value scrolls instead of being truncated off the right edge.
+        self.value_scrollers = {}
         self.status_dict = {
             "LAST SLV": "--",
             "RA/DEC": "--",
@@ -177,12 +181,43 @@ class UIStatus(UIModule):
             if isinstance(v, list):
                 key = v[0]
                 v = v[1]
-            _, result = self.spacecalc.calculate_spaces(key, v, empty_if_exceeds=False)
+            value = str(v)
+            field = self.spacecalc.width - len(key)
+            if 0 < field < len(value):
+                # Value overflows its column; scroll it so the whole thing
+                # stays readable instead of having the tail chopped off.
+                result = key + self._scrolled_value(k, value, field)
+            else:
+                self.value_scrollers.pop(k, None)
+                _, result = self.spacecalc.calculate_spaces(
+                    key, v, empty_if_exceeds=False
+                )
             lines.append(result)
         outline = "\n".join(lines)
         self.text_layout.set_text(outline, reset_pointer=False)
         self.text_layout.draw(pos=self._draw_pos)
         return self.screen_update()
+
+    def _scrolled_value(self, row_key: str, value: str, field: int) -> str:
+        """
+        Return a `field`-wide window of `value` that advances each frame so a
+        long value scrolls horizontally within its column. Reuses one
+        TextLayouterScroll per row, recreated when the value or column width
+        changes.
+        """
+        scroller = self.value_scrollers.get(row_key)
+        if scroller is None or scroller.text != value or scroller.width != field:
+            scroller = TextLayouterScroll(
+                value,
+                draw=self.draw,
+                color=self.colors.get(255),
+                font=self.fonts.base,
+                width=field,
+                scrollspeed=TextLayouterScroll.MEDIUM,
+            )
+            self.value_scrollers[row_key] = scroller
+        scroller.layout()
+        return scroller.object_text[0] if scroller.object_text else value[:field]
 
     def key_up(self):
         self.text_layout.previous()

--- a/python/PiFinder/ui/status.py
+++ b/python/PiFinder/ui/status.py
@@ -174,29 +174,36 @@ class UIStatus(UIModule):
     def update(self, force=False):
         self.update_status_dict()
         self.clear_screen()
-        lines = []
-        # Insert IP address here...
-        for k, v in self.status_dict.items():
-            key = f"{k:<7}"
-            if isinstance(v, list):
-                key = v[0]
-                v = v[1]
-            value = str(v)
-            field = self.spacecalc.width - len(key)
-            if 0 < field < len(value):
-                # Value overflows its column; scroll it so the whole thing
-                # stays readable instead of having the tail chopped off.
-                result = key + self._scrolled_value(k, value, field)
-            else:
-                self.value_scrollers.pop(k, None)
-                _, result = self.spacecalc.calculate_spaces(
-                    key, v, empty_if_exceeds=False
-                )
-            lines.append(result)
-        outline = "\n".join(lines)
-        self.text_layout.set_text(outline, reset_pointer=False)
+        lines = [self._render_row(k, v) for k, v in self.status_dict.items()]
+        self.text_layout.set_text("\n".join(lines), reset_pointer=False)
         self.text_layout.draw(pos=self._draw_pos)
         return self.screen_update()
+
+    def _render_row(self, k, v) -> str:
+        """
+        Render one status row as ``key`` followed by its value.
+
+        The value is justified into its column with SpaceCalculatorFixed when it
+        fits, or rendered through a per-row horizontal scroller (see
+        _scrolled_value) when it overflows, so long values (a long IP address or
+        SSID) stay readable instead of being truncated. The scroller is dropped
+        again as soon as the value fits, so a row flips between static and
+        scrolling as its value changes.
+        """
+        key = f"{k:<7}"
+        if isinstance(v, list):
+            # Rows with a runtime-computed label (e.g. GPS, whose label embeds
+            # the live satellite count) carry [label, value] and supply their
+            # own label instead of the padded dict key.
+            key = v[0]
+            v = v[1]
+        value = str(v)
+        field = self.spacecalc.width - len(key)
+        if 0 < field < len(value):
+            return key + self._scrolled_value(k, value, field)
+        self.value_scrollers.pop(k, None)
+        _, result = self.spacecalc.calculate_spaces(key, v, empty_if_exceeds=False)
+        return result
 
     def _scrolled_value(self, row_key: str, value: str, field: int) -> str:
         """

--- a/python/tests/test_status_scroll.py
+++ b/python/tests/test_status_scroll.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for the STATUS screen's per-row rendering (UIStatus._render_row):
+values that fit render statically, values that overflow their column scroll,
+and a row flips correctly between the two as its value changes (e.g. the IP
+address or SSID changing at runtime), dropping the scroller again when a value
+shrinks back to fitting.
+"""
+
+import pytest
+from PIL import Image, ImageDraw
+
+# Installs the _() gettext builtin the UI modules rely on; must precede ui imports.
+import PiFinder.i18n  # noqa: F401
+
+from PiFinder.displays import get_display
+from PiFinder.ui.status import UIStatus
+from PiFinder.ui.ui_utils import SpaceCalculatorFixed
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def status():
+    """A minimal UIStatus carrying only the attributes _render_row /
+    _scrolled_value touch, backed by a real headless display (real fonts /
+    colors), constructed without the heavy UIModule.__init__."""
+    display = get_display("headless")
+    s = UIStatus.__new__(UIStatus)
+    s.display_class = display
+    s.colors = display.colors
+    s.fonts = display.fonts
+    s.draw = ImageDraw.Draw(Image.new("RGBA", display.resolution), mode="RGBA")
+    s.spacecalc = SpaceCalculatorFixed(display.fonts.base.line_length)
+    s.value_scrollers = {}
+    return s
+
+
+def _field(status, key="IP"):
+    # _render_row left-pads the key to 7 chars, so the value column is width - 7.
+    return status.spacecalc.width - len(f"{key:<7}")
+
+
+def test_short_value_renders_static_without_scroller(status):
+    field = _field(status)
+    short = "x" * (field - 1)
+    line = status._render_row("IP", short)
+    assert "IP" not in status.value_scrollers  # no scroller for a fitting value
+    assert short in line  # full value stays visible
+
+
+def test_long_value_creates_scroller(status):
+    field = _field(status)
+    long = "1" * (field + 5)
+    status._render_row("IP", long)
+    assert "IP" in status.value_scrollers
+    assert status.value_scrollers["IP"].text == long
+
+
+def test_static_to_scroller_transition(status):
+    field = _field(status)
+    status._render_row("IP", "x" * (field - 1))  # fits -> static
+    assert "IP" not in status.value_scrollers
+    status._render_row("IP", "9" * (field + 5))  # now overflows -> scroller appears
+    assert "IP" in status.value_scrollers
+
+
+def test_scroller_to_static_transition_drops_scroller(status):
+    field = _field(status)
+    status._render_row("IP", "9" * (field + 5))  # overflows -> scroller
+    assert "IP" in status.value_scrollers
+    status._render_row("IP", "x" * (field - 1))  # fits again -> scroller dropped
+    assert "IP" not in status.value_scrollers
+
+
+def test_value_change_while_overflowing_recreates_scroller(status):
+    field = _field(status)
+    long_a = "a" * (field + 5)
+    long_b = "b" * (field + 8)
+    status._render_row("IP", long_a)
+    scroller_a = status.value_scrollers["IP"]
+    assert scroller_a.text == long_a
+    status._render_row("IP", long_b)
+    scroller_b = status.value_scrollers["IP"]
+    assert scroller_b.text == long_b
+    assert scroller_b is not scroller_a  # recreated for the new value
+
+
+def test_rows_scroll_independently(status):
+    field_ip = status.spacecalc.width - len(f"{'IP':<7}")
+    field_ssid = status.spacecalc.width - len(f"{'SSID':<7}")
+    status._render_row("IP", "1" * (field_ip + 5))
+    status._render_row("SSID", "N" * (field_ssid + 5))
+    assert "IP" in status.value_scrollers
+    assert "SSID" in status.value_scrollers
+    assert status.value_scrollers["IP"] is not status.value_scrollers["SSID"]
+
+
+def test_dynamic_label_row_unpacks_label_and_value(status):
+    # The GPS row supplies a runtime-computed label (live sat count) as
+    # [label, value], so _render_row uses that label rather than the dict key.
+    line = status._render_row("GPS", ["GPS 7/12", "1.0/2.0"])
+    assert line.startswith("GPS 7/12")  # list label used as the row label
+    assert "1.0/2.0" in line  # short value rendered statically


### PR DESCRIPTION
## What

Status-screen values that are wider than the display (most visibly the IP
address) are currently truncated, so you can't read the whole value. This makes
those long values **scroll horizontally** instead, so the full text is legible.

## Changes

- `python/PiFinder/ui/status.py` — scroll overflowing status values instead of
  truncating them.

Single commit, based directly on `main`.
