### PR TITLE
Add -fb/--fakebattery flag; -fh alone no longer fakes the BQ25895

### DIFF
--- a/docs/source/dev_guide.rst
+++ b/docs/source/dev_guide.rst
@@ -590,11 +590,23 @@ for testing purposes. Else specify which camera to use: pi, asi, debug or none.
 -fh, --fakehardware | imu, gps only
 ...................................
 
-This uses fake hardware for the imu and gps.
+This uses fake hardware for the imu and gps. On its own this emulates
+rev-3 hardware, with no battery indicator; add ``--fakebattery`` to
+emulate rev-4.
 
 .. code-block::
 
     python3 -m PiFinder.main -fh -k local --camera debug -x
+
+-fb, --fakebattery
+..................
+
+With ``--fakehardware``, runs the fake battery monitor and enables the
+rev-4 battery indicator.
+
+.. code-block::
+
+    python3 -m PiFinder.main -fh -fb -k local --camera debug -x
 
 
 -k KEYBOARD, --keyboard KEYBOARD

--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -1107,6 +1107,15 @@ if __name__ == "__main__":
         required=False,
     )
     parser.add_argument(
+        "-fb",
+        "--fakebattery",
+        help="With --fakehardware, run the fake battery monitor "
+        "(rev-4 has_bq25895 capability, shows the battery indicator)",
+        default=False,
+        action="store_true",
+        required=False,
+    )
+    parser.add_argument(
         "-c",
         "--camera",
         help="Specify which camera to use: pi, asi, debug or none",
@@ -1193,14 +1202,19 @@ if __name__ == "__main__":
         imu = importlib.import_module("PiFinder.imu_fake")
         integrator = importlib.import_module("PiFinder.integrator")
         gps_monitor = importlib.import_module("PiFinder.gps_fake")
-        # Force the rev-4 capabilities under -fh so the fake battery monitor
-        # runs. has_buzzer is set for consistency, but the sound process is
-        # gated on real hardware (hardware_platform == "Pi") and so stays
-        # unspawned here — dev has no PWM/buzzer (handoff watch-out #4).
+        # -fh alone emulates rev-3 hardware (no battery indicator, keeps
+        # docs screenshots consistent); add -fb to emulate the rev-4 BQ25895
+        # and run the fake battery monitor. has_buzzer is set for
+        # consistency, but the sound process is gated on real hardware
+        # (hardware_platform == "Pi") and so stays unspawned here — dev has
+        # no PWM/buzzer (handoff watch-out #4).
         from PiFinder.types.hardware import HardwareCapabilities
 
-        capabilities = HardwareCapabilities(has_bq25895=True, has_buzzer=True)
-        battery = importlib.import_module("PiFinder.battery_fake")
+        capabilities = HardwareCapabilities(
+            has_bq25895=args.fakebattery, has_buzzer=True
+        )
+        if args.fakebattery:
+            battery = importlib.import_module("PiFinder.battery_fake")
     else:
         hardware_platform = "Pi"
         # Probe the real board; the battery monitor only spawns if a


### PR DESCRIPTION
## Summary

`-fh`/`--fakehardware` used to force `has_bq25895` (and `has_buzzer`) so the fake battery monitor always ran — which put the rev-4 battery indicator in the title bar of every headless capture. Docs screenshots should show the baseline rev-3 UI (128x128, no battery indicator), so:

- `-fh` alone now emulates rev-3 hardware: `has_bq25895` stays off, no battery monitor, no battery icon.
- New `-fb`/`--fakebattery` flag opts back into the rev-4 fake battery monitor (`battery_fake` is only imported when the flag is given, matching the real-hardware branch's probe-then-import pattern).
- `has_buzzer` remains set under `-fh`; the sound process is already gated on real hardware so this changes nothing in dev.
- Both flags documented in the dev guide's CLI-flags section.

## Testing

- `ruff check` / `ruff format` clean; smoke tests pass.
- Ran headless from a clean worktree both ways and captured `/api/screen`:
  - `-fh` only: startup log shows no Battery process; title bar has no battery icon.
  - `-fh -fb`: Battery process spawns (`Write:    Battery`); battery icon renders in the title bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)