### PR TITLE
feat(migration): source the migration tarball from the update manifest (stable→beta→unstable)

### DIFF
--- a/python/PiFinder/ui/software.py
+++ b/python/PiFinder/ui/software.py
@@ -28,25 +28,25 @@ REQUEST_TIMEOUT = 10
 MIGRATION_GATE_URL = (
     "https://raw.githubusercontent.com/brickbots/PiFinder/release/migration_gate.json"
 )
+UPDATE_MANIFEST_URL = (
+    "https://raw.githubusercontent.com/brickbots/PiFinder/"
+    "nixos-manifest/update-manifest.json"
+)
 
 # Secret unlock: 7x square button
 _UNLOCK_SEQUENCE = ["square"] * 7
 
-_MIGRATION_VERSION_INFO = {
-    "version": "3.0.0",
-    "type": "upgrade",
-    "migration_size_mb": 292,
-    "migration_url": "https://github.com/mrosseel/PiFinder/releases/download/v3.0.0-migration/pifinder-nixos-v3.0.0.tar.zst",
-    "migration_sha256_url": "https://github.com/mrosseel/PiFinder/releases/download/v3.0.0-migration/pifinder-nixos-v3.0.0.tar.zst.sha256",
-}
+# Migration targets are read from the update manifest, consulted in descending
+# stability; the first available entry carrying a migration tarball wins.
+_MIGRATION_CHANNELS = ("stable", "beta", "unstable")
 
 
 def _fetch_migration_config() -> Optional[dict]:
-    """Fetch and parse the remote migration config JSON.
+    """Fetch and parse the remote migration gate JSON.
 
-    Returns the parsed dict if it contains a usable `nixos_url`; None on
-    network error, non-200 response, malformed JSON, or missing url.
-    The `nixos_for_everyone` gate is enforced by the caller.
+    Returns the parsed dict on success; None on network error, non-200
+    response, or malformed JSON. Only the `nixos_for_everyone` flag is used by
+    the caller — the tarball itself comes from the update manifest.
     """
     try:
         res = requests.get(MIGRATION_GATE_URL, timeout=REQUEST_TIMEOUT)
@@ -60,9 +60,85 @@ def _fetch_migration_config() -> Optional[dict]:
         return None
     if not isinstance(data, dict):
         return None
-    if not data.get("nixos_url"):
+    return data
+
+
+def _fetch_update_manifest() -> Optional[dict]:
+    """Fetch and parse the update manifest, or None on any failure."""
+    try:
+        res = requests.get(UPDATE_MANIFEST_URL, timeout=REQUEST_TIMEOUT)
+    except requests.exceptions.RequestException:
+        return None
+    if res.status_code != 200:
+        return None
+    try:
+        data = res.json()
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
         return None
     return data
+
+
+def _fetch_download_size_mb(url: str) -> Optional[int]:
+    """Return the tarball download size in MB from a HEAD request, or None.
+
+    GitHub release assets 302-redirect to a signed URL whose response carries
+    the real Content-Length, so redirects must be followed. Returns None on
+    network error, non-200 status, or a missing/unparseable Content-Length.
+    """
+    try:
+        res = requests.head(url, allow_redirects=True, timeout=REQUEST_TIMEOUT)
+    except requests.exceptions.RequestException:
+        return None
+    if res.status_code != 200:
+        return None
+    length = res.headers.get("Content-Length")
+    if length is None:
+        return None
+    try:
+        return round(int(length) / (1024 * 1024))
+    except (TypeError, ValueError):
+        return None
+
+
+def _migration_version_info_from_manifest() -> Optional[dict]:
+    """Select a migration target from the update manifest.
+
+    Walks channels stable -> beta -> unstable and returns version_info for the
+    first available entry that carries a migration tarball, or None if the
+    manifest can't be fetched or has no such entry.
+    """
+    manifest = _fetch_update_manifest()
+    if not manifest:
+        return None
+    channels = manifest.get("channels")
+    if not isinstance(channels, dict):
+        return None
+    for channel in _MIGRATION_CHANNELS:
+        entries = channels.get(channel)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict) or not entry.get("available"):
+                continue
+            url = entry.get("migration_url")
+            sha_url = entry.get("migration_sha256_url")
+            if not url or not sha_url:
+                continue
+            version_info = {
+                "version": entry.get("version", "?"),
+                "type": "upgrade",
+                "migration_url": url,
+                "migration_sha256_url": sha_url,
+            }
+            # Size comes from a live HEAD on the tarball; omitted on failure
+            # (the confirm screen then shows "?").
+            size_mb = _fetch_download_size_mb(url)
+            if size_mb is not None:
+                version_info["migration_size_mb"] = size_mb
+            return version_info
+    return None
 
 
 def update_needed(current_version: str, repo_version: str) -> bool:
@@ -127,9 +203,14 @@ class UISoftware(UIModule):
             self._key_buffer = self._key_buffer[-len(_UNLOCK_SEQUENCE) :]
         if self._key_buffer == _UNLOCK_SEQUENCE:
             self._key_buffer = []
-            # Unlock: self-contained — uses the hardcoded URLs and does not
-            # require the remote migration_gate.json to exist.
-            self._trigger_migration(dict(_MIGRATION_VERSION_INFO))
+            # Unlock: offer the first available migration target from the
+            # manifest, ignoring the nixos_for_everyone gate (that governs only
+            # the public path).
+            version_info = _migration_version_info_from_manifest()
+            if version_info:
+                self._trigger_migration(version_info)
+            else:
+                self.message(_("No release found"), 2)
 
     def _trigger_migration(self, version_info: dict):
         """Push UIMigrationConfirm onto the UI stack with the supplied
@@ -152,12 +233,12 @@ class UISoftware(UIModule):
         """
         config = _fetch_migration_config()
         if config and config.get("nixos_for_everyone"):
-            version_info = dict(_MIGRATION_VERSION_INFO)
-            nixos_url = config["nixos_url"]
-            version_info["migration_url"] = nixos_url
-            version_info["migration_sha256_url"] = f"{nixos_url}.sha256"
-            self._trigger_migration(version_info)
-            return
+            # Gate is open for everyone; the tarball comes from the manifest
+            # (stable -> beta -> unstable).
+            version_info = _migration_version_info_from_manifest()
+            if version_info:
+                self._trigger_migration(version_info)
+                return
 
         try:
             res = requests.get(

--- a/python/tests/test_software.py
+++ b/python/tests/test_software.py
@@ -7,6 +7,8 @@ from PiFinder.ui.software import (
     update_needed,
     _strip_markdown,
     _fetch_migration_config,
+    _fetch_update_manifest,
+    _migration_version_info_from_manifest,
     _UNLOCK_SEQUENCE,
 )
 
@@ -105,23 +107,19 @@ class TestFetchMigrationConfig:
         assert _fetch_migration_config() == payload
 
     @patch("PiFinder.ui.software.requests.get")
-    def test_returns_dict_when_gate_closed_but_url_set(self, mock_get):
-        # Gate check is the caller's job; fetch only requires nixos_url.
-        payload = {"nixos_for_everyone": False, "nixos_url": _NIXOS_URL}
+    def test_returns_dict_when_gate_closed(self, mock_get):
+        # Gate check is the caller's job; fetch just parses the JSON.
+        payload = {"nixos_for_everyone": False}
         mock_get.return_value = _mock_json_response(payload)
         assert _fetch_migration_config() == payload
 
     @patch("PiFinder.ui.software.requests.get")
-    def test_returns_none_when_url_missing(self, mock_get):
-        mock_get.return_value = _mock_json_response({"nixos_for_everyone": True})
-        assert _fetch_migration_config() is None
-
-    @patch("PiFinder.ui.software.requests.get")
-    def test_returns_none_when_url_empty(self, mock_get):
-        mock_get.return_value = _mock_json_response(
-            {"nixos_for_everyone": True, "nixos_url": ""}
-        )
-        assert _fetch_migration_config() is None
+    def test_returns_dict_without_url(self, mock_get):
+        # The tarball comes from the manifest now, so the gate no longer needs a
+        # nixos_url — only the nixos_for_everyone flag matters to the caller.
+        payload = {"nixos_for_everyone": True}
+        mock_get.return_value = _mock_json_response(payload)
+        assert _fetch_migration_config() == payload
 
     @patch("PiFinder.ui.software.requests.get")
     def test_returns_none_on_http_error(self, mock_get):
@@ -149,3 +147,141 @@ class TestFetchMigrationConfig:
     def test_returns_none_when_payload_is_not_object(self, mock_get):
         mock_get.return_value = _mock_json_response(["nixos_for_everyone"])
         assert _fetch_migration_config() is None
+
+
+def _migration_entry(version="3.0.0", available=True, with_urls=True):
+    entry = {"version": version, "available": available}
+    if with_urls:
+        base = f"https://example.invalid/releases/download/v{version}"
+        entry["migration_url"] = f"{base}/pifinder-migration-v{version}.tar.zst"
+        entry["migration_sha256_url"] = (
+            f"{base}/pifinder-migration-v{version}.tar.zst.sha256"
+        )
+    return entry
+
+
+def _manifest(stable=None, beta=None, unstable=None):
+    return {
+        "channels": {
+            "stable": stable or [],
+            "beta": beta or [],
+            "unstable": unstable or [],
+        }
+    }
+
+
+@pytest.mark.unit
+class TestFetchUpdateManifest:
+    @patch("PiFinder.ui.software.requests.get")
+    def test_returns_dict(self, mock_get):
+        payload = {"channels": {}}
+        mock_get.return_value = _mock_json_response(payload)
+        assert _fetch_update_manifest() == payload
+
+    @patch("PiFinder.ui.software.requests.get")
+    def test_none_on_http_error(self, mock_get):
+        mock_get.return_value = _mock_json_response({}, status_code=500)
+        assert _fetch_update_manifest() is None
+
+    @patch("PiFinder.ui.software.requests.get")
+    def test_none_on_malformed_json(self, mock_get):
+        mock_get.return_value = _mock_invalid_json_response()
+        assert _fetch_update_manifest() is None
+
+
+def _mock_head_response(size_bytes=None, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = {} if size_bytes is None else {"Content-Length": str(size_bytes)}
+    return resp
+
+
+# Selection also HEADs the chosen tarball for its size, so requests.head is
+# stubbed throughout (never hit the network from tests).
+@pytest.mark.unit
+@patch(
+    "PiFinder.ui.software.requests.head",
+    side_effect=requests.exceptions.ConnectionError,
+)
+class TestMigrationVersionInfoFromManifest:
+    @patch("PiFinder.ui.software.requests.get")
+    def test_prefers_stable(self, mock_get, _mock_head):
+        mock_get.return_value = _mock_json_response(
+            _manifest(
+                stable=[_migration_entry("3.0.0")],
+                beta=[_migration_entry("3.1.0-beta")],
+                unstable=[_migration_entry("nixos-abc")],
+            )
+        )
+        info = _migration_version_info_from_manifest()
+        assert info["version"] == "3.0.0"
+        assert info["type"] == "upgrade"
+        assert info["migration_url"].endswith("pifinder-migration-v3.0.0.tar.zst")
+        assert info["migration_sha256_url"].endswith(".sha256")
+
+    @patch("PiFinder.ui.software.requests.get")
+    def test_includes_size_when_head_succeeds(self, mock_get, mock_head):
+        mock_get.return_value = _mock_json_response(
+            _manifest(stable=[_migration_entry("3.0.0")])
+        )
+        mock_head.side_effect = None
+        mock_head.return_value = _mock_head_response(size_bytes=300 * 1024 * 1024)
+        info = _migration_version_info_from_manifest()
+        assert info["migration_size_mb"] == 300
+
+    @patch("PiFinder.ui.software.requests.get")
+    def test_omits_size_when_head_fails(self, mock_get, _mock_head):
+        mock_get.return_value = _mock_json_response(
+            _manifest(stable=[_migration_entry("3.0.0")])
+        )
+        info = _migration_version_info_from_manifest()
+        assert "migration_size_mb" not in info
+
+    @patch("PiFinder.ui.software.requests.get")
+    def test_falls_back_to_beta_when_stable_empty(self, mock_get, _mock_head):
+        mock_get.return_value = _mock_json_response(
+            _manifest(beta=[_migration_entry("3.1.0-beta")])
+        )
+        assert _migration_version_info_from_manifest()["version"] == "3.1.0-beta"
+
+    @patch("PiFinder.ui.software.requests.get")
+    def test_falls_back_to_unstable_last(self, mock_get, _mock_head):
+        mock_get.return_value = _mock_json_response(
+            _manifest(unstable=[_migration_entry("nixos-abc")])
+        )
+        assert _migration_version_info_from_manifest()["version"] == "nixos-abc"
+
+    @patch("PiFinder.ui.software.requests.get")
+    def test_skips_unavailable_entries(self, mock_get, _mock_head):
+        mock_get.return_value = _mock_json_response(
+            _manifest(
+                stable=[_migration_entry("3.0.0", available=False)],
+                beta=[_migration_entry("3.1.0-beta")],
+            )
+        )
+        assert _migration_version_info_from_manifest()["version"] == "3.1.0-beta"
+
+    @patch("PiFinder.ui.software.requests.get")
+    def test_skips_entries_without_migration_tarball(self, mock_get, _mock_head):
+        mock_get.return_value = _mock_json_response(
+            _manifest(
+                stable=[_migration_entry("3.0.0", with_urls=False)],
+                beta=[_migration_entry("3.1.0-beta")],
+            )
+        )
+        assert _migration_version_info_from_manifest()["version"] == "3.1.0-beta"
+
+    @patch("PiFinder.ui.software.requests.get")
+    def test_none_when_no_migration_entries(self, mock_get, _mock_head):
+        mock_get.return_value = _mock_json_response(_manifest())
+        assert _migration_version_info_from_manifest() is None
+
+    @patch("PiFinder.ui.software.requests.get")
+    def test_none_on_network_error(self, mock_get, _mock_head):
+        mock_get.side_effect = requests.exceptions.ConnectionError
+        assert _migration_version_info_from_manifest() is None
+
+    @patch("PiFinder.ui.software.requests.get")
+    def test_none_when_channels_missing(self, mock_get, _mock_head):
+        mock_get.return_value = _mock_json_response({"schema": 1})
+        assert _migration_version_info_from_manifest() is None


### PR DESCRIPTION
Replaces the hardcoded migration tarball URL with a lookup in the update manifest, so migration follows releases automatically instead of a pinned `v3.0.0-migration` URL.

## What changed
- New `_migration_version_info_from_manifest()`: fetches `update-manifest.json` (brickbots `nixos-manifest`), walks channels **stable → beta → unstable**, and returns `version_info` (`version`, `type`, `migration_url`, `migration_sha256_url`) for the **first available entry that carries a migration tarball**. Skips unavailable entries and entries without a tarball.
- **Unlock (7× square):** now offers the first-available manifest target (was the hardcoded `_MIGRATION_VERSION_INFO`); shows "No release found" if the manifest has none.
- **Public/automatic path:** still gated by `nixos_for_everyone` (unchanged rollout control), but the tarball now comes from the manifest rather than the gate's `nixos_url`. `_fetch_migration_config()` no longer requires `nixos_url` — it only carries the gate flag.
- Removed the hardcoded `_MIGRATION_VERSION_INFO`.

Depends on the manifest carrying `migration_url`/`migration_sha256_url`, added by the release workflow in #516.

## Tests
- 37 pass. Added `TestFetchUpdateManifest` + `TestMigrationVersionInfoFromManifest` (channel priority, beta/unstable fallback, skip unavailable, skip entries without a tarball, network/JSON failure → None). Updated the two obsolete `_fetch_migration_config` url-requirement tests.

Note: the new "No release found" string needs `nox -s babel` extraction before translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)