### PR TITLE
ci(manifest): stamp built_at on update-manifest entries (release)

### DIFF
--- a/.github/scripts/update_manifest.py
+++ b/.github/scripts/update_manifest.py
@@ -98,6 +98,7 @@ def update_build(args: argparse.Namespace) -> None:
             "source_sha": args.head_sha,
             "version": args.version or f"PR#{number}-{short_sha}",
             "store_path": store_path,
+            "built_at": now_iso(),
         }
         set_available(entry)
         channels["unstable"] = replace_entry(
@@ -117,6 +118,7 @@ def update_build(args: argparse.Namespace) -> None:
             "source_sha": args.sha,
             "version": args.version or f"{args.ref_name}-{short_sha}",
             "store_path": store_path,
+            "built_at": now_iso(),
         }
         set_available(entry)
         channels["unstable"] = replace_entry(
@@ -146,6 +148,7 @@ def update_release(args: argparse.Namespace) -> None:
         "store_path": args.store_path or None,
         "migration_url": args.migration_url or None,
         "migration_sha256_url": args.migration_sha256_url or None,
+        "built_at": now_iso(),
     }
     set_available(entry)
     manifest["channels"][channel] = replace_entry(


### PR DESCRIPTION
Same 3-line change as #537, but based on `release`.

#537 landed on `main`, yet manifest entries still come out without `built_at`: `pull_request_target` workflows run the workflow file and trusted scripts from the repository's **default branch**, which is `release` here (verified in the update-manifest job log: `git checkout -B release refs/remotes/origin/release`). So the stamp must exist on `release` to take effect for PR builds.

Targeting `release` directly is intentional: this is a CI-script fix for the branch CI actually executes, not a code promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBmsuU7dJbHcYrV2CrYHxv