### PR TITLE
ci: cut the migration tarball from the minimal migration image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,20 @@ jobs:
           path: result-sd/sd-image/*.img.zst
           retention-days: 1
 
+      # The migration tarball is cut from the MINIMAL migration system, not the
+      # full image — it resolves the full system from the update manifest at
+      # first boot (ADR 0004 / 0003).
+      - name: Build migration image
+        run: |
+          nix build .#images.pifinder-migration -L -o result-mig
+
+      - name: Upload migration image
+        uses: actions/upload-artifact@v4
+        with:
+          name: migimage-native
+          path: result-mig/sd-image/*.img.zst
+          retention-days: 1
+
   # Poll the native builder for ~15 min, then decide whether to fall back.
   native-wait:
     runs-on: ubuntu-latest
@@ -178,6 +192,18 @@ jobs:
           path: result-sd/sd-image/*.img.zst
           retention-days: 1
 
+      # Minimal migration system — see the native job's comment (ADR 0004).
+      - name: Build migration image
+        run: |
+          nix build .#images.pifinder-migration -L -o result-mig
+
+      - name: Upload migration image
+        uses: actions/upload-artifact@v4
+        with:
+          name: migimage-hosted
+          path: result-mig/sd-image/*.img.zst
+          retention-days: 1
+
   # Arch-independent: package the migration tarball + checksums and publish. Runs
   # on whichever build succeeded (native preferred).
   release:
@@ -213,6 +239,20 @@ jobs:
           name: sdimage-hosted
           path: img-hosted
 
+      - name: Download native migration image
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: migimage-native
+          path: mig-native
+
+      - name: Download hosted migration image
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: migimage-hosted
+          path: mig-hosted
+
       - name: Compute tag
         run: |
           TAG="v${{ inputs.version }}"
@@ -222,23 +262,26 @@ jobs:
       - name: Assemble image + migration tarball + checksums
         run: |
           set -euo pipefail
-          # Only one dir may exist (downloads are continue-on-error); create both
-          # so find can't fail under pipefail. Prefer the native image (listed
-          # first); fall back to hosted.
-          mkdir -p img-native img-hosted
+          # Only some dirs may exist (downloads are continue-on-error); create
+          # all so find can't fail under pipefail. Prefer the native builder's
+          # artifacts (listed first); fall back to hosted.
+          mkdir -p img-native img-hosted mig-native mig-hosted
           IMAGE_SRC=$(find img-native img-hosted -type f -name '*.img.zst' -print -quit)
-          if [ -z "$IMAGE_SRC" ]; then
-            echo "No SD image artifact found from either builder" >&2
+          MIG_SRC=$(find mig-native mig-hosted -type f -name '*.img.zst' -print -quit)
+          if [ -z "$IMAGE_SRC" ] || [ -z "$MIG_SRC" ]; then
+            echo "Missing artifact: sd=[$IMAGE_SRC] migration=[$MIG_SRC]" >&2
             exit 1
           fi
           mkdir -p release
           cp "$IMAGE_SRC" "release/pifinder-${TAG}.img.zst"
 
-          # Decompress to a loopback-mountable image for the migration tarball.
-          rm -f /tmp/pifinder-release.img
-          zstd -d "$IMAGE_SRC" -o /tmp/pifinder-release.img
+          # The migration tarball is cut from the MINIMAL migration image — it
+          # resolves the full system from the update manifest at first boot, so
+          # its content never goes stale (ADR 0004 / 0003).
+          rm -f /tmp/pifinder-mig.img
+          zstd -d "$MIG_SRC" -o /tmp/pifinder-mig.img
 
-          LOOP=$(sudo losetup --find --show --partscan /tmp/pifinder-release.img)
+          LOOP=$(sudo losetup --find --show --partscan /tmp/pifinder-mig.img)
           sudo mkdir -p /mnt/boot /mnt/root
           sudo mount "${LOOP}p1" /mnt/boot
           sudo mount "${LOOP}p2" /mnt/root
@@ -246,13 +289,10 @@ jobs:
           mkdir -p /tmp/tarball-staging
           sudo cp -a /mnt/boot /tmp/tarball-staging/boot
           sudo cp -a /mnt/root /tmp/tarball-staging/rootfs
-          # Migration tarball omits catalog images to stay small; devices keep
-          # their own copy.
-          sudo rm -rf /tmp/tarball-staging/rootfs/home/pifinder/PiFinder_data/catalog_images
 
           sudo umount /mnt/boot /mnt/root
           sudo losetup -d "$LOOP"
-          rm -f /tmp/pifinder-release.img
+          rm -f /tmp/pifinder-mig.img
 
           sudo tar -C /tmp/tarball-staging -cf - \
             --exclude='*/lost+found' \


### PR DESCRIPTION
The migration tarball release asset is now built from the **minimal** migration image (`images.pifinder-migration`) instead of the full SD image.

- The minimal system downloads the full PiFinder system from the update manifest at first boot (ADR 0003/0004), so the tarball works regardless of when it was built.
- The previous full-system tarball was ~1.4 GB per release and froze migrated devices to the tarball's build date.
- Both build jobs now also build and upload the migration image; the release job requires both artifacts and tars the minimal one.
- The full SD image asset (fresh-flash path) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)