### PR TITLE
Revert PR #532's cedar-detect handoff changes; restore camera test mode

### DIFF
--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -599,13 +599,6 @@ class PFCedarDetectClient(cedar_detect_client.CedarDetectClient):
             )
         return self._stub
 
-    def _alloc_shmem(self, size):
-        # Report a freshly created segment (not just a resized one) so the
-        # request sets reopen_shmem and the server drops its stale cached fd.
-        fresh = self._shmem is None
-        resized = super()._alloc_shmem(size)
-        return resized or fresh
-
     def extract_centroids(
         self, image, sigma, max_size, use_binned, detect_hot_pixels=True
     ):
@@ -619,17 +612,14 @@ class PFCedarDetectClient(cedar_detect_client.CedarDetectClient):
 
         # Use shared memory path (same machine)
         if self._use_shmem:
-            reopen = self._alloc_shmem(size=width * height)
+            self._alloc_shmem(size=width * height)
             shimg = np.ndarray(
                 np_image.shape, dtype=np_image.dtype, buffer=self._shmem.buf
             )
             shimg[:] = np_image[:]
 
             im = cedar_detect_pb2.Image(
-                width=width,
-                height=height,
-                shmem_name=self._shmem.name,
-                reopen_shmem=reopen,
+                width=width, height=height, shmem_name=self._shmem.name
             )
             req = cedar_detect_pb2.CentroidsRequest(
                 input_image=im,
@@ -644,11 +634,6 @@ class PFCedarDetectClient(cedar_detect_client.CedarDetectClient):
             except grpc.RpcError as err:
                 if err.code() == grpc.StatusCode.INTERNAL:
                     # Shared memory issue, fall back to non-shmem
-                    logger.warning(
-                        "Cedar shmem transfer failed (%s); "
-                        "falling back to inline image passing",
-                        err.details(),
-                    )
                     self._del_shmem()
                     self._use_shmem = False
                 else:
@@ -774,9 +759,7 @@ def solver(
 ):
     MultiprocLogging.configurer(log_queue)
     logger.debug("Starting Solver")
-    # Load tetra3's bundled pattern database by name; tetra3 resolves it from
-    # its own package data dir (shipped inside the cedar-solve wheel).
-    t3 = tetra3.Tetra3("default_database")
+    t3 = tetra3.Tetra3(str(utils.tetra3_dir / "data" / "default_database.npz"))
     align_ra = 0
     align_dec = 0
     last_solve_attempt: float = 0.0


### PR DESCRIPTION
## Summary

PR #532 (the SQM redesign) also changed how the solver passes images to cedar-detect and disconnected the camera test mode. Neither change was required for the SQM functionality, and both broke working behavior. This PR restores the known-working pre-merge (`b5b16883^`) behavior for both, leaving all of #532's SQM work in place.

## Fix 1: cedar-detect shared-memory handoff (`solver.py`)

The shmem request now passes `reopen_shmem=`, but the checked-in `cedar_detect_pb2` bindings (tetra3 submodule @ `38c3f48f`, which #532 did **not** bump) have no such field on `Image`. Every shared-memory `ExtractCentroids` call therefore raises

```
ValueError: Protocol message Image has no "reopen_shmem" field.
```

before any RPC is made — and because that's a `ValueError`, not a `grpc.RpcError`, the existing inline-image fallback never engages.

Reverted to the known-working version:
- the `_alloc_shmem` override that tracked freshly created segments
- `reopen_shmem=` on the shmem `cedar_detect_pb2.Image` request
- the added shmem-fallback `logger.warning`
- pattern-database load by name (`Tetra3("default_database")`) → back to the explicit path (`utils.tetra3_dir / "data" / "default_database.npz"`)

## Fix 2: camera test mode (`camera_interface.py`)

#532 renamed the capture loop's test-mode flag (`debug` → `test_mode_on`) but moved its initialization **inside** the loop (reset to `False` every frame) and deleted the command handler that toggled it when the UI sends `"debug"` (Tools → Test Mode, console key 0). Test mode therefore did nothing — the camera kept publishing real captures instead of the disk test image.

Restored: the flag is initialized once before the loop and the `"debug"` command toggle is reinstated. The test-mode branch itself (including #532's `set_sqm_radiometer_sample(None)` guard) is unchanged.

## Kept from #532

- all SQM solver changes (raw-green photometry, radiometer cadence, lazy calculator creation)
- `matched_catID` passthrough in `_build_successful_solve` (used by SQM stellar photometry)
- the pre-existing `_clear_stale_shmem` startup cleanup (predates #532)

## Verification

- `cedar_detect_pb2.Image(width=…, height=…, shmem_name=…)` constructs cleanly against the checked-in bindings; the #532 form with `reopen_shmem=` reproduces the `ValueError` above
- reverted solver regions byte-match `b5b16883^`
- Headless end-to-end run of this branch: app launches, plate-solves live (Chart shows coordinates); before Test Mode the Focus preview cycles the debug camera's three frames (including the starless one); after Tools → Test Mode both Focus and Align (Day) stay pinned to `test_images/pifinder_debug_02.png` and the solver solves it
- `ruff check` / `ruff format --check` clean on both files
- `pytest tests/test_solver_sqm.py`: 10 passed; `pytest -m smoke`: 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)