### PR TITLE
fix(obslist): import Stellarium 2.0 observing lists

### DIFF
--- a/python/PiFinder/obslist.py
+++ b/python/PiFinder/obslist.py
@@ -16,6 +16,7 @@ import os
 import logging
 from PiFinder import utils
 from PiFinder.calc_utils import sf_utils
+from PiFinder.obj_types import OBJ_TYPES
 from PiFinder.catalog_base import VirtualIDManager
 from PiFinder.catalogs import Catalogs
 from PiFinder.composite_object import CompositeObject
@@ -105,12 +106,16 @@ def _coordinate_object(entry: ObsListEntry, index: int) -> CompositeObject:
         except Exception:
             pass
     virtual_id = VirtualIDManager.mint_id()
+    # Only known type codes may reach the object: a raw source string like
+    # "Nebula" matches no Type filter entry, so the object would import but
+    # never display. Unknown types become '?' and stay visible.
+    obj_type = entry.obj_type if entry.obj_type in OBJ_TYPES else "?"
     return CompositeObject(
         id=virtual_id,
         object_id=virtual_id,
         ra=entry.ra,
         dec=entry.dec,
-        obj_type=entry.obj_type or "?",
+        obj_type=obj_type,
         const=const,
         size=entry.size,
         # Coordinate objects always carry catalog code OBS (see Catalog

--- a/python/PiFinder/obslist_formats.py
+++ b/python/PiFinder/obslist_formats.py
@@ -96,8 +96,8 @@ def format_dec_string(dec: float) -> str:
 
 
 def _parse_ra_string(s: str) -> float:
-    """Parse RA from 'Xh Xm X.Xs' format to degrees."""
-    match = re.match(r"(\d+)h\s+(\d+)m\s+([\d.]+)s", s.strip())
+    """Parse RA from 'Xh Xm X.Xs' or 'XhXmX.Xs' format to degrees."""
+    match = re.match(r"(\d+)h\s*(\d+)m\s*([\d.]+)s", s.strip())
     if match:
         return ra_to_deg(
             int(match.group(1)), int(match.group(2)), float(match.group(3))
@@ -491,6 +491,69 @@ def read_text(text: str) -> ObsList:
 
 # ── Stellarium (.sol) ──────────────────────────────────────────────────
 
+# Stellarium's 2.0 export writes object types as English display names
+# (NebulaMgr type strings), keyed here lowercased -> PiFinder type code.
+# Unknown types map to "?" so they still pass the default Type filter.
+STELLARIUM_TYPE_MAP: dict[str, str] = {
+    "galaxy": "Gx",
+    "active galaxy": "Gx",
+    "radio galaxy": "Gx",
+    "interacting galaxy": "Gx",
+    "galaxy pair": "Gx",
+    "galaxy triplet": "Gx",
+    "group of galaxies": "Gx",
+    "quasar": "Gx",
+    "blazar": "Gx",
+    "bll object": "Gx",
+    "open star cluster": "OC",
+    "open cluster": "OC",
+    "star cluster": "OC",
+    "stellar association": "OC",
+    "globular star cluster": "Gb",
+    "globular cluster": "Gb",
+    "nebula": "Nb",
+    "emission nebula": "Nb",
+    "reflection nebula": "Nb",
+    "bipolar nebula": "Nb",
+    "protoplanetary nebula": "Nb",
+    "hii region": "Nb",
+    "emission object": "Nb",
+    "interstellar matter": "Nb",
+    "supernova remnant": "Nb",
+    "supernova candidate": "Nb",
+    "supernova remnant candidate": "Nb",
+    "molecular cloud": "Nb",
+    "planetary nebula": "PN",
+    "possible planetary nebula": "PN",
+    "dark nebula": "DN",
+    "cluster associated with nebulosity": "C+N",
+    "star": "*",
+    "symbiotic star": "*",
+    "emission-line star": "*",
+    "double star": "D*",
+    "asterism": "Ast",
+    "planet": "Pla",
+    "moon": "Pla",
+    "minor planet": "Pla",
+    "dwarf planet": "Pla",
+    "comet": "CM",
+    "region of the sky": "?",
+}
+
+
+def _map_stellarium_type(type_str: str) -> str:
+    """Map a Stellarium type string to a PiFinder type code.
+
+    Already-valid codes pass through (v1.0 files written by PiFinder store
+    codes); anything else unrecognized becomes '?' rather than leaking a raw
+    display string that no Type filter would ever select.
+    """
+    if not type_str:
+        return ""
+    if type_str in ARGO_TYPE_MAP:  # ARGO_TYPE_MAP keys the PiFinder code set
+        return type_str
+    return STELLARIUM_TYPE_MAP.get(type_str.strip().lower(), "?")
+
 
 def write_stellarium(obs_list: ObsList) -> str:
     data = {
@@ -516,10 +579,21 @@ def write_stellarium(obs_list: ObsList) -> str:
 def read_stellarium(text: str) -> ObsList:
     data = json.loads(text)
     name = data.get("shortName", "")
+    objects = data.get("objects", [])
+    # Version 2.0 (Stellarium's current export) nests objects one level down:
+    # observingLists -> {olud} -> {name, objects}. Import the default list,
+    # falling back to the first one.
+    observing_lists = data.get("observingLists")
+    if isinstance(observing_lists, dict) and observing_lists:
+        olud = data.get("defaultListOlud", "")
+        obs_list_data = observing_lists.get(olud, next(iter(observing_lists.values())))
+        name = obs_list_data.get("name", "") or name
+        objects = obs_list_data.get("objects", [])
     entries: list[ObsListEntry] = []
-    for obj in data.get("objects", []):
+    for obj in objects:
         designation = obj.get("designation", "")
-        obj_type = obj.get("objtype", "")
+        # v1.0 wrote 'objtype'; v2.0 writes 'type'.
+        obj_type = _map_stellarium_type(obj.get("objtype", "") or obj.get("type", ""))
         ra = _parse_ra_string(obj.get("ra", ""))
         dec = _parse_dec_string(obj.get("dec", ""))
         mag: Optional[float] = None
@@ -1141,9 +1215,11 @@ def detect_format(text: str, filename: str = "") -> str:
     if stripped.startswith("{"):
         try:
             data = json.loads(text)
-            if "version" in data and "objects" in data:
+            # .pifinder writes an integer version; Stellarium writes a string
+            # ("1.0"/"2.0"), so the type disambiguates the two JSON formats.
+            if isinstance(data.get("version"), int) and "objects" in data:
                 return "pifinder"
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValueError, AttributeError):
             pass
         return "stellarium"
     if stripped.startswith("!J2000"):

--- a/python/tests/test_obslist_formats.py
+++ b/python/tests/test_obslist_formats.py
@@ -5,6 +5,8 @@ Each format is tested by creating an ObsList, writing it to a string,
 reading it back, and verifying the entries match.
 """
 
+import json
+
 import pytest
 from PiFinder.calc_utils import (
     ra_to_hms_exact,
@@ -210,6 +212,71 @@ def test_stellarium_roundtrip():
     parsed = read_stellarium(text)
     assert parsed.name == "Test List"
     _assert_entries_close(obs.entries, parsed.entries, ra_tol=0.15, dec_tol=0.15)
+
+
+@pytest.mark.unit
+def test_stellarium_v2_import():
+    # Stellarium's current export: objects nested under observingLists,
+    # spaceless RA strings, and 'type' instead of 'objtype'.
+    text = json.dumps(
+        {
+            "defaultListOlud": "{uuid-2}",
+            "observingLists": {
+                "{uuid-1}": {
+                    "name": "Other List",
+                    "objects": [],
+                },
+                "{uuid-2}": {
+                    "name": "Juli 2026",
+                    "objects": [
+                        {
+                            "designation": "Dumbbell Nebula",
+                            "ra": "19h59m37.8s",
+                            "dec": "+22°43'17\"",
+                            "magnitude": "7.40",
+                            "type": "Nebula",
+                        }
+                    ],
+                },
+            },
+            "shortName": "Observing list for Stellarium",
+            "version": "2.0",
+        }
+    )
+    parsed = read_stellarium(text)
+    assert parsed.name == "Juli 2026"
+    assert len(parsed.entries) == 1
+    entry = parsed.entries[0]
+    assert entry.name == "Dumbbell Nebula"
+    # Stellarium type strings map to PiFinder type codes so imported
+    # objects pass the Type filter.
+    assert entry.obj_type == "Nb"
+    assert entry.ra == pytest.approx(299.9075, abs=0.01)
+    assert entry.dec == pytest.approx(22.7214, abs=0.01)
+    assert entry.mag.filter_mag == pytest.approx(7.4)
+
+
+@pytest.mark.unit
+def test_stellarium_type_mapping():
+    def _read_type(type_str):
+        text = json.dumps(
+            {
+                "version": "1.0",
+                "shortName": "x",
+                "objects": [
+                    {"designation": "n", "objtype": type_str, "ra": "", "dec": ""}
+                ],
+            }
+        )
+        return read_stellarium(text).entries[0].obj_type
+
+    assert _read_type("Planetary Nebula") == "PN"
+    assert _read_type("open star cluster") == "OC"
+    # PiFinder codes (from our own v1.0 exports) pass through unchanged
+    assert _read_type("Gx") == "Gx"
+    # Unknown strings become '?' so the default Type filter still shows them
+    assert _read_type("Something Exotic") == "?"
+    assert _read_type("") == ""
 
 
 @pytest.mark.unit
@@ -455,6 +522,16 @@ class TestDetectFormat:
 
     def test_by_content_stellarium(self):
         assert detect_format('{"version": "1.0"}') == "stellarium"
+
+    def test_by_content_stellarium_v1_with_objects(self):
+        # Stellarium 1.0 also has version + objects; its string version
+        # must not be mistaken for the integer-versioned .pifinder format.
+        text = '{"version": "1.0", "shortName": "x", "objects": []}'
+        assert detect_format(text) == "stellarium"
+
+    def test_by_content_stellarium_v2(self):
+        text = '{"version": "2.0", "observingLists": {}, "shortName": "x"}'
+        assert detect_format(text) == "stellarium"
 
     def test_by_content_eqmod(self):
         assert detect_format("!J2000\n1.234; 45.678; NGC 224\n") == "eqmod"

--- a/python/tests/test_obslist_resolve.py
+++ b/python/tests/test_obslist_resolve.py
@@ -64,6 +64,23 @@ class TestResolveByName:
         assert resolve_by_name("", {"x": 1}) is None
 
 
+@pytest.mark.unit
+class TestCoordinateObjectType:
+    def test_unknown_type_becomes_question_mark(self):
+        # A raw source type string ("Nebula") matches no Type filter entry,
+        # which would hide the object from every filtered list.
+        entry = ObsListEntry(name="Ring Nebula", ra=283.4, dec=33.0, obj_type="Nebula")
+        assert obslist._coordinate_object(entry, 0).obj_type == "?"
+
+    def test_known_code_kept(self):
+        entry = ObsListEntry(name="M 57", ra=283.4, dec=33.0, obj_type="PN")
+        assert obslist._coordinate_object(entry, 0).obj_type == "PN"
+
+    def test_empty_type_becomes_question_mark(self):
+        entry = ObsListEntry(name="X", ra=1.0, dec=2.0)
+        assert obslist._coordinate_object(entry, 0).obj_type == "?"
+
+
 def _entry(name, code, seq, desc=""):
     """Minimal catalog-resolvable entry (read_list reads catalog_code+sequence)."""
     return ObsListEntry(


### PR DESCRIPTION
## Problem

Importing a `.sol` file exported by a current Stellarium build silently produces an empty list. Stellarium's observing-list export changed to a "2.0" schema:

- objects are nested under `observingLists -> {olud} -> objects` instead of a top-level `objects` array
- RA strings have no whitespace (`19h59m37.8s`), which the RA regex (`\s+` between fields) failed to parse
- the object type field is named `type` instead of `objtype`, and holds display strings like `"Nebula"` rather than PiFinder type codes

## Fix

- `read_stellarium` detects the `observingLists` map and imports the list named by `defaultListOlud` (falling back to the first list), taking its `name` for the list title instead of the generic `shortName`
- accepts both `objtype` (1.0) and `type` (2.0)
- `_parse_ra_string` allows spaceless HMS (`\s+` → `\s*`); spaced 1.0 strings still parse
- Stellarium type display strings map to PiFinder type codes (`"Planetary Nebula"` → `PN`), falling back to `?` when unknown
- General safety net in `_coordinate_object`: any type that is not a known PiFinder code is coerced to `?`. Without this, entries (from any format) that fail catalog resolution carry a raw type string that no Type filter entry matches — the object imports but never displays in a filtered list. Concretely: a 2.0 list with "Ring Nebula" (catalog name is "Ring nebula in Lyra", so name resolution misses) imported but showed 1 of 2 objects.

Also fixes extension-less content sniffing: any JSON with `version` + `objects` was classified as `.pifinder`, swallowing Stellarium 1.0 files. Detection now requires an integer version (`.pifinder` writes `1`; Stellarium writes `"1.0"`/`"2.0"`).

## Testing

- New unit tests: 2.0 nested-list import (name, coords, type, magnitude), type-string mapping (mapped / pass-through / unknown→`?`), coordinate-object type coercion, and content sniffing for both Stellarium schemas
- Verified against a real Stellarium 2.0 export: both objects import with correct J2000 coordinates and both pass the default catalog filter
- All 57 obslist tests pass; ruff lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

