### PR TITLE
fix(obs-list): apply active filter to observing lists

### DIFF
--- a/python/PiFinder/ui/object_list.py
+++ b/python/PiFinder/ui/object_list.py
@@ -199,7 +199,13 @@ class UIObjectList(UITextMenu):
 
         if self.item_definition["objects"] == "custom":
             # item_definition must contain a list of CompositeObjects
-            self._menu_items = self.item_definition["object_list"]
+            object_list = self.item_definition["object_list"]
+            # Opt-in filtering: observing lists honour the active filter
+            # (altitude, magnitude, etc); ad-hoc lists like name-search
+            # results are shown as-is.
+            if self.item_definition.get("filtered", False):
+                object_list = self.catalogs.catalog_filter.apply(object_list)
+            self._menu_items = object_list
 
         self.catalog_info_1 = str(self.get_nr_of_menu_items())
         self._menu_items_sorted = self._menu_items

--- a/python/PiFinder/ui/obs_list.py
+++ b/python/PiFinder/ui/obs_list.py
@@ -165,6 +165,7 @@ class UIObsList(UITextMenu):
             "class": UIObjectList,
             "objects": "custom",
             "object_list": catalog_objects,
+            "filtered": True,
             "label": "obs_list",
         }
         self.add_to_stack(object_list_def)


### PR DESCRIPTION
## Problem

After loading an observing (Ops) list, changing the **altitude** filter (or any filter) did nothing — the object count never changed.

## Cause

When an observing list is opened it's pushed to `UIObjectList` as a `"custom"` object source. In `refresh_object_list()`, the `"custom"` branch assigned the list straight through:

```python
if self.item_definition["objects"] == "custom":
    self._menu_items = self.item_definition["object_list"]
```

Unlike the `catalog` / `catalogs.filtered` branches, it never ran the objects through `catalog_filter`, so no filter was ever applied to an observing list.

## Fix

Run `"custom"` lists through `catalog_filter.apply()`, gated by a new `"filtered"` flag in the item definition so only observing lists opt in. The other `"custom"` consumer — name-search results — stays unfiltered on purpose, so searching for an object by name doesn't return zero results when it happens to be below the altitude cutoff.

## Testing

Verified by driving the app headlessly (`-fh --camera debug`, which fakes a GPS fix so `altaz_ready()` is true and the altitude filter actually engages):

- Loaded `messier_marathon`, altitude filter **None** → full list (~111 objects).
- Set altitude filter to **40°** → list dropped to ~30 objects.

Measured via the scrollbar thumb height (= track ÷ total): 1px → 4px, confirming the count changed. Before this change the count stayed put regardless of the filter.

`ruff check` passes on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)