### PR TITLE
docs: fill v2.6.0 user-facing gaps (mounting, chart orientation, manual place/time, web i18n)

### DIFF
--- a/docs/source/connectivity.rst
+++ b/docs/source/connectivity.rst
@@ -48,6 +48,7 @@ The PiFinder's web interface lets you:
 * Add and edit your telescopes and eyepieces (see :doc:`equipment`)
 * Back up and restore your observing logs, settings, and other data
 * View and download your logged observations
+* Choose or upload a logging configuration to capture detailed logs for a bug report
 
 To reach the web interface for the first time, make sure the PiFinder is in Access Point mode (see :ref:`user_guide:settings menu`) — the default for new PiFinders, to ease first-time setup.  From a phone, tablet, or computer, connect to the PiFinder's open wireless network, PiFinderAP (no password), then open your browser and visit:
 ``http://pifinder.local``
@@ -74,6 +75,10 @@ is the same as the ``pifinder`` user's; changing one changes the other.  The def
 images and PiFinders is ``solveit``, and you can change it from the Tools option in the web
 interface.
 
+The web interface is available in English, German, French, and Spanish.  It follows your
+browser's preferred language, so set the language on your phone or computer and the pages
+follow suit.
+
 Connecting to a new WiFi network
 ---------------------------------
 
@@ -96,6 +101,15 @@ WiFi network with Internet access, follow these steps:
 11) Click the 'UPDATE AND RESTART' button
 
 To add more WiFi networks, navigate to the Network Setup page of the :ref:`connectivity:web interface`, click the + button near the WiFi networks list, and repeat the steps above.
+
+Logging configuration
+---------------------
+
+When you're tracking down a problem, the Logs page of the web interface can turn up the
+detail the PiFinder records.  Pick one of the built-in configurations — default, debug, or
+webserver — or upload your own, and the PiFinder restarts with it in place.  The richer logs
+make it much easier to capture what happened for a bug report; switch back to default when
+you're done.
 
 SkySafari and Planetarium Apps
 ==============================

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -151,15 +151,14 @@ PiFinders attach the same way.
 .. image:: images/quick_start/pifinder_mounted.jpeg
    :width: 47%
 
-Mount the PiFinder close to perpendicular to the ground, or it won't be as accurate when
-estimating position as you move. The PiFinder always knows where it's looking and assumes
-it's perpendicular to the earth, giving its instructions on that basis.
+The PiFinder works out its own orientation, so it no longer needs to sit perfectly upright
+— any mounting angle is fine, as long as the camera points where the scope points. You may
+still prefer it roughly level so the screen is easy to read.
 
-The dovetail is adjustable so the PiFinder can sit upright even if your finder shoe isn't
-right at the top of the optical tube. Loosen the two dovetail screws, set the PiFinder on
-your scope, and adjust the angle until it's roughly perpendicular to the ground. Once
-you're happy, remove the PiFinder and tighten the two screws. You're all set for a night
-of observing.
+The dovetail is adjustable, so you can set a comfortable angle even if your finder shoe
+isn't right at the top of the optical tube. Loosen the two dovetail screws, set the PiFinder
+on your scope, adjust the angle to suit, then remove it and tighten the two screws. You're
+all set for a night of observing.
 
 .. note::
    * Mount the PiFinder so the camera has an unimpeded view of the sky.
@@ -217,6 +216,11 @@ relying on the accelerometer. An 'X' means it hasn't worked out where it's point
 
    Leaving the PiFinder on the GPS Status screen speeds up the lock: this screen disables
    the camera, which reduces EM noise and helps the receiver see more satellites.
+
+.. note::
+   No GPS, or don't want to wait for a lock?  You can enter your location and time by hand
+   and start using the PiFinder right away — see :ref:`Place & Time <user_guide:place & time>`
+   in the User Guide.
 
 
 

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -32,7 +32,9 @@ which section of sky it's seeing — incredibly fast (up to 20 times per second!
 accurately.  This only works while the scope is still, so it pairs that camera with an
 accelerometer (the IMU, as the Status screen and Settings menu call it) that estimates
 how far the scope has moved since the last solve.  The
-estimate carries some error, but the moment you stop, a fresh photo corrects it.
+estimate carries some error, but the moment you stop, a fresh photo corrects it.  The
+PiFinder works out its own orientation as it solves, so it can be mounted at any angle —
+it doesn't need to sit upright — as long as the camera points the same way as your scope.
 
 Knowing where your scope points and where thousands of interesting objects sit, the
 PiFinder combines the two to show you how to move the scope to bring any of those objects
@@ -254,6 +256,12 @@ view, getting them below 0.25 (half the true field) should put the object in vie
 Closer to zero means more centered.  For a very dim object, knowing it's dead center and
 consulting the object image can make all the difference.
 
+.. note::
+   By default the Push-To arrows guide you in altitude and azimuth — the way an Alt/Az or
+   Dobsonian mount moves.  On an equatorial mount or platform, set Mount Type to Equatorial
+   in the :ref:`user_guide:settings menu` and the guidance switches to right ascension and
+   declination to match your mount's axes.
+
 The number in the upper right is the object's
 :ref:`contrast reserve <user_guide:contrast reserve>` — an estimate of how easily it
 should show in your eyepiece tonight.
@@ -329,6 +337,34 @@ brightness — the number is simply left off.
    conditions: the same object reads higher under a dark sky than from town.  Treat it as a
    guide rather than a guarantee — averted vision, transparency, and how dark-adapted you
    are all still play their part at the eyepiece.
+
+Star Chart
+-------------
+
+The Star Chart, reached from the main PiFinder menu, draws a live map of the sky around
+where your telescope is pointing, with constellation lines and markers for nearby objects.
+It redraws as you move the scope, so it's a quick way to see what's around you and confirm
+your aim.  Zoom in and out with the **+/-** keys.
+
+How the chart is turned is up to you.  Choose Coordinate Sys. under Chart... in the
+:ref:`user_guide:settings menu`:
+
+- **Horizontal** (the default) keeps the horizon level and the zenith up, matching what you
+  see with the naked eye.
+- **EQ (Auto)** lines the chart up with the celestial pole — north-up in the northern
+  hemisphere, south-up in the southern.
+- **EQ (North-up)** and **EQ (South-up)** force north-up or south-up wherever you are.
+
+The chart labels what's currently at the top — "Zenith up", "NCP up" (north celestial
+pole), or "SCP up" (south celestial pole) — so you always know how it's oriented.  The same
+orientation applies to the Align screen.
+
+.. note::
+   The chart works before the PiFinder has a GPS fix.  The Horizontal and EQ (Auto) modes
+   need to know where you are to orient themselves, so until GPS locks — or you
+   :ref:`enter your location by hand <user_guide:place & time>` — the chart falls back to
+   north-celestial-pole-up and marks the label with a leading "!" (for example "!NCP up")
+   to show it's a temporary orientation that settles once your location is known.
 
 Filters
 ----------
@@ -792,6 +828,31 @@ Some of the key information shown:
   the number of stars matched.
 - WiFi information a bit further down, including the current WiFi mode, network name, and
   IP address.
+
+Place & Time
+----------------------------------
+
+The PiFinder needs to know where and when it is to turn the sky's coordinates into the
+directions it gives you.  Its built-in GPS handles this automatically, but you don't have
+to wait for a fix — or have GPS at all — to get going.  Open Tools, then Place & Time, to
+set everything by hand.
+
+Set Location gathers the ways to manage your observing site:
+
+- **Enter Coords** lets you type your latitude, then longitude, then altitude with the
+  number keys.  The **+** key flips the sign for southern latitudes and western longitudes.
+- **Load Location** recalls one of your saved sites, and **Save Location** stores the
+  current one so you can pick it again next time.
+
+Set Time/Date sets the clock when there's no GPS: enter the time and the PiFinder moves on
+to a date-entry screen.  A time you set by hand is protected — a later GPS fix won't
+overwrite it — so your manual clock stays put.  Reset Location and Reset Time/Date discard
+what's set if you'd rather start fresh or hand control back to GPS.
+
+.. note::
+   With your location and time set by hand, the PiFinder is fully usable without a GPS
+   signal — you can focus, align, browse objects, and push to them.  The
+   :ref:`user_guide:star chart` and Align screens also work before a GPS lock.
 
 Update Software
 ------------------


### PR DESCRIPTION
## What & why

Preparing for the 2.6.0 release, I cross-checked the `release` → `main` delta (104 commits) against the published docs, using `RELEASE.md` as the feature list. Most features already shipped with docs; this PR fills the four **user-facing** gaps that didn't have coverage.

## Changes

**`quick_start.rst`**
- Correct the stale *Mounting* text. It claimed the PiFinder must sit perpendicular and "assumes it's perpendicular to the earth" — no longer true. The rewritten IMU (quaternion dead-reckoning) works out its own orientation, so any mounting angle is fine as long as the camera points where the scope points.
- Add a note that you can enter location/time by hand and use the PiFinder without waiting for (or having) a GPS fix.

**`user_guide.rst`**
- Add the any-mounting-angle fact to *How It Works*.
- Add a Push-To note: `Mount Type → Equatorial` switches guidance to right ascension / declination.
- New **Star Chart** section: `Coordinate Sys.` options (Horizontal default / EQ Auto / North-up / South-up), the "Zenith up / NCP up / SCP up" labels, the "!" GPS-not-ready fallback, and that the chart works before GPS lock.
- New **Place & Time** section under Tools: Enter Coords (lat → lon → altitude), Set Time/Date chaining, GPS-overwrite protection, and "fully usable without GPS".

**`connectivity.rst`**
- Document the web interface's DE/FR/ES language support and the Logs configuration switch/upload feature.

## Verification
- Every claim checked against the code (IMU dead-reckoning, `aim_degrees`, `chart.py`, `locationentry.py`, `server.py`).
- `sphinx-build -n` (nitpicky) is clean — no warnings/errors; all new `:ref:` anchors resolve.

## ⚠️ Two RELEASE.md claims that don't match the code
These are **not** reflected in the docs (I documented the verified behavior instead) — worth correcting in the release notes:
1. **"Mount Type → Equatorial enables IMU tracking."** It doesn't — the IMU runs for both mount types. `Mount Type` only sets the Push-To axis style (Alt/Az vs RA/Dec).
2. **"Changing the UI language also translates the web interface after a restart."** The web locale comes from the browser's `Accept-Language` (`server.py:90`), not the device Language setting, and isn't restart-gated.

## Out of scope (deliberately deferred)
Secondary/dev gaps: SQM enhancements, `--display ssd1333`/headless flags + SSD1351 brightness, telemetry; plus the undocumented planet-names change and two orphaned focus images. New sections are prose-only — optional screenshots could follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)