### PR TITLE
ci: activate NixOS testable-PR builder on the default branch (release)

### DIFF
--- a/.github/scripts/publish_manifest.sh
+++ b/.github/scripts/publish_manifest.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Update update-manifest.json on the metadata-only `nixos-manifest` branch.
+#
+# The branch holds only that one JSON file; it carries no source tree. The job
+# here is just: read the current manifest, let the updater rewrite its entry,
+# and push. Concurrency-safe: a git ref update is compare-and-swap, so if a
+# concurrent writer lands first our push is rejected, and we re-fetch the new
+# tip, re-apply this run's entry onto it, and retry.
+#
+# Usage:
+#   publish_manifest.sh "<commit message>" <updater argv...>
+# The updater argv contains the literal token @MANIFEST@, replaced with the
+# manifest path on each attempt. It must be idempotent (replaces its own entry).
+set -euo pipefail
+
+BRANCH="nixos-manifest"
+COMMIT_MSG="$1"
+shift
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+WORKTREE="$(mktemp -d)"
+trap 'git worktree remove --force "$WORKTREE" >/dev/null 2>&1 || true' EXIT
+git worktree add --detach "$WORKTREE" >/dev/null
+MANIFEST="$WORKTREE/update-manifest.json"
+
+for attempt in 1 2 3 4 5; do
+  git fetch origin "$BRANCH" >/dev/null 2>&1 || true
+
+  if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+    # reset --hard so a retry after a rejected push starts from the true tip,
+    # not the stale entry from the previous attempt (which would otherwise
+    # silently drop the concurrent writer's change).
+    git -C "$WORKTREE" checkout -q -B "$BRANCH" "refs/remotes/origin/$BRANCH"
+    git -C "$WORKTREE" reset -q --hard "refs/remotes/origin/$BRANCH"
+  else
+    # Branch does not exist yet: start it empty.
+    git -C "$WORKTREE" checkout -q --orphan "$BRANCH"
+    git -C "$WORKTREE" rm -rfq --cached . >/dev/null 2>&1 || true
+  fi
+
+  cmd=()
+  for arg in "$@"; do
+    cmd+=( "${arg/@MANIFEST@/$MANIFEST}" )
+  done
+  "${cmd[@]}"
+
+  git -C "$WORKTREE" add update-manifest.json
+  if git -C "$WORKTREE" diff --staged --quiet; then
+    echo "Manifest unchanged"
+    exit 0
+  fi
+
+  git -C "$WORKTREE" commit -q -m "$COMMIT_MSG"
+  if git -C "$WORKTREE" push origin "HEAD:$BRANCH" 2>/dev/null; then
+    echo "Manifest published (attempt $attempt)"
+    exit 0
+  fi
+
+  echo "Push rejected by a concurrent update; retrying ($attempt/5)"
+  sleep $((attempt * 2))
+done
+
+echo "Failed to publish manifest after 5 attempts" >&2
+exit 1

--- a/.github/scripts/update_manifest.py
+++ b/.github/scripts/update_manifest.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Update the generated PiFinder software update manifest."""
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+STORE_PATH_RE = re.compile(r"^/nix/store/[a-z0-9]+-[A-Za-z0-9._+=?,-]+$")
+EMPTY_MANIFEST = {
+    "schema": 1,
+    "generated_at": None,
+    "channels": {
+        "stable": [],
+        "beta": [],
+        "unstable": [],
+    },
+}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def load_manifest(path: Path) -> dict:
+    if not path.exists():
+        return json.loads(json.dumps(EMPTY_MANIFEST))
+    with path.open() as f:
+        data = json.load(f)
+    if data.get("schema") != 1:
+        raise SystemExit(f"unsupported manifest schema in {path}")
+    channels = data.setdefault("channels", {})
+    for name in ("stable", "beta", "unstable"):
+        channels.setdefault(name, [])
+    return data
+
+
+def save_manifest(path: Path, manifest: dict) -> None:
+    manifest["generated_at"] = now_iso()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def valid_store_path(value: str | None) -> bool:
+    return isinstance(value, str) and STORE_PATH_RE.fullmatch(value) is not None
+
+
+def set_available(entry: dict) -> dict:
+    if valid_store_path(entry.get("store_path")):
+        entry["available"] = True
+        entry.pop("reason", None)
+    else:
+        entry["store_path"] = None
+        entry["available"] = False
+        entry.setdefault("reason", "no build")
+    return entry
+
+
+def replace_entry(entries: list[dict], predicate, entry: dict) -> list[dict]:
+    return [item for item in entries if not predicate(item)] + [entry]
+
+
+def sort_unstable(entries: list[dict]) -> list[dict]:
+    def key(item: dict) -> tuple[int, int, str]:
+        if item.get("kind") == "trunk":
+            return (0, 0, item.get("source_ref", ""))
+        if item.get("kind") == "pr":
+            return (1, -int(item.get("number") or 0), item.get("label", ""))
+        return (2, 0, item.get("label", ""))
+
+    return sorted(entries, key=key)
+
+
+def update_build(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    channels = manifest["channels"]
+    store_path = args.store_path or None
+    short_sha = (args.head_sha or args.sha)[:7]
+
+    if args.pr_number:
+        number = int(args.pr_number)
+        entry = {
+            "kind": "pr",
+            "number": number,
+            "label": f"PR#{number}-{short_sha}",
+            "title": args.pr_title or f"PR #{number}",
+            "notes": args.pr_body or None,
+            "source_repo": args.head_repo,
+            "source_ref": args.head_ref,
+            "source_sha": args.head_sha,
+            "version": args.version or f"PR#{number}-{short_sha}",
+            "store_path": store_path,
+        }
+        set_available(entry)
+        channels["unstable"] = replace_entry(
+            channels["unstable"],
+            lambda item: item.get("kind") == "pr"
+            and int(item.get("number") or 0) == number,
+            entry,
+        )
+    else:
+        entry = {
+            "kind": "trunk",
+            "label": args.version or f"{args.ref_name}-{short_sha}",
+            "title": f"{args.ref_name} branch",
+            "notes": None,
+            "source_repo": args.repository,
+            "source_ref": args.ref_name,
+            "source_sha": args.sha,
+            "version": args.version or f"{args.ref_name}-{short_sha}",
+            "store_path": store_path,
+        }
+        set_available(entry)
+        channels["unstable"] = replace_entry(
+            channels["unstable"],
+            lambda item: item.get("kind") == "trunk"
+            and item.get("source_repo") == args.repository
+            and item.get("source_ref") == args.ref_name,
+            entry,
+        )
+
+    channels["unstable"] = sort_unstable(channels["unstable"])
+    save_manifest(args.manifest, manifest)
+
+
+def update_release(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    channel = "beta" if args.release_type == "beta" else "stable"
+    entry = {
+        "kind": "release",
+        "label": args.tag,
+        "title": args.title or f"PiFinder {args.tag}",
+        "notes": args.notes or None,
+        "source_repo": args.repository,
+        "source_ref": args.tag,
+        "source_sha": args.sha,
+        "version": args.version,
+        "store_path": args.store_path or None,
+    }
+    set_available(entry)
+    manifest["channels"][channel] = replace_entry(
+        manifest["channels"][channel],
+        lambda item: item.get("kind") == "release" and item.get("label") == args.tag,
+        entry,
+    )
+    save_manifest(args.manifest, manifest)
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser()
+    sub = root.add_subparsers(dest="command", required=True)
+
+    build = sub.add_parser("build")
+    build.add_argument("--manifest", type=Path, required=True)
+    build.add_argument("--repository", required=True)
+    build.add_argument("--ref-name", required=True)
+    build.add_argument("--sha", required=True)
+    build.add_argument("--store-path", required=True)
+    build.add_argument("--version", required=True)
+    build.add_argument("--pr-number")
+    build.add_argument("--pr-title")
+    build.add_argument("--pr-body")
+    build.add_argument("--head-repo")
+    build.add_argument("--head-ref")
+    build.add_argument("--head-sha")
+    build.set_defaults(func=update_build)
+
+    release = sub.add_parser("release")
+    release.add_argument("--manifest", type=Path, required=True)
+    release.add_argument("--repository", required=True)
+    release.add_argument("--sha", required=True)
+    release.add_argument("--tag", required=True)
+    release.add_argument("--version", required=True)
+    release.add_argument("--release-type", choices=("stable", "beta"), required=True)
+    release.add_argument("--store-path", required=True)
+    release.add_argument("--title")
+    release.add_argument("--notes")
+    release.set_defaults(func=update_release)
+
+    return root
+
+
+def main() -> None:
+    args = parser().parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/nixos-pr-build.yml
+++ b/.github/workflows/nixos-pr-build.yml
@@ -1,0 +1,204 @@
+name: Build PiFinder NixOS (testable PRs)
+
+# Builds testable NixOS PRs — including those from contributor forks — and
+# publishes the result so devices can install it.
+#
+# `pull_request_target` runs in the BASE repo's trusted context, so the job has
+# the real ATTIC_TOKEN and a read-write GITHUB_TOKEN even for fork PRs. The
+# contributor's code is checked out explicitly (head SHA) and built. This is
+# only reached after a maintainer applies the `testable` (or `preview`) label —
+# that label is the security boundary: it runs contributor code on the
+# self-hosted aarch64 runner with the cache push token, so review the diff
+# before labeling, and re-review on each new push to a labeled PR.
+on:
+  pull_request_target:
+    types: [labeled, synchronize, opened]
+
+concurrency:
+  group: nixos-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  # Try the Pi5 native aarch64 runner first (fast).
+  build-native:
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview') ||
+      contains(github.event.pull_request.labels.*.name, 'testable')
+    runs-on: [self-hosted, aarch64]
+    timeout-minutes: 30
+    outputs:
+      success: ${{ steps.build.outcome == 'success' }}
+      store_path: ${{ steps.push.outputs.store_path }}
+    steps:
+      # Build the contributor's code. persist-credentials:false so the
+      # GITHUB_TOKEN is not left in the fork checkout's git config.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
+
+      - name: Ensure nix is on PATH (self-hosted runner)
+        run: |
+          echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Attic substituter (cache.pifinder.eu)
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+        run: |
+          nix profile install nixpkgs#attic-client
+          attic login pifinder https://cache.pifinder.eu "$ATTIC_TOKEN"
+          attic use pifinder:pifinder
+
+      - name: Build NixOS system closure
+        id: build
+        run: |
+          nix build .#nixosConfigurations.pifinder.config.system.build.toplevel \
+            -L --no-link
+
+      - name: Push to Attic
+        id: push
+        run: |
+          STORE_PATH=$(nix build .#nixosConfigurations.pifinder.config.system.build.toplevel \
+            --json | jq -r '.[].outputs.out')
+          attic push pifinder:pifinder "$STORE_PATH"
+          echo "store_path=$STORE_PATH" >> "$GITHUB_OUTPUT"
+
+  # Wait up to ~15 min for the native builder, then decide on the hosted fallback.
+  native-wait:
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview') ||
+      contains(github.event.pull_request.labels.*.name, 'testable')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      need_emulated: ${{ steps.wait.outputs.need_emulated }}
+    steps:
+      - name: Wait for native build
+        id: wait
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for i in $(seq 1 30); do
+            sleep 30
+            RESULT=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
+              --jq '.jobs[] | select(.name == "build-native") | .conclusion // "pending"' 2>/dev/null || echo "pending")
+            echo "Check $i/30: build-native=$RESULT"
+            if [ "$RESULT" = "success" ]; then
+              echo "need_emulated=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            elif [ "$RESULT" = "failure" ] || [ "$RESULT" = "cancelled" ]; then
+              echo "need_emulated=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "Native build not done after 15 min, falling back to emulated"
+          echo "need_emulated=true" >> "$GITHUB_OUTPUT"
+
+  # Fallback on a free hosted arm64 runner (native aarch64, no QEMU).
+  build-emulated:
+    needs: native-wait
+    if: needs.native-wait.outputs.need_emulated == 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    outputs:
+      store_path: ${{ steps.push.outputs.store_path }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
+
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: false
+          extra-conf: |
+            extra-system-features = big-parallel
+            extra-substituters = https://cache.pifinder.eu/pifinder
+            extra-trusted-public-keys = pifinder:VkemNaMqXDcsYlpONItSvOOcBIa1vEfnpyqdetr3gck=
+
+      - name: Attic login for push
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+        run: |
+          if [ -z "$ATTIC_TOKEN" ]; then
+            echo "No ATTIC_TOKEN — pull-only via the public substituter"
+            exit 0
+          fi
+          nix profile install nixpkgs#attic-client
+          attic login pifinder https://cache.pifinder.eu "$ATTIC_TOKEN"
+          attic use pifinder:pifinder
+
+      - name: Build NixOS system closure
+        run: |
+          nix build .#nixosConfigurations.pifinder.config.system.build.toplevel \
+            -L --no-link
+
+      - name: Push to Attic
+        id: push
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+        run: |
+          STORE_PATH=$(nix build .#nixosConfigurations.pifinder.config.system.build.toplevel \
+            --json | jq -r '.[].outputs.out')
+          echo "store_path=$STORE_PATH" >> "$GITHUB_OUTPUT"
+          if [ -n "$ATTIC_TOKEN" ]; then
+            attic push pifinder:pifinder "$STORE_PATH"
+          else
+            echo "No ATTIC_TOKEN — skipping push; build is verify-only"
+          fi
+
+  # Stamp the PR's build into the metadata-only nixos-manifest branch. Runs the
+  # TRUSTED scripts from the base branch (default checkout), never the fork's,
+  # since this step holds the write token.
+  update-manifest:
+    needs: [build-native, build-emulated]
+    if: |
+      always() &&
+      (needs.build-native.result == 'success' || needs.build-emulated.result == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: manifest-write
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update generated manifest branch
+        env:
+          STORE_PATH: ${{ needs.build-native.outputs.store_path || needs.build-emulated.outputs.store_path }}
+          GH_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER="$(jq -r '.pull_request.number // ""' "$GITHUB_EVENT_PATH")"
+          PR_TITLE="$(jq -r '.pull_request.title // ""' "$GITHUB_EVENT_PATH")"
+          PR_BODY="$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")"
+          HEAD_REPO="$(jq -r '.pull_request.head.repo.full_name // ""' "$GITHUB_EVENT_PATH")"
+          HEAD_REF="$(jq -r '.pull_request.head.ref // ""' "$GITHUB_EVENT_PATH")"
+          HEAD_SHA="$(jq -r '.pull_request.head.sha // ""' "$GITHUB_EVENT_PATH")"
+          SHORT_SHA="${HEAD_SHA:0:7}"
+          VERSION="PR#${PR_NUMBER}-${SHORT_SHA}"
+
+          bash .github/scripts/publish_manifest.sh \
+            "chore: update build manifest [skip ci]" \
+            python3 .github/scripts/update_manifest.py build \
+              --manifest @MANIFEST@ \
+              --repository "$GH_REPOSITORY" \
+              --ref-name "$HEAD_REF" \
+              --sha "$HEAD_SHA" \
+              --store-path "$STORE_PATH" \
+              --version "$VERSION" \
+              --pr-number "$PR_NUMBER" \
+              --pr-title "$PR_TITLE" \
+              --pr-body "$PR_BODY" \
+              --head-repo "$HEAD_REPO" \
+              --head-ref "$HEAD_REF" \
+              --head-sha "$HEAD_SHA"


### PR DESCRIPTION
**Why this is needed:** `nixos-pr-build.yml` (the trusted, label-gated testable-PR builder) was merged to `main` in #493 — but it's a **`pull_request_target`** workflow, and GitHub only fires those from the repository's **default branch**. brickbots' default is `release`, which doesn't have the workflow (or `.github/scripts/`), so labeling a `testable` PR currently does nothing.

This adds exactly the three files from #493 to `release` (the rotated `pifinder:Vkem…` key included):
- `.github/workflows/nixos-pr-build.yml`
- `.github/scripts/publish_manifest.sh`
- `.github/scripts/update_manifest.py`

Once merged, a `testable`/`preview` label on a PR builds on the Pi5 → pushes the closure to the `pifinder` cache → writes the PR's entry to `nixos-manifest`, all in the trusted base-repo context.

Alternative to this PR: switch the repo's **default branch to `main`** (where the builder already lives, CI-aligned) — that's an admin setting and would make this PR unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)