### PR TITLE
ci: NixOS release workflow — SD image + migration tarball (reinstate)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,168 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g., 2.5.0)'
+        required: true
+      notes:
+        description: 'Release notes'
+        required: true
+      type:
+        description: 'Release type'
+        type: choice
+        options:
+          - stable
+          - beta
+        default: stable
+      source_branch:
+        description: 'Source branch (default: main, use release/X.Y for hotfixes)'
+        required: false
+        default: 'main'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: false
+          extra-conf: |
+            extra-platforms = aarch64-linux
+            extra-system-features = big-parallel
+
+      - name: Setup Attic caches (cache.pifinder.eu)
+        # Self-hosted FastCDC-chunked binary cache — see ADR 0004. The release
+        # closure is published to the retained `pifinder-release` cache (push
+        # step below); build-time deps are substituted from the `pifinder` dev
+        # cache, which recent CI runs keep warm.
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+        run: |
+          nix profile install nixpkgs#attic-client
+          attic login pifinder https://cache.pifinder.eu "$ATTIC_TOKEN"
+          attic use pifinder:pifinder
+
+      - name: Register QEMU binfmt for aarch64
+        run: sudo apt-get update && sudo apt-get install -y qemu-user-static
+
+      - name: Compute tag and write temporary build metadata
+        run: |
+          TAG="v${{ inputs.version }}"
+          [[ "${{ inputs.type }}" == "beta" ]] && TAG="${TAG}-beta"
+          echo "TAG=$TAG" >> $GITHUB_ENV
+
+          VERSION="${{ inputs.version }}"
+          jq -n --arg sp "" --arg v "$VERSION" \
+            '{store_path: $sp, version: $v}' > pifinder-build.json
+
+      - name: Build and push release closure to Attic (pifinder-release)
+        id: push
+        run: |
+          STORE_PATH=$(nix build .#nixosConfigurations.pifinder.config.system.build.toplevel \
+            --system aarch64-linux -L --json | jq -r '.[].outputs.out')
+          # Stable → retained pifinder-release (GC off; devices resolve it
+          # months later). Beta/prerelease → dev pifinder cache (finite
+          # retention), so prereleases stay transient.
+          if [[ "${{ inputs.type }}" == "beta" ]]; then
+            attic push pifinder:pifinder "$STORE_PATH"
+          else
+            attic push pifinder:pifinder-release "$STORE_PATH"
+          fi
+          echo "store_path=$STORE_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Build SD image
+        run: |
+          nix build .#images.pifinder \
+            --system aarch64-linux \
+            -L -o result-sd
+          mkdir -p release
+          for f in result-sd/sd-image/*.img.zst; do
+            cp "$f" "release/pifinder-${TAG}.img.zst"
+          done
+
+      - name: Tag release source commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Build migration tarball from SD image
+        run: |
+          IMAGE_FILE=$(find result-sd/sd-image -type f \( -name "*.img" -o -name "*.img.zst" \) | head -1)
+
+          rm -f /tmp/pifinder-release.img
+          if [[ "${IMAGE_FILE}" == *.zst ]]; then
+            zstd -d "${IMAGE_FILE}" -o /tmp/pifinder-release.img
+          else
+            cp "${IMAGE_FILE}" /tmp/pifinder-release.img
+          fi
+
+          LOOP=$(sudo losetup --find --show --partscan /tmp/pifinder-release.img)
+          sudo mkdir -p /mnt/boot /mnt/root
+          sudo mount "${LOOP}p1" /mnt/boot
+          sudo mount "${LOOP}p2" /mnt/root
+
+          mkdir -p /tmp/tarball-staging
+          sudo cp -a /mnt/boot /tmp/tarball-staging/boot
+          sudo cp -a /mnt/root /tmp/tarball-staging/rootfs
+          sudo rm -rf /tmp/tarball-staging/rootfs/home/pifinder/PiFinder_data/catalog_images
+
+          sudo umount /mnt/boot /mnt/root
+          sudo losetup -d "${LOOP}"
+          rm -f /tmp/pifinder-release.img
+
+          sudo tar -C /tmp/tarball-staging -cf - \
+            --exclude='*/lost+found' \
+            boot rootfs | zstd -T0 -19 -o "release/pifinder-migration-${TAG}.tar.zst"
+          sudo rm -rf /tmp/tarball-staging
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pifinder-release-${{ env.TAG }}
+          path: release/pifinder-*.zst
+          retention-days: 90
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.TAG }}
+          name: PiFinder ${{ env.TAG }}
+          body: ${{ inputs.notes }}
+          prerelease: ${{ inputs.type == 'beta' }}
+          files: |
+            release/pifinder-*.zst
+
+      - name: Update generated manifest branch
+        env:
+          STORE_PATH: ${{ steps.push.outputs.store_path }}
+          RELEASE_NOTES: ${{ inputs.notes }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          SOURCE_SHA="$(git rev-parse "$TAG^{commit}")"
+
+          .github/scripts/publish_manifest.sh \
+            "chore: update release manifest [skip ci]" \
+            python3 .github/scripts/update_manifest.py release \
+              --manifest @MANIFEST@ \
+              --repository "${{ github.repository }}" \
+              --sha "$SOURCE_SHA" \
+              --tag "$TAG" \
+              --version "${{ inputs.version }}" \
+              --release-type "${{ inputs.type }}" \
+              --store-path "$STORE_PATH" \
+              --title "PiFinder $TAG" \
+              --notes "$RELEASE_NOTES"


### PR DESCRIPTION
Reinstates the release workflow that was dropped when the nixos branch's CI was aligned to #493. It builds the SD image **and the Debian→NixOS migration tarball** (the migration target), neither of which is produced anywhere right now.

On `release` because `workflow_dispatch` only fires from the default branch (same rule as `pull_request_target` in #493/#495).

`workflow_dispatch` (maintainer-triggered, trusted context):
- builds the aarch64 closure, **stable → `pifinder-release`** (retained) / **beta → `pifinder`** (dev, transient — the beta→dev split);
- builds the **SD image** and the **`pifinder-migration-<tag>.tar.zst`** tarball;
- tags the source commit, creates the GitHub Release, writes the `release` entry to `nixos-manifest`.

Inert until the nixos flake config lands on `release`/`main` (it builds `.#nixosConfigurations.pifinder` + `.#images.pifinder`). Uses the manifest scripts already on `release` (from #495).

Note: `softprops/action-gh-release@v1` carries an old-runtime actionlint warning — worth bumping to `@v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)