### PR TITLE
fix(web): accept comma or period decimal separator when saving locations

### DIFF
--- a/python/PiFinder/server.py
+++ b/python/PiFinder/server.py
@@ -48,6 +48,16 @@ logs_logger = logging.getLogger("Server.Logs")
 SESSION_SECRET = str(uuid.uuid4())
 
 
+def parse_coordinate(value, field_name):
+    """Parse a coordinate/measurement field, accepting comma or period decimals."""
+    if value is None:
+        raise ValueError(_("%s is required") % field_name)
+    try:
+        return float(str(value).strip().replace(",", "."))
+    except ValueError:
+        raise ValueError(_("%s must be a number") % field_name)
+
+
 def auth_required(func):
     def auth_wrapper(*args, **kwargs):
         # check for and validate session
@@ -358,11 +368,13 @@ class Server:
         @auth_required
         def location_add():
             try:
-                name = request.form.get("name").strip()
-                lat = float(request.form.get("latitude"))
-                lon = float(request.form.get("longitude"))
-                altitude = float(request.form.get("altitude"))
-                error_in_m = float(request.form.get("error_in_m", "0"))
+                name = (request.form.get("name") or "").strip()
+                lat = parse_coordinate(request.form.get("latitude"), _("Latitude"))
+                lon = parse_coordinate(request.form.get("longitude"), _("Longitude"))
+                altitude = parse_coordinate(request.form.get("altitude"), _("Altitude"))
+                error_in_m = parse_coordinate(
+                    request.form.get("error_in_m", "0"), _("Error")
+                )
                 source = request.form.get("source", "Manual Entry")
 
                 # Server-side validation
@@ -416,11 +428,13 @@ class Server:
                 if not (0 <= location_id < len(cfg.locations.locations)):
                     raise ValueError("Invalid location ID")
 
-                name = request.form.get("name").strip()
-                lat = float(request.form.get("latitude"))
-                lon = float(request.form.get("longitude"))
-                altitude = float(request.form.get("altitude"))
-                error_in_m = float(request.form.get("error_in_m", "0"))
+                name = (request.form.get("name") or "").strip()
+                lat = parse_coordinate(request.form.get("latitude"), _("Latitude"))
+                lon = parse_coordinate(request.form.get("longitude"), _("Longitude"))
+                altitude = parse_coordinate(request.form.get("altitude"), _("Altitude"))
+                error_in_m = parse_coordinate(
+                    request.form.get("error_in_m", "0"), _("Error")
+                )
                 source = request.form.get("source", "Manual Entry")
 
                 # Server-side validation

--- a/python/tests/test_server_coordinates.py
+++ b/python/tests/test_server_coordinates.py
@@ -1,0 +1,40 @@
+"""Unit tests for web location coordinate parsing.
+
+The web location forms let users type coordinates, altitude and error. In a
+comma-decimal browser locale a ``<input type="number">`` yields an empty value
+for a period-formatted number (and vice-versa), which silently blocked the
+save. ``parse_coordinate`` accepts either separator so the server never sees a
+stray comma; these tests lock that in and guard the missing/garbage cases that
+previously raised an uncaught 500.
+"""
+
+import pytest
+
+from PiFinder.server import parse_coordinate
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("51.3", 51.3),
+        ("51,3", 51.3),
+        ("51", 51.0),
+        ("  -3,2 ", -3.2),
+        ("0", 0.0),
+    ],
+)
+def test_parse_coordinate_accepts_both_separators(raw, expected):
+    assert parse_coordinate(raw, "Latitude") == expected
+
+
+@pytest.mark.unit
+def test_parse_coordinate_missing_raises_value_error():
+    with pytest.raises(ValueError):
+        parse_coordinate(None, "Latitude")
+
+
+@pytest.mark.unit
+def test_parse_coordinate_garbage_raises_value_error():
+    with pytest.raises(ValueError):
+        parse_coordinate("not-a-number", "Longitude")

--- a/python/views/location_form.html
+++ b/python/views/location_form.html
@@ -17,52 +17,52 @@
     </div>
     <div class="row" id="decimalFormat-location_form">
       <div class="input-field col s6">
-        <input id="latitude-location_form" type="number" step="any" name="latitude" value="" required/>
+        <input id="latitude-location_form" type="text" inputmode="decimal" name="latitude" value="" required/>
         <label for="latitude-location_form">{{ _('Latitude (Decimal)') }}</label>
         <span class="helper-text"></span>
       </div>
       <div class="input-field col s6">
-        <input id="longitude-location_form" type="number" step="any" name="longitude" value="" required/>
+        <input id="longitude-location_form" type="text" inputmode="decimal" name="longitude" value="" required/>
         <label for="longitude-location_form">{{ _('Longitude (Decimal)') }}</label>
         <span class="helper-text"></span>
       </div>
     </div>
     <div class="row" id="dmsFormat-location_form" style="display:none;">
       <div class="input-field col s4">
-        <input id="latitudeD-location_form" type="number" name="latitudeD"/>
+        <input id="latitudeD-location_form" type="text" inputmode="decimal" name="latitudeD"/>
         <label for="latitudeD-location_form">{{ _('Latitude Degrees') }}</label>
       </div>
       <div class="input-field col s4">
-        <input id="latitudeM-location_form" type="number" name="latitudeM"/>
+        <input id="latitudeM-location_form" type="text" inputmode="decimal" name="latitudeM"/>
         <label for="latitudeM-location_form">{{ _('Latitude Minutes') }}</label>
       </div>
       <div class="input-field col s4">
-        <input id="latitudeS-location_form" type="number" name="latitudeS"/>
+        <input id="latitudeS-location_form" type="text" inputmode="decimal" name="latitudeS"/>
         <label for="latitudeS-location_form">{{ _('Latitude Seconds') }}</label>
       </div>
       <div class="input-field col s4">
-        <input id="longitudeD-location_form" type="number" name="longitudeD"/>
+        <input id="longitudeD-location_form" type="text" inputmode="decimal" name="longitudeD"/>
         <label for="longitudeD-location_form">{{ _('Longitude Degrees') }}</label>
       </div>
       <div class="input-field col s4">
-        <input id="longitudeM-location_form" type="number" name="longitudeM"/>
+        <input id="longitudeM-location_form" type="text" inputmode="decimal" name="longitudeM"/>
         <label for="longitudeM-location_form">{{ _('Longitude Minutes') }}</label>
       </div>
       <div class="input-field col s4">
-        <input id="longitudeS-location_form" type="number" name="longitudeS"/>
+        <input id="longitudeS-location_form" type="text" inputmode="decimal" name="longitudeS"/>
         <label for="longitudeS-location_form">{{ _('Longitude Seconds') }}</label>
       </div>
     </div>
     <div class="row">
       <div class="input-field col s12">
-        <input id="altitude-location_form" type="number" step="any" name="altitude" value="" required/>
+        <input id="altitude-location_form" type="text" inputmode="decimal" name="altitude" value="" required/>
         <label for="altitude-location_form">{{ _('Altitude (meters)') }}</label>
         <span class="helper-text"></span>
       </div>
     </div>
     <div class="row">
       <div class="input-field col s6">
-        <input id="error_in_m-location_form" type="number" step="any" name="error_in_m" value="10"/>
+        <input id="error_in_m-location_form" type="text" inputmode="decimal" name="error_in_m" value="10"/>
         <label for="error_in_m-location_form">{{ _('Error (meters)') }}</label>
         <span class="helper-text"></span>
       </div>

--- a/python/views/locations.html
+++ b/python/views/locations.html
@@ -127,52 +127,52 @@
         </div>
         <div class="row" id="decimalFormat-edit_form_{{ loop.index0 }}">
           <div class="input-field col s6">
-            <input id="latitude-edit_form_{{ loop.index0 }}" type="number" step="any" name="latitude" value="{{ location.latitude }}" required/>
+            <input id="latitude-edit_form_{{ loop.index0 }}" type="text" inputmode="decimal" name="latitude" value="{{ location.latitude }}" required/>
             <label for="latitude-edit_form_{{ loop.index0 }}">{{ _('Latitude (Decimal)') }}</label>
             <span class="helper-text"></span>
           </div>
           <div class="input-field col s6">
-            <input id="longitude-edit_form_{{ loop.index0 }}" type="number" step="any" name="longitude" value="{{ location.longitude }}" required/>
+            <input id="longitude-edit_form_{{ loop.index0 }}" type="text" inputmode="decimal" name="longitude" value="{{ location.longitude }}" required/>
             <label for="longitude-edit_form_{{ loop.index0 }}">{{ _('Longitude (Decimal)') }}</label>
             <span class="helper-text"></span>
           </div>
         </div>
         <div class="row" id="dmsFormat-edit_form_{{ loop.index0 }}" style="display:none;">
           <div class="input-field col s4">
-            <input id="latitudeD-edit_form_{{ loop.index0 }}" type="number" name="latitudeD"/>
+            <input id="latitudeD-edit_form_{{ loop.index0 }}" type="text" inputmode="decimal" name="latitudeD"/>
             <label for="latitudeD-edit_form_{{ loop.index0 }}">{{ _('Latitude Degrees') }}</label>
           </div>
           <div class="input-field col s4">
-            <input id="latitudeM-edit_form_{{ loop.index0 }}" type="number" name="latitudeM"/>
+            <input id="latitudeM-edit_form_{{ loop.index0 }}" type="text" inputmode="decimal" name="latitudeM"/>
             <label for="latitudeM-edit_form_{{ loop.index0 }}">{{ _('Latitude Minutes') }}</label>
           </div>
           <div class="input-field col s4">
-            <input id="latitudeS-edit_form_{{ loop.index0 }}" type="number" name="latitudeS"/>
+            <input id="latitudeS-edit_form_{{ loop.index0 }}" type="text" inputmode="decimal" name="latitudeS"/>
             <label for="latitudeS-edit_form_{{ loop.index0 }}">{{ _('Latitude Seconds') }}</label>
           </div>
           <div class="input-field col s4">
-            <input id="longitudeD-edit_form_{{ loop.index0 }}" type="number" name="longitudeD"/>
+            <input id="longitudeD-edit_form_{{ loop.index0 }}" type="text" inputmode="decimal" name="longitudeD"/>
             <label for="longitudeD-edit_form_{{ loop.index0 }}">{{ _('Longitude Degrees') }}</label>
           </div>
           <div class="input-field col s4">
-            <input id="longitudeM-edit_form_{{ loop.index0 }}" type="number" name="longitudeM"/>
+            <input id="longitudeM-edit_form_{{ loop.index0 }}" type="text" inputmode="decimal" name="longitudeM"/>
             <label for="longitudeM-edit_form_{{ loop.index0 }}">{{ _('Longitude Minutes') }}</label>
           </div>
           <div class="input-field col s4">
-            <input id="longitudeS-edit_form_{{ loop.index0 }}" type="number" name="longitudeS"/>
+            <input id="longitudeS-edit_form_{{ loop.index0 }}" type="text" inputmode="decimal" name="longitudeS"/>
             <label for="longitudeS-edit_form_{{ loop.index0 }}">{{ _('Longitude Seconds') }}</label>
           </div>
         </div>
         <div class="row">
           <div class="input-field col s12">
-            <input id="altitude-edit_form_{{ loop.index0 }}" type="number" step="any" name="altitude" value="{{ location.height }}" required/>
+            <input id="altitude-edit_form_{{ loop.index0 }}" type="text" inputmode="decimal" name="altitude" value="{{ location.height }}" required/>
             <label for="altitude-edit_form_{{ loop.index0 }}">{{ _('Altitude (meters)') }}</label>
             <span class="helper-text"></span>
           </div>
         </div>
         <div class="row">
           <div class="input-field col s6">
-            <input id="error_in_m-edit_form_{{ loop.index0 }}" type="number" step="any" name="error_in_m" value="{{ location.error_in_m }}"/>
+            <input id="error_in_m-edit_form_{{ loop.index0 }}" type="text" inputmode="decimal" name="error_in_m" value="{{ location.error_in_m }}"/>
             <label for="error_in_m-edit_form_{{ loop.index0 }}">{{ _('Error (meters)') }}</label>
             <span class="helper-text"></span>
           </div>
@@ -206,6 +206,12 @@
 
 {% block scripts %}
 <script>
+// Accept both period and comma as the decimal separator, normalising to period
+function normalizeDecimal(value) {
+    if (value === null || value === undefined) return '';
+    return String(value).trim().replace(',', '.');
+}
+
 // Conversion from Decimal to DMS
 function decimalToDMS(decimal) {
     var degrees = Math.floor(decimal);
@@ -226,9 +232,9 @@ function decimalToDMS(decimal) {
 // Conversion from DMS to Decimal
 function DMSToDecimal(degrees, minutes, seconds) {
     // Ensure all inputs are numbers and default missing values to 0
-    degrees = parseFloat(degrees) || 0;
-    minutes = parseFloat(minutes) || 0;
-    seconds = parseFloat(seconds) || 0;
+    degrees = parseFloat(normalizeDecimal(degrees)) || 0;
+    minutes = parseFloat(normalizeDecimal(minutes)) || 0;
+    seconds = parseFloat(normalizeDecimal(seconds)) || 0;
     
     // Validate minutes and seconds are in valid ranges
     if (minutes < 0 || minutes >= 60) {
@@ -393,7 +399,8 @@ function focusFirstDMSField(id = '') {
 }
 
 function validateField(value, fieldName) {
-    if (value === '' || value === null) return false;
+    value = normalizeDecimal(value);
+    if (value === '') return false;
     const numValue = parseFloat(value);
     if (isNaN(numValue)) return false;
     
@@ -526,8 +533,16 @@ document.addEventListener('DOMContentLoaded', function() {
         });
 
         form.addEventListener('submit', function(e) {
+            // Rewrite entered values to period-form so the server receives valid floats
+            ["latitude", "longitude", "altitude", "error_in_m",
+             "latitudeD", "latitudeM", "latitudeS",
+             "longitudeD", "longitudeM", "longitudeS"].forEach(function(fieldName) {
+                const el = document.getElementById(fieldName + "-" + id);
+                if (el && el.value) el.value = normalizeDecimal(el.value);
+            });
+
             const allValid = checkFields(id);
-            
+
             if (!allValid) {
                 e.preventDefault();
                 M.toast({html: "{{ _('Please fix the validation errors before saving') }}", classes: 'red'});


### PR DESCRIPTION
## Problem

Saving a location in the web UI silently fails in a **comma-decimal browser locale** (much of Europe). Typing `51,3` or `51.3` and clicking **Save Location** does nothing — the button looks active but no request is sent. Only integer values (e.g. `51`) save.

### Root cause

The coordinate/altitude/error inputs on both the add and edit forms are `<input type="number">`. For a number input the browser returns an **empty `.value`** when the entered text doesn't match its locale's number format (a dot in a comma locale, or vice-versa). The client-side validation (`checkFields()`) then treats the field as empty, returns invalid, and the submit handler calls `e.preventDefault()`. The request never reaches the server. Integers have no separator, so they always parse — hence "integers work, decimals don't."

Same class of bug as #291 (equipment focal-length decimal crash).

## Fix

- **Inputs → `type="text" inputmode="decimal"`** on the coordinate/altitude/error/DMS fields (keeps the mobile numeric keypad, but the browser no longer blanks locale-mismatched values).
- **JS normalises both separators** to a period before validation (`validateField`, `DMSToDecimal`) and rewrites values to period-form on submit, so the server always receives valid floats.
- **Server-side `parse_coordinate()`** tolerates a comma and turns a missing/garbage field into a friendly validation message instead of an uncaught 500.

## Tests

Adds `tests/test_server_coordinates.py` (unit) covering comma/period/integer/whitespace parsing and the missing/garbage error paths.

Note: the existing Selenium `test_web_locations.py` never caught this because it types dotted decimals into a default **en-US** Chrome (where dots are valid), and the `tests/website/` suite isn't run in CI (it needs an external Selenium Grid and self-skips). The new server-side unit test runs under `pytest -m unit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaxurSrCzxrsfJrSjfA5bo