### PR TITLE
test(web): fix remote-nav sequences for current menu layout

### DIFF
--- a/python/tests/website/test_web_locations.py
+++ b/python/tests/website/test_web_locations.py
@@ -500,7 +500,7 @@ def test_locations_add_remote(driver):
     # before the API validation call (needed especially in Firefox).
     press_keys_and_validate(
         driver,
-        "ZLZLWUUUUUUURDDW",
+        "ZLZLWUUUUUUURDDDW",
         expected_values={
             "ui_type": "UITextMenu",
             "title": "Start",

--- a/python/tests/website/test_web_remote.py
+++ b/python/tests/website/test_web_remote.py
@@ -497,7 +497,7 @@ def test_remote_entry(driver):
 
     press_keys_and_validate(
         driver,
-        "RDDDDR",
+        "RDDDDDR",
         expected_values={
             "ui_type": "UITextEntry",
             "title": "Search",
@@ -524,7 +524,7 @@ def test_remote_entry_digits(driver):
 
     press_keys_and_validate(
         driver,
-        "RDDDDR0123456789",
+        "RDDDDDR0123456789",
         expected_values={
             "ui_type": "UITextEntry",
             "title": "Search",

--- a/python/tests/website/test_web_remote_filter.py
+++ b/python/tests/website/test_web_remote_filter.py
@@ -16,9 +16,10 @@ Objects submenu (entered from root Objects → R) items (0-indexed):
   0: All Filtered
   1: By Catalog
   2: Recent
-  3: Custom
-  4: Name Search
-  5: Set Filters   ← this menu
+  3: Obs Lists
+  4: Custom
+  5: Name Search
+  6: Set Filters   ← this menu
 
 Set Filters submenu (0-indexed):
   0: Reset All  (confirmation submenu with Confirm / Cancel)
@@ -29,10 +30,10 @@ Set Filters submenu (0-indexed):
   5: Observed   (single-select: Any, Observed, Not Observed)
 
 Key sequence from navigate_to_root_menu() (lands on Objects in root menu):
-  R       → enter Objects (lands on All Filtered, index 0)
-  DDDDD   → highlight Set Filters (index 5)
-  R       → enter Set Filters submenu (now at Reset All, index 0)
-  i.e. "RDDDDDR" enters Set Filters at Reset All.
+  R        → enter Objects (lands on All Filtered, index 0)
+  DDDDDD   → highlight Set Filters (index 6)
+  R        → enter Set Filters submenu (now at Reset All, index 0)
+  i.e. "RDDDDDDR" enters Set Filters at Reset All.
 
 All tests that change filter values use Reset All > Confirm to restore defaults
 before exiting, keeping filter state neutral for subsequent tests.
@@ -49,10 +50,10 @@ def test_filter_menu_entry(driver):
     login_to_remote(driver)
     navigate_to_root_menu(driver)
 
-    # RDDDDD = enter Objects, down to Set Filters (index 5); R = enter it
+    # RDDDDDD = enter Objects, down to Set Filters (index 6); R = enter it
     press_keys_and_validate(
         driver,
-        "RDDDDDR",
+        "RDDDDDDR",
         {
             "ui_type": "UITextMenu",
             "title": "Set Filters",
@@ -69,10 +70,10 @@ def test_filter_reset_all_shows_confirm_cancel(driver):
     login_to_remote(driver)
     navigate_to_root_menu(driver)
 
-    # RDDDDDR = enter Set Filters at Reset All; R = enter the confirmation submenu
+    # RDDDDDDR = enter Set Filters at Reset All; R = enter the confirmation submenu
     press_keys_and_validate(
         driver,
-        "RDDDDDRR",
+        "RDDDDDDRR",
         {
             "ui_type": "UITextMenu",
             "title": "Reset All",
@@ -89,10 +90,10 @@ def test_filter_reset_all_cancel_returns_to_filter(driver):
     login_to_remote(driver)
     navigate_to_root_menu(driver)
 
-    # RDDDDDRR = enter Reset All confirmation; D = move to Cancel; R = select Cancel
+    # RDDDDDDRR = enter Reset All confirmation; D = move to Cancel; R = select Cancel
     press_keys_and_validate(
         driver,
-        "RDDDDDRRDR",
+        "RDDDDDDRRDR",
         {
             "ui_type": "UITextMenu",
             "title": "Set Filters",
@@ -108,10 +109,10 @@ def test_filter_reset_all_confirm_resets_filters(driver):
     login_to_remote(driver)
     navigate_to_root_menu(driver)
 
-    # RDDDDDRR = enter Reset All confirmation; R = select Confirm
+    # RDDDDDDRR = enter Reset All confirmation; R = select Confirm
     press_keys_and_validate(
         driver,
-        "RDDDDDRRR",
+        "RDDDDDDRRR",
         {
             "ui_type": "UITextMenu",
             "title": "Set Filters",
@@ -127,10 +128,10 @@ def test_filter_catalogs_entry(driver):
     login_to_remote(driver)
     navigate_to_root_menu(driver)
 
-    # RDDDDDR = enter Set Filters at Reset All; DR = D to Catalogs (index 1), R to enter
+    # RDDDDDDR = enter Set Filters at Reset All; DR = D to Catalogs (index 1), R to enter
     press_keys_and_validate(
         driver,
-        "RDDDDDRDR",
+        "RDDDDDDRDR",
         {
             "ui_type": "UITextMenu",
             "title": "Catalogs",
@@ -146,10 +147,10 @@ def test_filter_type_entry(driver):
     login_to_remote(driver)
     navigate_to_root_menu(driver)
 
-    # RDDDDDR = enter Set Filters; DDR = DD to Type (index 2), R to enter
+    # RDDDDDDR = enter Set Filters; DDR = DD to Type (index 2), R to enter
     press_keys_and_validate(
         driver,
-        "RDDDDDRDDR",
+        "RDDDDDDRDDR",
         {
             "ui_type": "UITextMenu",
             "title": "Type",
@@ -165,10 +166,10 @@ def test_filter_altitude_entry(driver):
     login_to_remote(driver)
     navigate_to_root_menu(driver)
 
-    # RDDDDDR = enter Set Filters; DDDR = DDD to Altitude (index 3), R to enter
+    # RDDDDDDR = enter Set Filters; DDDR = DDD to Altitude (index 3), R to enter
     press_keys_and_validate(
         driver,
-        "RDDDDDRDDDR",
+        "RDDDDDDRDDDR",
         {
             "ui_type": "UITextMenu",
             "title": "Altitude",
@@ -184,12 +185,12 @@ def test_filter_altitude_select_and_reset(driver):
     login_to_remote(driver)
     navigate_to_root_menu(driver)
 
-    # Enter Altitude: RDDDDDR (Set Filters) + DDDR (navigate to Altitude) + R (enter)
+    # Enter Altitude: RDDDDDDR (Set Filters) + DDDR (navigate to Altitude) + R (enter)
     # Altitude items: None (0), 0° (1), 10° (2), 20° (3), 30° (4), 40° (5)
     # DD = move to 10°; R = select → returns to Set Filters menu
     press_keys_and_validate(
         driver,
-        "RDDDDDRDDDRR",  # enter Altitude (now at None, index 0)
+        "RDDDDDDRDDDRR",  # enter Altitude (now at None, index 0)
         {"ui_type": "UITextMenu", "title": "Altitude"},
     )
     press_keys_and_validate(
@@ -215,10 +216,10 @@ def test_filter_magnitude_entry(driver):
     login_to_remote(driver)
     navigate_to_root_menu(driver)
 
-    # RDDDDDR = enter Set Filters; DDDDR = DDDD to Magnitude (index 4), R to enter
+    # RDDDDDDR = enter Set Filters; DDDDR = DDDD to Magnitude (index 4), R to enter
     press_keys_and_validate(
         driver,
-        "RDDDDDRDDDDR",
+        "RDDDDDDRDDDDR",
         {
             "ui_type": "UITextMenu",
             "title": "Magnitude",
@@ -234,10 +235,10 @@ def test_filter_observed_entry(driver):
     login_to_remote(driver)
     navigate_to_root_menu(driver)
 
-    # RDDDDDR = enter Set Filters; DDDDDR = DDDDD to Observed (index 5), R to enter
+    # RDDDDDDR = enter Set Filters; DDDDDR = DDDDD to Observed (index 5), R to enter
     press_keys_and_validate(
         driver,
-        "RDDDDDRDDDDDR",
+        "RDDDDDDRDDDDDR",
         {
             "ui_type": "UITextMenu",
             "title": "Observed",
@@ -257,7 +258,7 @@ def test_filter_observed_select_and_reset(driver):
     # Observed items: Any (0), Observed (1), Not Observed (2)
     press_keys_and_validate(
         driver,
-        "RDDDDDRDDDDDRR",  # enter Set Filters + navigate to Observed + enter
+        "RDDDDDDRDDDDDRR",  # enter Set Filters + navigate to Observed + enter
         {"ui_type": "UITextMenu", "title": "Observed"},
     )
     press_keys_and_validate(

--- a/python/tests/website/test_web_remote_objects.py
+++ b/python/tests/website/test_web_remote_objects.py
@@ -26,9 +26,10 @@ Objects submenu (entered from root menu Objects → R) items (0-indexed):
   0: All Filtered  (UIObjectList)
   1: By Catalog    (submenu)
   2: Recent        (UIObjectList)
-  3: Custom        (UIRADecEntry)
-  4: Name Search   (UITextEntry)  ← already tested in test_web_remote.py
-  5: Set Filters   (submenu)      ← navigation tested in test_web_remote_filter.py
+  3: Obs Lists     (UIObjectList)
+  4: Custom        (UIRADecEntry)
+  5: Name Search   (UITextEntry)  ← already tested in test_web_remote.py
+  6: Set Filters   (submenu)      ← navigation tested in test_web_remote_filter.py
 
 By Catalog submenu (0-indexed):
   0: Planets   (UIObjectList, catalog "PL")
@@ -39,12 +40,13 @@ By Catalog submenu (0-indexed):
   5: Stars...  (nested UITextMenu submenu)
 
 Key sequences from navigate_to_root_menu() (lands on Objects in root menu):
-  R     → enter Objects submenu (now at All Filtered, index 0)
-  D     → By Catalog (index 1)
-  DD    → Recent     (index 2)
-  DDD   → Custom     (index 3)
-  DDDD  → Name Search (index 4) ← confirmed by test_remote_entry in test_web_remote.py
-  DDDDD → Set Filters (index 5) ← see test_web_remote_filter.py
+  R      → enter Objects submenu (now at All Filtered, index 0)
+  D      → By Catalog (index 1)
+  DD     → Recent     (index 2)
+  DDD    → Obs Lists  (index 3)
+  DDDD   → Custom     (index 4)
+  DDDDD  → Name Search (index 5) ← confirmed by test_remote_entry in test_web_remote.py
+  DDDDDD → Set Filters (index 6) ← see test_web_remote_filter.py
 """
 
 # ---------------------------------------------------------------------------
@@ -282,10 +284,10 @@ def test_objects_custom_radec_entry_screen(driver):
     navigate_to_root_menu(driver)
 
     # R = Objects submenu at All Filtered (0)
-    # DDD = Custom (index 3); R = enter UIRADecEntry
+    # DDDD = Custom (index 4); R = enter UIRADecEntry
     press_keys_and_validate(
         driver,
-        "RDDDR",
+        "RDDDDR",
         {
             "ui_type": "UIRADecEntry",
         },
@@ -301,15 +303,15 @@ def test_objects_custom_radec_entry_screen(driver):
 
 @pytest.mark.web
 def test_objects_set_filters_is_last_item(driver):
-    """Set Filters is the last Objects item (index 5) and opens the filter menu."""
+    """Set Filters is the last Objects item (index 6) and opens the filter menu."""
     login_to_remote(driver)
     navigate_to_root_menu(driver)
 
     # R = Objects submenu at All Filtered (0)
-    # DDDDD = Set Filters (index 5); R = enter the Set Filters submenu at Reset All
+    # DDDDDD = Set Filters (index 6); R = enter the Set Filters submenu at Reset All
     press_keys_and_validate(
         driver,
-        "RDDDDDR",
+        "RDDDDDDR",
         {
             "ui_type": "UITextMenu",
             "title": "Set Filters",


### PR DESCRIPTION
## Summary

The Selenium web tests drive PiFinder's remote keypad with fixed key sequences and assert the resulting screen (`ui_type`/`title`/`current_item`). Two menu changes on `main` shifted item indices, **deterministically** breaking 16 navigation tests (not flakiness — confirmed by re-running in isolation):

- **Objects submenu** gained an **"Obs Lists"** item at index 3, shifting Custom (3→4), Name Search (4→5) and Set Filters (5→6).
- **Start submenu** reordered so **GPS Status** is now index 3 (was 2): `Focus, Align, Align (Day), GPS Status`.

The real menu order was confirmed by driving a live headless instance and reading `/api/current-selection` after each keypress.

## Changes

| File | Tests | Fix |
|---|---|---|
| `test_web_remote_filter.py` | 11 | Objects→Set Filters hop `RDDDDD`→`RDDDDDD` (+ docstring/comments) |
| `test_web_remote_objects.py` | 2 | Custom `RDDDR`→`RDDDDR`; Set Filters `RDDDDDR`→`RDDDDDDR` (+ docstring) |
| `test_web_remote.py` | 2 | Name Search `RDDDDR`→`RDDDDDR` (`test_remote_entry`, `test_remote_entry_digits`) |
| `test_web_locations.py` | 1 | `test_locations_add_remote`: Start→GPS Status `RDD`→`RDDD` |

Only key sequences and their docstrings/comments changed — no assertions or test logic altered.

## Validation

Run against a live headless PiFinder instance:
- Filter file: clean batch **11/11 passed**
- Objects (2), remote-entry (2), locations-add-remote (1): **all passed** → **16/16**

## Out of scope

The two other failures in the current `-m web` run — `test_locations_testloc_present` and `test_locations_add_test_locations` — are **not** navigation. Both pass in isolation; they're order/state-dependent (a definition-order data dependency and a Materialize form-CRUD first-add timing issue). Left unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)