### PR TITLE
Support Bookworm install paths

### DIFF
--- a/migrate_db.sql
+++ b/migrate_db.sql
@@ -1,5 +1,5 @@
-attach `/home/pifinder/PiFinder/astro_data/observations.db` as ad_obs;
-attach `/home/pifinder/PiFinder_data/observations.db` as pfd_obs;
+attach `__PIFINDER_REPO_DIR__/astro_data/observations.db` as ad_obs;
+attach `__PIFINDER_DATA_DIR__/observations.db` as pfd_obs;
 BEGIN;
 insert into pfd_obs.obs_sessions(start_time_local, lat, lon, timezone, UID)
 select start_time_local, lat, lon, timezone, UID from ad_obs.obs_sessions;

--- a/migration_source/v1.x.x.sh
+++ b/migration_source/v1.x.x.sh
@@ -1,41 +1,48 @@
+PIFINDER_REPO_DIR="${PIFINDER_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+source "${PIFINDER_REPO_DIR}/pifinder_paths.sh"
+
 # GPSD
 sudo apt install -y gpsd
 sudo dpkg-reconfigure -plow gpsd
-sudo cp ~/PiFinder/pi_config_files/gpsd.conf /etc/default/gpsd
+sudo cp "${PIFINDER_REPO_DIR}/pi_config_files/gpsd.conf" /etc/default/gpsd
 
 # PWM
-sudo sed -zi '/dtoverlay=pwm,pin=13,func=4\n/!s/$/\ndtoverlay=pwm,pin=13,func=4\n/' /boot/config.txt
+BOOT_CONFIG="$(pifinder_boot_config_path)"
+sudo sed -zi '/dtoverlay=pwm,pin=13,func=4\n/!s/$/\ndtoverlay=pwm,pin=13,func=4\n/' "${BOOT_CONFIG}"
 
 # Uart for GPS
-sudo sed -zi '/dtoverlay=uart3\n/!s/$/\ndtoverlay=uart3\n/' /boot/config.txt
+sudo sed -zi '/dtoverlay=uart3\n/!s/$/\ndtoverlay=uart3\n/' "${BOOT_CONFIG}"
 
 # Migrate DB
-if [ -f "/home/pifinder/PiFinder/astro_data/observations.db" ]
+if [ -f "${PIFINDER_REPO_DIR}/astro_data/observations.db" ]
 then
     echo "Migrating astro_data DB"
     python -c "from PiFinder import setup;setup.create_logging_tables();"
-    sqlite3 < /home/pifinder/PiFinder/migrate_db.sql
-    rm /home/pifinder/PiFinder/astro_data/observations.db
+    sed \
+        -e "s|__PIFINDER_REPO_DIR__|${PIFINDER_REPO_DIR}|g" \
+        -e "s|__PIFINDER_DATA_DIR__|${PIFINDER_DATA_DIR}|g" \
+        "${PIFINDER_REPO_DIR}/migrate_db.sql" | sqlite3
+    rm "${PIFINDER_REPO_DIR}/astro_data/observations.db"
 fi
 
 # Migrate Config files
-if ! [ -f "/home/pifinder/PiFinder_data/config.json" ]
+if ! [ -f "${PIFINDER_DATA_DIR}/config.json" ] && [ -f "${PIFINDER_REPO_DIR}/config.json" ]
 then
     echo "Migrating config.json"
-    mv /home/pifinder/PiFinder/config.json /home/pifinder/PiFinder_data/config.json
+    mv "${PIFINDER_REPO_DIR}/config.json" "${PIFINDER_DATA_DIR}/config.json"
 fi
 
 # Adjust service definition
 sudo systemctl disable pifinder
 sudo rm /etc/systemd/system/pifinder.service
-sudo cp /home/pifinder/PiFinder/pi_config_files/pifinder.service /lib/systemd/system/pifinder.service
+pifinder_render_config "${PIFINDER_REPO_DIR}/pi_config_files/pifinder.service" /lib/systemd/system/pifinder.service
 sudo systemctl daemon-reload
 sudo systemctl enable pifinder
 
 # add PiFinder_splash if not already in place
 if ! [ -f "/lib/systemd/system/pifinder_spash.service" ]
 then
-    sudo cp /home/pifinder/PiFinder/pi_config_files/pifinder_splash.service /lib/systemd/system/pifinder_splash.service
+    pifinder_render_config "${PIFINDER_REPO_DIR}/pi_config_files/pifinder_splash.service" /lib/systemd/system/pifinder_splash.service
     sudo systemctl daemon-reload
     sudo systemctl enable pifinder_splash
 fi
@@ -45,4 +52,3 @@ sudo chmod 666 /etc/wpa_supplicant/wpa_supplicant.conf
 
 # DONE
 echo "Post Update Complete"
-

--- a/migration_source/v2.1.0.sh
+++ b/migration_source/v2.1.0.sh
@@ -1,7 +1,9 @@
+PIFINDER_REPO_DIR="${PIFINDER_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+source "${PIFINDER_REPO_DIR}/pifinder_paths.sh"
+
 # swap tetra3 submodule
 git submodule sync
 git submodule update --init --recursive
 
 # Set up symlink
-ln -s /home/pifinder/PiFinder/python/PiFinder/tetra3/tetra3 /home/pifinder/PiFinder/python/tetra3
-
+ln -sfn "${PIFINDER_REPO_DIR}/python/PiFinder/tetra3/tetra3" "${PIFINDER_REPO_DIR}/python/tetra3"

--- a/migration_source/v2.2.1.sh
+++ b/migration_source/v2.2.1.sh
@@ -1,6 +1,8 @@
+PIFINDER_REPO_DIR="${PIFINDER_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+source "${PIFINDER_REPO_DIR}/pifinder_paths.sh"
+
 # install lib input
 sudo apt install -y libinput10
 
 # Add PiFinder user to input group
-sudo usermod -G input -a "pifinder"
-
+sudo usermod -G input -a "${PIFINDER_USER}"

--- a/migration_source/v2.2.2.sh
+++ b/migration_source/v2.2.2.sh
@@ -1,7 +1,11 @@
+PIFINDER_REPO_DIR="${PIFINDER_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+source "${PIFINDER_REPO_DIR}/pifinder_paths.sh"
+
 # Enable usb-host on usb-c port
+BOOT_CONFIG="$(pifinder_boot_config_path)"
 
 #Add it to the dw2 line if it exist
-sudo sed -zi "s/dtoverlay=dwc2\n/dtoverlay=dwc2,dr_mode=host\n/" /boot/config.txt
+sudo sed -zi "s/dtoverlay=dwc2\n/dtoverlay=dwc2,dr_mode=host\n/" "${BOOT_CONFIG}"
 
 #Add the line if it does not exist
-sudo sed -zi '/dtoverlay=dwc2,dr_mode=host\n/!s/$/\ndtoverlay=dwc2,dr_mode=host\n/' /boot/config.txt
+sudo sed -zi '/dtoverlay=dwc2,dr_mode=host\n/!s/$/\ndtoverlay=dwc2,dr_mode=host\n/' "${BOOT_CONFIG}"

--- a/migration_source/v2.4.0.sh
+++ b/migration_source/v2.4.0.sh
@@ -1,4 +1,7 @@
+PIFINDER_REPO_DIR="${PIFINDER_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+source "${PIFINDER_REPO_DIR}/pifinder_paths.sh"
+
 #Add and enable cedar-detect as system process
-sudo cp /home/pifinder/PiFinder/pi_config_files/cedar_detect.service /lib/systemd/system/cedar_detect.service
+pifinder_render_config "${PIFINDER_REPO_DIR}/pi_config_files/cedar_detect.service" /lib/systemd/system/cedar_detect.service
 sudo systemctl daemon-reload
 sudo systemctl enable cedar_detect

--- a/migration_source/v2.6.0.sh
+++ b/migration_source/v2.6.0.sh
@@ -1,6 +1,9 @@
+PIFINDER_REPO_DIR="${PIFINDER_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+source "${PIFINDER_REPO_DIR}/pifinder_paths.sh"
+
 # Clear stale flop_image=true on the shipped "Generic Dobsonian" default.
 # flip/flop are now applied to the object-detail image; a Dobsonian needs
 # neither flag, so repair any persisted config that froze the bad default.
 # Idempotent and version-gated by pifinder_post_update.sh. See
 # docs/adr/0003-object-image-orientation.md.
-python /home/pifinder/PiFinder/python/PiFinder/migrations/v2_6_0_dob_flop.py /home/pifinder/PiFinder_data/config.json
+python "${PIFINDER_REPO_DIR}/python/PiFinder/migrations/v2_6_0_dob_flop.py" "${PIFINDER_DATA_DIR}/config.json"

--- a/pi_config_files/cedar_detect.service
+++ b/pi_config_files/cedar_detect.service
@@ -4,10 +4,10 @@ After=basic.target
 
 [Service]
 Type=idle
-User=pifinder
-WorkingDirectory=/home/pifinder/PiFinder
+User=__PIFINDER_USER__
+WorkingDirectory=__PIFINDER_REPO_DIR__
 Environment=RUST_BACKTRACE=1
-ExecStart=/home/pifinder/PiFinder/bin/cedar-detect-server-aarch64 --port 50551
+ExecStart=__PIFINDER_REPO_DIR__/bin/cedar-detect-server-aarch64 --port 50551
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]

--- a/pi_config_files/pifinder.service
+++ b/pi_config_files/pifinder.service
@@ -4,8 +4,8 @@ After=basic.target
 
 [Service]
 Type=idle
-User=pifinder
-WorkingDirectory=/home/pifinder/PiFinder/python
+User=__PIFINDER_USER__
+WorkingDirectory=__PIFINDER_REPO_DIR__/python
 ExecStart=/usr/bin/python -m PiFinder.main
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 

--- a/pi_config_files/pifinder_splash.service
+++ b/pi_config_files/pifinder_splash.service
@@ -2,7 +2,7 @@
 Description=PiFinderSplash
 
 [Service]
-WorkingDirectory=/home/pifinder/PiFinder/python
+WorkingDirectory=__PIFINDER_REPO_DIR__/python
 ExecStart=/usr/bin/python -m PiFinder.splash
 
 [Install]

--- a/pi_config_files/smb.conf
+++ b/pi_config_files/smb.conf
@@ -22,7 +22,7 @@
 #======================= Global Settings =======================
 
 [global]
-guest account = pifinder
+guest account = __PIFINDER_USER__
 
 ## Browsing/Identification ###
 
@@ -235,7 +235,7 @@ guest account = pifinder
 # to the drivers directory for these users to have write rights in it
 ;   write list = root, @lpadmin
 [shared]
-path=/home/pifinder/PiFinder_data
+path=__PIFINDER_DATA_DIR__
 writeable=Yes
 create mask=0777
 directory mask=0777

--- a/pifinder_paths.sh
+++ b/pifinder_paths.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Shared path helpers for PiFinder shell install/update scripts.
+
+set -e
+
+if [[ -z "${PIFINDER_REPO_DIR:-}" ]]; then
+    PIFINDER_REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+if [[ -z "${PIFINDER_USER:-}" ]]; then
+    if [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
+        PIFINDER_USER="${SUDO_USER}"
+    else
+        PIFINDER_USER="$(id -un)"
+    fi
+fi
+
+if [[ "${PIFINDER_USER}" == "root" ]]; then
+    echo "PiFinder must be installed for a non-root OS user." >&2
+    echo "Set PIFINDER_USER=<user> when running as root." >&2
+    exit 1
+fi
+
+if [[ -z "${PIFINDER_HOME:-}" ]]; then
+    PIFINDER_HOME="$(getent passwd "${PIFINDER_USER}" | cut -d: -f6)"
+fi
+
+if [[ -z "${PIFINDER_HOME}" || ! -d "${PIFINDER_HOME}" ]]; then
+    echo "Could not determine home directory for ${PIFINDER_USER}" >&2
+    exit 1
+fi
+
+PIFINDER_DATA_DIR="${PIFINDER_DATA_DIR:-${PIFINDER_HOME}/PiFinder_data}"
+
+export PIFINDER_USER
+export PIFINDER_HOME
+export PIFINDER_REPO_DIR
+export PIFINDER_DATA_DIR
+
+pifinder_render_config() {
+    local source_file="$1"
+    local target_file="$2"
+
+    sudo sed \
+        -e "s|__PIFINDER_USER__|${PIFINDER_USER}|g" \
+        -e "s|__PIFINDER_HOME__|${PIFINDER_HOME}|g" \
+        -e "s|__PIFINDER_REPO_DIR__|${PIFINDER_REPO_DIR}|g" \
+        -e "s|__PIFINDER_DATA_DIR__|${PIFINDER_DATA_DIR}|g" \
+        "${source_file}" | sudo tee "${target_file}" >/dev/null
+}
+
+pifinder_boot_config_path() {
+    if [[ -e /boot/firmware/config.txt ]]; then
+        printf "%s\n" "/boot/firmware/config.txt"
+    else
+        printf "%s\n" "/boot/config.txt"
+    fi
+}

--- a/pifinder_post_update.sh
+++ b/pifinder_post_update.sh
@@ -1,60 +1,62 @@
+PIFINDER_REPO_DIR="${PIFINDER_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+source "${PIFINDER_REPO_DIR}/pifinder_paths.sh"
+
 git submodule update --init --recursive
-sudo pip install -r /home/pifinder/PiFinder/python/requirements.txt
+sudo python3 -m pip install --break-system-packages -r "${PIFINDER_REPO_DIR}/python/requirements.txt"
 
 # Set up migrations folder if it does not exist
-if ! [ -d "/home/pifinder/PiFinder_data/migrations" ]
+if ! [ -d "${PIFINDER_DATA_DIR}/migrations" ]
 then
-    mkdir /home/pifinder/PiFinder_data/migrations
+    mkdir -p "${PIFINDER_DATA_DIR}/migrations"
 fi
 
 # v1.x.x
 # everying prior to selecitve migrations
-if ! [ -f "/home/pifinder/PiFinder_data/migrations/v1.x.x" ]
+if ! [ -f "${PIFINDER_DATA_DIR}/migrations/v1.x.x" ]
 then
-    source /home/pifinder/PiFinder/migration_source/v1.x.x.sh
-    touch /home/pifinder/PiFinder_data/migrations/v1.x.x
+    source "${PIFINDER_REPO_DIR}/migration_source/v1.x.x.sh"
+    touch "${PIFINDER_DATA_DIR}/migrations/v1.x.x"
 fi
 
 # v2.1.0
 # Switch to Cedar
-if ! [ -f "/home/pifinder/PiFinder_data/migrations/v2.1.0" ]
+if ! [ -f "${PIFINDER_DATA_DIR}/migrations/v2.1.0" ]
 then
-    source /home/pifinder/PiFinder/migration_source/v2.1.0.sh
-    touch /home/pifinder/PiFinder_data/migrations/v2.1.0
+    source "${PIFINDER_REPO_DIR}/migration_source/v2.1.0.sh"
+    touch "${PIFINDER_DATA_DIR}/migrations/v2.1.0"
 fi
 
 # v2.2.1
 # Install libinput
-if ! [ -f "/home/pifinder/PiFinder_data/migrations/v2.2.1" ]
+if ! [ -f "${PIFINDER_DATA_DIR}/migrations/v2.2.1" ]
 then
-    source /home/pifinder/PiFinder/migration_source/v2.2.1.sh
-    touch /home/pifinder/PiFinder_data/migrations/v2.2.1
+    source "${PIFINDER_REPO_DIR}/migration_source/v2.2.1.sh"
+    touch "${PIFINDER_DATA_DIR}/migrations/v2.2.1"
 fi
 
 # v2.2.2
 # Enable host usb on usb-c port
-if ! [ -f "/home/pifinder/PiFinder_data/migrations/v2.2.2" ]
+if ! [ -f "${PIFINDER_DATA_DIR}/migrations/v2.2.2" ]
 then
-    source /home/pifinder/PiFinder/migration_source/v2.2.2.sh
-    touch /home/pifinder/PiFinder_data/migrations/v2.2.2
+    source "${PIFINDER_REPO_DIR}/migration_source/v2.2.2.sh"
+    touch "${PIFINDER_DATA_DIR}/migrations/v2.2.2"
 fi
 
 # v2.4.0
 # Switch detect to system process
-if ! [ -f "/home/pifinder/PiFinder_data/migrations/v2.4.0" ]
+if ! [ -f "${PIFINDER_DATA_DIR}/migrations/v2.4.0" ]
 then
-    source /home/pifinder/PiFinder/migration_source/v2.4.0.sh
-    touch /home/pifinder/PiFinder_data/migrations/v2.4.0
+    source "${PIFINDER_REPO_DIR}/migration_source/v2.4.0.sh"
+    touch "${PIFINDER_DATA_DIR}/migrations/v2.4.0"
 fi
 
 # v2.6.0
 # Clear stale flop_image=true on the default Dobsonian (flip/flop now live)
-if ! [ -f "/home/pifinder/PiFinder_data/migrations/v2.6.0" ]
+if ! [ -f "${PIFINDER_DATA_DIR}/migrations/v2.6.0" ]
 then
-    source /home/pifinder/PiFinder/migration_source/v2.6.0.sh
-    touch /home/pifinder/PiFinder_data/migrations/v2.6.0
+    source "${PIFINDER_REPO_DIR}/migration_source/v2.6.0.sh"
+    touch "${PIFINDER_DATA_DIR}/migrations/v2.6.0"
 fi
 
 # DONE
 echo "Post Update Complete"
-

--- a/pifinder_setup.sh
+++ b/pifinder_setup.sh
@@ -4,73 +4,105 @@
 
 set -e
 
-cd ~pifinder/
+if [[ "$(id -u)" -eq 0 ]]; then
+    echo "Do not run this script with sudo." >&2
+    echo "Run it as the target OS user; the script will use sudo when needed." >&2
+    exit 1
+fi
 
-sudo apt-get install -y git python3-pip samba samba-common-bin dnsmasq hostapd dhcpd gpsd
+PIFINDER_USER="${PIFINDER_USER:-${SUDO_USER:-$(id -un)}}"
+if [[ "${PIFINDER_USER}" == "root" ]]; then
+    echo "Run as the target OS user, or set PIFINDER_USER=<user>." >&2
+    exit 1
+fi
+
+PIFINDER_HOME="$(getent passwd "${PIFINDER_USER}" | cut -d: -f6)"
+if [[ -z "${PIFINDER_HOME}" || ! -d "${PIFINDER_HOME}" ]]; then
+    echo "Could not determine home directory for ${PIFINDER_USER}" >&2
+    exit 1
+fi
+
+cd "${PIFINDER_HOME}"
+
+sudo bash -c '
+set -e
+trap "rm -f /usr/sbin/policy-rc.d" EXIT
+printf "%s\n" "#!/bin/sh" "exit 101" > /usr/sbin/policy-rc.d
+chmod 755 /usr/sbin/policy-rc.d
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    git python3-pip python3-venv python3-dev build-essential pkg-config \
+    samba samba-common-bin dnsmasq hostapd dhcpcd gpsd wget \
+    libinput10 libcap2-bin libjpeg-dev zlib1g-dev libfreetype6-dev \
+    liblcms2-dev libopenjp2-7-dev libtiff-dev libffi-dev libssl-dev \
+    python3-picamera2 rpicam-apps i2c-tools spi-tools
+'
 
 if [[ -d PiFinder/ ]]; then
     cd PiFinder/ && git config pull.rebase false && git pull
 else
     git clone --recursive --branch release https://github.com/brickbots/PiFinder.git
 fi
-cd ~/PiFinder/ && sudo pip install -r python/requirements.txt
+
+PIFINDER_REPO_DIR="${PIFINDER_HOME}/PiFinder"
+source "${PIFINDER_REPO_DIR}/pifinder_paths.sh"
+
+cd "${PIFINDER_REPO_DIR}"
+sudo python3 -m pip install --break-system-packages -r python/requirements.txt
 
 # Setup GPSD
-sudo dpkg-reconfigure -plow gpsd
-sudo cp ~/PiFinder/pi_config_files/gpsd.conf /etc/default/gpsd
+sudo cp "${PIFINDER_REPO_DIR}/pi_config_files/gpsd.conf" /etc/default/gpsd
 
-# data dirs
-[[ -d ~/PiFinder_data ]] || \
-mkdir ~/PiFinder_data
-[[ -d ~/PiFinder_data/captures ]] || \
-mkdir ~/PiFinder_data/captures
-[[ -d ~/PiFinder_data/obslists ]] || \
-mkdir ~/PiFinder_data/obslists
-[[ -d ~/PiFinder_data/screenshots ]] || \
-mkdir ~/PiFinder_data/screenshots
-[[ -d ~/PiFinder_data/solver_debug_dumps ]] || \
-mkdir ~/PiFinder_data/solver_debug_dumps
-[[ -d ~/PiFinder_data/logs ]] || \
-mkdir ~/PiFinder_data/logs
-find ~/PiFinder_data -type d -exec chmod 755 {} \;
+# Data dirs
+sudo install -d -o "${PIFINDER_USER}" -g "${PIFINDER_USER}" -m 755 \
+    "${PIFINDER_DATA_DIR}" \
+    "${PIFINDER_DATA_DIR}/captures" \
+    "${PIFINDER_DATA_DIR}/obslists" \
+    "${PIFINDER_DATA_DIR}/screenshots" \
+    "${PIFINDER_DATA_DIR}/solver_debug_dumps" \
+    "${PIFINDER_DATA_DIR}/logs" \
+    "${PIFINDER_DATA_DIR}/migrations"
 
 # Wifi config
-sudo cp ~/PiFinder/pi_config_files/dhcpcd.* /etc
-sudo cp ~/PiFinder/pi_config_files/dhcpcd.conf.sta /etc/dhcpcd.conf
-sudo cp ~/PiFinder/pi_config_files/dnsmasq.conf /etc/dnsmasq.conf
-sudo cp ~/PiFinder/pi_config_files/hostapd.conf /etc/hostapd/hostapd.conf
-echo -n "Client" > ~/PiFinder/wifi_status.txt
+sudo cp "${PIFINDER_REPO_DIR}"/pi_config_files/dhcpcd.* /etc
+sudo cp "${PIFINDER_REPO_DIR}/pi_config_files/dhcpcd.conf.sta" /etc/dhcpcd.conf
+sudo cp "${PIFINDER_REPO_DIR}/pi_config_files/dnsmasq.conf" /etc/dnsmasq.conf
+sudo cp "${PIFINDER_REPO_DIR}/pi_config_files/hostapd.conf" /etc/hostapd/hostapd.conf
+echo -n "Client" > "${PIFINDER_REPO_DIR}/wifi_status.txt"
 sudo systemctl unmask hostapd
 
-# open permissisons on wpa_supplicant file so we can adjust network config
+# Open permissions on wpa_supplicant file so we can adjust network config.
+sudo install -d -m 755 /etc/wpa_supplicant
+sudo touch /etc/wpa_supplicant/wpa_supplicant.conf
 sudo chmod 666 /etc/wpa_supplicant/wpa_supplicant.conf
 
 # Samba config
-sudo cp ~/PiFinder/pi_config_files/smb.conf /etc/samba/smb.conf
+pifinder_render_config "${PIFINDER_REPO_DIR}/pi_config_files/smb.conf" /etc/samba/smb.conf
 
 # Hipparcos catalog
-HIP_MAIN_DAT="/home/pifinder/PiFinder/astro_data/hip_main.dat"
+HIP_MAIN_DAT="${PIFINDER_REPO_DIR}/astro_data/hip_main.dat"
 if [[ ! -e $HIP_MAIN_DAT ]]; then
     wget -O $HIP_MAIN_DAT https://cdsarc.cds.unistra.fr/ftp/cats/I/239/hip_main.dat
 fi
 
 # Enable interfaces
-grep -q "dtparam=spi=on" /boot/config.txt || \
-   echo "dtparam=spi=on" | sudo tee -a /boot/config.txt
-grep -q "dtparam=i2c_arm=on" /boot/config.txt || \
-   echo "dtparam=i2c_arm=on" | sudo tee -a /boot/config.txt
-grep -q "dtparam=i2c_arm_baudrate=10000" /boot/config.txt || \
-   echo "dtparam=i2c_arm_baudrate=10000" | sudo tee -a /boot/config.txt
-grep -q "dtoverlay=pwm,pin=13,func=4" /boot/config.txt || \
-   echo "dtoverlay=pwm,pin=13,func=4" | sudo tee -a /boot/config.txt
-grep -q "dtoverlay=uart3" /boot/config.txt || \
-   echo "dtoverlay=uart3" | sudo tee -a /boot/config.txt
+BOOT_CONFIG="$(pifinder_boot_config_path)"
+grep -q "dtparam=spi=on" "${BOOT_CONFIG}" || \
+   echo "dtparam=spi=on" | sudo tee -a "${BOOT_CONFIG}"
+grep -q "dtparam=i2c_arm=on" "${BOOT_CONFIG}" || \
+   echo "dtparam=i2c_arm=on" | sudo tee -a "${BOOT_CONFIG}"
+grep -q "dtparam=i2c_arm_baudrate=10000" "${BOOT_CONFIG}" || \
+   echo "dtparam=i2c_arm_baudrate=10000" | sudo tee -a "${BOOT_CONFIG}"
+grep -q "dtoverlay=pwm,pin=13,func=4" "${BOOT_CONFIG}" || \
+   echo "dtoverlay=pwm,pin=13,func=4" | sudo tee -a "${BOOT_CONFIG}"
+grep -q "dtoverlay=uart3" "${BOOT_CONFIG}" || \
+   echo "dtoverlay=uart3" | sudo tee -a "${BOOT_CONFIG}"
 
 # Power-off latch (rev-4): at kernel poweroff drive GPIO14 low -> LTC2954 KILL ->
 # TPS61088 boost EN off -> power cut. active_low + the hardware pull-up on GPIO14
 # keep the pin high (power on) through boot/reboot. No-op on rev-3. See ADR 0007.
-grep -q "dtoverlay=gpio-poweroff" /boot/config.txt || \
-   echo "dtoverlay=gpio-poweroff,gpiopin=14,active_low" | sudo tee -a /boot/config.txt
+grep -q "dtoverlay=gpio-poweroff" "${BOOT_CONFIG}" || \
+   echo "dtoverlay=gpio-poweroff,gpiopin=14,active_low" | sudo tee -a "${BOOT_CONFIG}"
 
 # Free GPIO14 (UART0 TXD) for the power-off latch: drop the serial console so the
 # kernel doesn't drive console bytes onto the kill line. Leaves enable_uart/BT alone.
@@ -80,16 +112,22 @@ sudo systemctl mask serial-getty@ttyAMA0.service
 # Note: camera types are added lateron by python/PiFinder/switch_camera.py
 
 # Disable unwanted services
-sudo systemctl disable ModemManager
+sudo systemctl disable ModemManager 2>/dev/null || true
+sudo systemctl disable dhcpcd dnsmasq hostapd 2>/dev/null || true
 
 # Enable service
-sudo cp /home/pifinder/PiFinder/pi_config_files/pifinder.service /lib/systemd/system/pifinder.service
-sudo cp /home/pifinder/PiFinder/pi_config_files/pifinder_splash.service /lib/systemd/system/pifinder_splash.service
-sudo cp /home/pifinder/PiFinder/pi_config_files/cedar_detect.service /lib/systemd/system/cedar_detect.service
+pifinder_render_config "${PIFINDER_REPO_DIR}/pi_config_files/pifinder.service" /lib/systemd/system/pifinder.service
+pifinder_render_config "${PIFINDER_REPO_DIR}/pi_config_files/pifinder_splash.service" /lib/systemd/system/pifinder_splash.service
+pifinder_render_config "${PIFINDER_REPO_DIR}/pi_config_files/cedar_detect.service" /lib/systemd/system/cedar_detect.service
 sudo systemctl daemon-reload
 sudo systemctl enable cedar_detect
 sudo systemctl enable pifinder
 sudo systemctl enable pifinder_splash
 
-echo "PiFinder setup complete, please restart the Pi"
+for group in input video render dialout gpio i2c spi; do
+    if getent group "${group}" >/dev/null; then
+        sudo usermod -aG "${group}" "${PIFINDER_USER}"
+    fi
+done
 
+echo "PiFinder setup complete, please restart the Pi"

--- a/pifinder_update.sh
+++ b/pifinder_update.sh
@@ -1,7 +1,12 @@
 #! /usr/bin/bash
+set -e
+
+PIFINDER_REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${PIFINDER_REPO_DIR}/pifinder_paths.sh"
+
+cd "${PIFINDER_REPO_DIR}"
 git checkout release
 git pull
-source /home/pifinder/PiFinder/pifinder_post_update.sh
+source "${PIFINDER_REPO_DIR}/pifinder_post_update.sh"
 
 echo "PiFinder software update complete, please restart the Pi"
-

--- a/python/PiFinder/api_extensions.py
+++ b/python/PiFinder/api_extensions.py
@@ -21,6 +21,7 @@ import logging
 
 from flask import request, session, Response
 from PIL import Image
+from PiFinder import utils
 
 logger = logging.getLogger("PiFinderAPI")
 
@@ -726,7 +727,7 @@ def register_api_routes(app, server_instance, require_auth=False):
         try:
             from pathlib import Path
 
-            debug_dir = Path("/home/pifinder/PiFinder_data/solver_debug_dumps")
+            debug_dir = utils.debug_dump_dir
             if not debug_dir.exists():
                 debug_dir = Path("solver_debug_dumps")
             if not debug_dir.exists():

--- a/python/PiFinder/boot_config.py
+++ b/python/PiFinder/boot_config.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def get_boot_config_path() -> Path:
+    """Return the active Raspberry Pi boot config path."""
+    firmware_config = Path("/boot/firmware/config.txt")
+    if firmware_config.exists():
+        return firmware_config
+    return Path("/boot/config.txt")

--- a/python/PiFinder/switch_camera.py
+++ b/python/PiFinder/switch_camera.py
@@ -1,18 +1,18 @@
 #!/usr/bin/python
 import sys
 
+from PiFinder.boot_config import get_boot_config_path
+
 
 def switch_boot(cam_type: str) -> None:
     """
-    Edit /boot/config.txt to swap camera drive
-    must be run as roo
+    Edit the Raspberry Pi boot config to swap camera driver.
+    Must be run as root.
     """
-    if cam_type == "imx462":
-        # The 462 uses the 290 driver
-        cam_type = "imx290"
+    boot_config_path = get_boot_config_path()
 
     # read config.txt into a list
-    with open("/boot/config.txt", "r") as boot_in:
+    with open(boot_config_path, "r") as boot_in:
         boot_lines = list(boot_in)
 
     # Disable any existing cams
@@ -31,13 +31,13 @@ def switch_boot(cam_type: str) -> None:
             cam_added = True
 
     if not cam_added:
-        if cam_type == "imx290":
+        if cam_type in ("imx290", "imx462"):
             boot_lines.append(f"dtoverlay={cam_type},clock-frequency=74250000\n")
         else:
             boot_lines.append(f"dtoverlay={cam_type}\n")
         cam_added = True
 
-    with open("/boot/config.txt", "w") as boot_out:
+    with open(boot_config_path, "w") as boot_out:
         for line in boot_lines:
             boot_out.write(line)
 

--- a/python/PiFinder/sys_utils.py
+++ b/python/PiFinder/sys_utils.py
@@ -12,7 +12,7 @@ import socket
 from PiFinder import utils
 import logging
 
-BACKUP_PATH = "/home/pifinder/PiFinder_data/PiFinder_backup.zip"
+BACKUP_PATH = str(utils.data_dir / "PiFinder_backup.zip")
 
 logger = logging.getLogger("SysUtils")
 
@@ -236,13 +236,13 @@ class Network:
 
 def go_wifi_ap():
     logger.info("SYS: Switching to AP")
-    sh.sudo("/home/pifinder/PiFinder/switch-ap.sh")
+    sh.sudo(str(utils.pifinder_dir / "switch-ap.sh"))
     return True
 
 
 def go_wifi_cli():
     logger.info("SYS: Switching to Client")
-    sh.sudo("/home/pifinder/PiFinder/switch-cli.sh")
+    sh.sudo(str(utils.pifinder_dir / "switch-cli.sh"))
     return True
 
 
@@ -269,9 +269,9 @@ def backup_userdata():
     _zip = sh.Command("zip")
     _zip(
         BACKUP_PATH,
-        "/home/pifinder/PiFinder_data/config.json",
-        "/home/pifinder/PiFinder_data/observations.db",
-        glob.glob("/home/pifinder/PiFinder_data/obslists/*"),
+        str(utils.data_dir / "config.json"),
+        str(utils.data_dir / "observations.db"),
+        glob.glob(str(utils.data_dir / "obslists" / "*")),
     )
 
     return BACKUP_PATH
@@ -317,7 +317,7 @@ def update_software():
     service
     """
     logger.info("SYS: Running update")
-    sh.bash("/home/pifinder/PiFinder/pifinder_update.sh")
+    sh.bash(str(utils.pifinder_dir / "pifinder_update.sh"))
     return True
 
 
@@ -478,7 +478,7 @@ def set_power_led(on: bool) -> None:
 # ---------------------------------------------------------------------------
 
 MIGRATION_PROGRESS_FILE = "/tmp/nixos_migration_progress"
-MIGRATION_SCRIPT = "/home/pifinder/PiFinder/python/scripts/nixos_migration.sh"
+MIGRATION_SCRIPT = str(utils.pifinder_dir / "python/scripts/nixos_migration.sh")
 
 
 def _fetch_migration_sha256(version_info: dict) -> str:

--- a/python/PiFinder/ui/callbacks.py
+++ b/python/PiFinder/ui/callbacks.py
@@ -17,6 +17,7 @@ import pytz
 
 from typing import Any, TYPE_CHECKING
 from PiFinder import utils, calc_utils
+from PiFinder.boot_config import get_boot_config_path
 from PiFinder.locations import Location as SavedLocation
 from PiFinder.state import Location
 from PiFinder.ui.base import UIModule
@@ -213,14 +214,14 @@ def get_camera_type(ui_module: UIModule) -> list[str]:
     cam_id = "000"
 
     # read config.txt into a list
-    with open("/boot/config.txt", "r") as boot_in:
+    with open(get_boot_config_path(), "r") as boot_in:
         boot_lines = list(boot_in)
 
     # Look for the line without a comment...
     for line in boot_lines:
         if line.startswith("dtoverlay=imx"):
             cam_id = line[10:16]
-            # imx462 uses imx290 driver
+            # Older installs used the imx290 overlay for imx462 cameras.
             if cam_id == "imx290":
                 cam_id = "imx462"
 

--- a/python/views/tools.html
+++ b/python/views/tools.html
@@ -27,7 +27,7 @@
   <div class="card-content">
     <h5 class="grey-text">{{ _('Change Password') }}</h5>
     <div class="row">
-        <p class="grey-text">{{ _('This will change the password for this web interface and the user account pifinder for ssh and other tools') }}</p>
+        <p class="grey-text">{{ _('This will change the password for this web interface and the current system user account for SSH and other tools') }}</p>
     </div>
     <form action="/tools/pwchange" method="post" id="pwchange_form" class="col s12"> 
         <div class="row">

--- a/switch-ap.sh
+++ b/switch-ap.sh
@@ -1,8 +1,9 @@
 #! /usr/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cp /etc/dhcpcd.conf.ap /etc/dhcpcd.conf
 systemctl enable dnsmasq
 systemctl enable hostapd
-echo -n "AP" > /home/pifinder/PiFinder/wifi_status.txt
+echo -n "AP" > "${SCRIPT_DIR}/wifi_status.txt"
 #systemctl start dnsmasq
 #systemctl start hostapd
 #systemctl restart dhcpcd

--- a/switch-cli.sh
+++ b/switch-cli.sh
@@ -1,8 +1,9 @@
 #! /usr/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 #systemctl stop dnsmasq
 #systemctl stop hostapd
 cp /etc/dhcpcd.conf.sta /etc/dhcpcd.conf
 systemctl disable dnsmasq
 systemctl disable hostapd
 #systemctl restart dhcpcd
-echo -n "Client" > /home/pifinder/PiFinder/wifi_status.txt
+echo -n "Client" > "${SCRIPT_DIR}/wifi_status.txt"


### PR DESCRIPTION
## Summary

This draft PR is the first split from my Raspberry Pi 4/CM5 Bookworm compatibility branch.

It focuses only on the install/path foundation:

- add shared shell path helpers for the current OS user and data directory
- prefer /boot/firmware/config.txt on Bookworm, with /boot/config.txt fallback
- render systemd/Samba templates with the actual install user and paths
- remove several hard-coded /home/pifinder paths from install/update/migration/runtime helpers
- keep the upstream Rev-4 gpio-poweroff setup while writing to the active boot config path
- make pifinder_setup.sh friendlier to Raspberry Pi OS Bookworm package/service behavior

Out of scope for this PR:

- board-specific GPS/UART defaults
- Bluetooth keyboard UI/input work
- focus/gain display changes
- Korean localization
- MF_PiFinder-specific documentation

## Tested

- bash -n pifinder_paths.sh pifinder_setup.sh pifinder_update.sh pifinder_post_update.sh switch-ap.sh switch-cli.sh migration_source/*.sh
- python3 -m compileall -q PiFinder
- python3 -m ruff check PiFinder tests
- python3 -m pytest tests/test_main.py tests/test_menu_struct.py -q
- python3 -m pytest tests/test_sys_utils.py -q

## Note

On this Raspberry Pi 4 test system, python3 -m pytest -m smoke currently fails during collection on upstream main because newly added battery/hardware/tetra3 tests import hardware-specific modules before marker selection completes. The targeted smoke files above pass.