### PR TITLE
Restore the camera test-mode toggle PR #532 disconnected

### DIFF
--- a/python/PiFinder/camera_interface.py
+++ b/python/PiFinder/camera_interface.py
@@ -301,6 +301,7 @@ class CameraInterface:
             # 60 half-second cycles (30 seconds between captures in sleep mode)
             sleep_delay = 60
             was_sleeping = False
+            test_mode_on = False
             while True:
                 sleeping = state_utils.sleep_for_framerate(
                     shared_state, limit_framerate=False
@@ -325,7 +326,6 @@ class CameraInterface:
                 imu_start = shared_state.imu()
                 image_start_time = time.time()
                 if self._camera_started:
-                    test_mode_on = False
                     if not test_mode_on:
                         base_image = self._capture_with_timeout()
                         if base_image is None:
@@ -471,6 +471,9 @@ class CameraInterface:
                         logger.error(f"CameraInterface: Command error: {e}")
 
                     try:
+                        if command == "debug":
+                            test_mode_on = not test_mode_on
+
                         if command.startswith("set_exp"):
                             transient_exposure = command.startswith(
                                 "set_exp_transient:"


### PR DESCRIPTION
## Summary

Follow-up to #542 (whose squash merge took only the solver revert): PR #532 also disconnected the camera test mode. With test mode "enabled", the camera kept publishing real captures instead of the disk test image on the Focus and Align (Day) screens.

## The bug

#532 renamed the capture loop's test-mode flag (`debug` → `test_mode_on`) in `camera_interface.py`, but:

1. moved its initialization **inside** the capture loop, resetting it to `False` every frame, and
2. deleted the command handler that flipped it when the UI sends `"debug"` on the camera queue — the only thing Tools → Test Mode (`callbacks.activate_debug`) and console key 0 do to the camera.

So the toggle had no effect and real captures were always used.

## The fix (4 lines)

- initialize `test_mode_on = False` once, before the loop
- reinstate `if command == "debug": test_mode_on = not test_mode_on` in the command handler

The test-mode branch itself — loading `test_images/pifinder_debug_02.png`, including #532's `set_sqm_radiometer_sample(None)` guard — was intact and is unchanged.

## Verification (headless end-to-end run of this change)

- Before activation, the Focus preview cycles the debug camera's three frames (bright starfield / dark starfield / starless)
- After Tools → Test Mode, both Focus and Align (Day) stay pinned to `pifinder_debug_02.png` across repeated captures, and the solver plate-solves it (live RA/Dec)
- `ruff check` / `ruff format --check` clean; `pytest -m smoke`: 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)