### PR TITLE
ci(manifest): stamp built_at on update-manifest entries

### DIFF
--- a/.github/scripts/update_manifest.py
+++ b/.github/scripts/update_manifest.py
@@ -94,6 +94,7 @@ def update_build(args: argparse.Namespace) -> None:
             "source_sha": args.head_sha,
             "version": args.version or f"PR#{number}-{short_sha}",
             "store_path": store_path,
+            "built_at": now_iso(),
         }
         set_available(entry)
         channels["unstable"] = replace_entry(
@@ -113,6 +114,7 @@ def update_build(args: argparse.Namespace) -> None:
             "source_sha": args.sha,
             "version": args.version or f"{args.ref_name}-{short_sha}",
             "store_path": store_path,
+            "built_at": now_iso(),
         }
         set_available(entry)
         channels["unstable"] = replace_entry(
@@ -140,6 +142,7 @@ def update_release(args: argparse.Namespace) -> None:
         "source_sha": args.sha,
         "version": args.version,
         "store_path": args.store_path or None,
+        "built_at": now_iso(),
     }
     set_available(entry)
     manifest["channels"][channel] = replace_entry(


### PR DESCRIPTION
Adds a `built_at` UTC timestamp to every entry the manifest updater writes (PR builds, trunk builds, releases).

The on-device software update screen shows each build's age ("built 5h ago") next to its short hash; entries without `built_at` fall back to hash-only. Since `pull_request_target` runs the trusted copy of this script from the PR base branch, the stamp only takes effect once this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBmsuU7dJbHcYrV2CrYHxv