### PR TITLE
SQM: scale-aware photometry, tracked black level, wizard capture fixes

### DIFF
--- a/docs/ax/camera/CONTEXT.md
+++ b/docs/ax/camera/CONTEXT.md
@@ -58,6 +58,36 @@ The number of consecutive zero-match solve attempts required before recovery act
 Zero-match recovery was briefly a plugin point with four selectable strategies (Sweep, Exponential, Reset, Histogram) behind the Experimental "AE Algo" menu. [ADR 0010](../../adr/0010-zero-match-recovery-single-ladder.md) kept the Sweep ladder as the only behavior and removed the rest, the plugin seam, the menu, and the `auto_exposure_zero_star_handler` config key. Recovery is now the single concrete `ZeroMatchRecovery` class.
 _Avoid_: AE algo, zero-star handler, handler, plugin.
 
+### Frame extents
+
+Two regions of the sensor are in play at once, and confusing them is the
+standing hazard in this area. Always say which one you mean.
+
+**Full-sensor frame**:
+Every pixel the sensor delivers, uncropped. Written by `capture_raw_file()` —
+always, with no option to write anything narrower — and archived by the
+exposure sweep capture as `*_rawfull_*.tiff`. Nothing measures it: it exists so
+the margins are on disk for later analysis, because a margin not captured is
+gone for good.
+_Avoid_: raw frame (unqualified — the crop is equally raw).
+
+**Crop**:
+The centred square region of the sensor. This is what `cam_raw()` holds, what
+SQM photometry measures, and what each sweep frame's `raw_stats` covers. The
+crop is a plain slice of the full-sensor frame, so
+`CameraProfile.ensure_cropped()` recovers it exactly from an archived
+full-sensor frame — that equivalence is what lets full-sensor sweeps reproduce
+every number the cropped-era archive produced.
+
+The asymmetry inside a single sweep frame is deliberate and worth stating
+plainly: **the TIFF is full-sensor, its `raw_stats` are crop-only.** Those
+statistics are the black-level-versus-temperature series, and the vignetted
+margins would shift every mean and percentile, ending comparability with sweeps
+taken before the archive went full-sensor. New records carry
+`raw_stats.extent: "crop"` and `sweep_metadata.json` carries
+`camera.raw_frame_extent: "full_sensor"`, so an archive states which is which
+instead of relying on anyone remembering.
+
 ### Cross-context terms
 
 - **`Matches`** — defined in [Positioning](../positioning/CONTEXT.md): count of stars tetra3 matched in the most recent solve attempt, published on every attempt (success or failure) because auto-exposure depends on it. The feedback signal for solver-driven auto-exposure.

--- a/docs/ax/sqm/CONTEXT.md
+++ b/docs/ax/sqm/CONTEXT.md
@@ -40,6 +40,10 @@ The processed 512×512 image used by Cedar and tetra3. It can be display-rotated
 **Raw photometry image**:
 The linear cropped raw mono frame, or the mean of both Bayer-green sites. Star
 flux and sky background are measured here, not on the processed solve image.
+Always the **crop**, never the full-sensor frame that exposure sweeps archive —
+see [Camera](../camera/CONTEXT.md) for the two extents. The margins are
+vignetted with no optical black, so measuring them would bias the sky
+background and break continuity with every calibrated sweep.
 
 **Derotation**:
 Mapping solve-image `(y, x)` centroids back to the orientation of the stored

--- a/python/PiFinder/camera_interface.py
+++ b/python/PiFinder/camera_interface.py
@@ -68,10 +68,14 @@ def _json_safe(value):
     return str(value)
 
 
-def sweep_frame_record(index, exp_us, driver_metadata, raw_frame, bit_depth):
+def sweep_frame_record(index, exp_us, driver_metadata, cropped_frame, bit_depth):
     """Build one sweep image's metadata record: the camera settings actually
-    applied (from driver metadata) plus ADU statistics of the raw frame as
-    saved in the TIFF (pre-bias-subtraction)."""
+    applied (from driver metadata) plus ADU statistics of the raw frame
+    (pre-bias-subtraction).
+
+    The statistics cover the square crop, while the TIFF alongside holds the
+    whole sensor. Keeping them on the crop is what makes the black-level
+    series comparable with sweeps taken before the archive went full-sensor."""
     camera_metadata = {
         key: _json_safe(driver_metadata.get(key)) if driver_metadata else None
         for key in SWEEP_FRAME_METADATA_KEYS
@@ -90,10 +94,16 @@ def sweep_frame_record(index, exp_us, driver_metadata, raw_frame, bit_depth):
             _json_safe(driver_metadata) if driver_metadata else None
         ),
     }
-    if raw_frame is not None:
-        frame = raw_frame.astype(np.float64)
+    if cropped_frame is not None:
+        frame = cropped_frame.astype(np.float64)
         p = np.percentile(frame, [1, 5, 25, 50, 75, 95, 99])
         record["raw_stats"] = {
+            # Which pixels these numbers cover. The sibling TIFF is
+            # full-sensor, so without this the two would silently be
+            # assumed to describe the same pixels. Sweeps from before the
+            # archive went full-sensor have no such key; there the TIFF
+            # was the crop too, so it meant the same thing either way.
+            "extent": "crop",
             "mean_adu": float(frame.mean()),
             "median_adu": float(p[3]),
             "std_adu": float(frame.std()),
@@ -110,7 +120,7 @@ def sweep_frame_record(index, exp_us, driver_metadata, raw_frame, bit_depth):
         }
         if bit_depth:
             record["raw_stats"]["saturated_fraction"] = float(
-                np.mean(raw_frame >= 2**bit_depth - 1)
+                np.mean(cropped_frame >= 2**bit_depth - 1)
             )
     return record
 
@@ -757,9 +767,16 @@ class CameraInterface:
                                 )  # Returns 8-bit PIL Image
                                 processed_img.save(str(processed_filename))
 
-                                # Save RAW TIFF (16-bit, from camera.capture_raw_file())
+                                # Save RAW TIFF (16-bit, from
+                                # camera.capture_raw_file()), always the full
+                                # sensor. The "rawfull" name keeps these out of
+                                # readers globbing the cropped era's
+                                # "*_raw_RGGB.tiff", so an un-updated tool finds
+                                # nothing rather than silently scaling centroids
+                                # against the wrong frame size.
                                 raw_filename = (
-                                    sweep_dir / f"img_{i:03d}_{exp_ms:.2f}ms_raw.tiff"
+                                    sweep_dir
+                                    / f"img_{i:03d}_{exp_ms:.2f}ms_rawfull.tiff"
                                 )
                                 self.capture_raw_file(str(raw_filename))
 
@@ -772,8 +789,8 @@ class CameraInterface:
                                 frame_record = sweep_frame_record(
                                     i,
                                     exp_us,
-                                    getattr(self, "last_raw_frame_metadata", None),
-                                    getattr(self, "last_raw_frame", None),
+                                    getattr(self, "last_frame_driver_metadata", None),
+                                    getattr(self, "last_cropped_frame", None),
                                     getattr(
                                         getattr(self, "profile", None),
                                         "bit_depth",

--- a/python/PiFinder/camera_pi.py
+++ b/python/PiFinder/camera_pi.py
@@ -204,6 +204,12 @@ class CameraPI(CameraInterface):
         For RGB sensors:
         - Converts to grayscale
         - Saves without Bayer pattern suffix
+
+        The square crop is never applied here, and there is deliberately no
+        option to apply it. The crop is a plain slice, so the full frame is a
+        superset and ``profile.ensure_cropped()`` reproduces the cropped frame
+        from it exactly -- while margins not written now are gone for good.
+        Live photometry is unaffected: it reads ``cam_raw()``, still the crop.
         """
         _request = self.camera.capture_request()
         # raw is actually 16 bit
@@ -220,14 +226,18 @@ class CameraPI(CameraInterface):
 
         _request.release()
 
-        # Apply camera-specific crop and rotation (preserves Bayer pattern alignment)
-        raw_capture = self.profile.crop_and_rotate(raw_capture)
-
-        # Expose this frame's driver metadata and cropped raw pixels so the
+        # Expose this frame's driver metadata and its CROPPED pixels so the
         # sweep capture can record per-image radiometry (exposure sweeps are
         # the only caller; both are overwritten on every raw capture).
-        self.last_raw_frame_metadata = metadata
-        self.last_raw_frame = raw_capture
+        #
+        # Note the asymmetry, and that it is deliberate: the TIFF written below
+        # is full-sensor, while these statistics cover the crop. They are the
+        # black-level-versus-temperature series, and the vignetted margins
+        # would shift every mean and percentile, silently ending comparability
+        # with the archive taken before sweeps went full-sensor. Full-sensor
+        # statistics stay computable from the TIFF.
+        self.last_frame_driver_metadata = metadata
+        self.last_cropped_frame = self.profile.crop_and_rotate(raw_capture)
 
         # Determine if we need to flag for debayering
         needs_debayer = False

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -83,6 +83,24 @@ def _extract_raw_photometry_image(raw, profile):
     return extract_photometry_image(raw, profile)
 
 
+def _scaled_photometry_radii(
+    scale, aperture_radius=5, inner_radius=10, outer_radius=18
+):
+    """Convert photometry radii from solve-image (512px) pixels to the
+    photometry image's own pitch.
+
+    The radii were tuned on the ~1.0-scale Bayer-green images (imx462: 490px).
+    On the full-res mono imx296 (scale 2.125) the unscaled r=5 aperture holds
+    only ~85% of a star's flux and the annuli land on the PSF itself, biasing
+    every local sky estimate. The floors keep the geometry ordered
+    (aperture < inner < outer) at any scale.
+    """
+    aperture = max(1, round(aperture_radius * scale))
+    inner = max(aperture + 1, round(inner_radius * scale))
+    outer = max(inner + 2, round(outer_radius * scale))
+    return aperture, inner, outer
+
+
 def _scale_solution_centroids(solution, scale):
     """Return a shallow copy of solution with matched_centroids scaled.
 
@@ -262,9 +280,10 @@ def update_sqm(
         exposure_sec: Exposure time in seconds
         altitude_deg: Altitude in degrees for extinction correction
         calculation_interval_seconds: Minimum time between calculations (default: 5.0)
-        aperture_radius: Aperture radius for photometry (default: 5)
-        annulus_inner_radius: Inner annulus radius (default: 10)
-        annulus_outer_radius: Outer annulus radius (default: 18)
+        aperture_radius: Aperture radius for photometry, in solve-image
+            (512px) pixels; rescaled to the photometry image (default: 5)
+        annulus_inner_radius: Inner annulus radius, solve-image pixels (default: 10)
+        annulus_outer_radius: Outer annulus radius, solve-image pixels (default: 18)
         wing_estimator: WingEstimator that supplies the rolling aperture
             (wing-loss) mzero correction and is fed each frame's photometry
             image + matched centroids.
@@ -314,6 +333,11 @@ def update_sqm(
         logger.debug("Raw frame unavailable/invalid for SQM; skipping this cycle")
         return False
     scale = green.shape[0] / 512.0
+    aperture_radius, annulus_inner_radius, annulus_outer_radius = (
+        _scaled_photometry_radii(
+            scale, aperture_radius, annulus_inner_radius, annulus_outer_radius
+        )
+    )
     calc_image = green
     calc_solution = _scale_solution_centroids(solution, scale)
     # All detected centroids, scaled to the photometry image: sqm masks them
@@ -344,6 +368,9 @@ def update_sqm(
 
     mzero_correction = 0.0
     if wing_estimator is not None:
+        # Match the estimator's patch geometry to this photometry image
+        # (no-op after the first frame; the scale is a per-camera constant).
+        wing_estimator.set_scale(scale)
         mzero_correction = wing_estimator.correction()
 
     # Track the wandering sensor pedestal from the sky-vs-exposure intercept

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -191,21 +191,26 @@ def update_radiometric_sqm(
 
     noise = sqm_calculator.noise_floor_estimator
 
+    def tracked_or_static_bias():
+        # The in-session intercept supersedes any static bias, wizard-measured
+        # or profile: the OB clamp level moves with sensor state, so a stored
+        # constant goes stale while the tracker measures the running session's
+        # own frames — bounded by its stderr, deviation-band, and lease gates.
+        # The wander is negligible over a city background but worth
+        # 0.2–0.4 mag (and dead short-exposure frames) at a dark site.
+        if black_level_tracker is not None:
+            tracked = black_level_tracker.pedestal()
+            if tracked is not None:
+                return tracked
+        return sqm_calculator.profile.bias_offset
+
     def pedestal_for_exposure(exposure_sec):
+        bias = tracked_or_static_bias()
         if not noise.dark_current_calibrated:
-            # Zero-touch path: the tracked black level supersedes the static
-            # profile constant (the real pedestal wanders ±2 ADU night to
-            # night — negligible over a city background, 0.2–0.4 mag at a
-            # dark site). A wizard calibration remains authoritative.
-            if black_level_tracker is not None:
-                tracked = black_level_tracker.pedestal()
-                if tracked is not None:
-                    return tracked
-            return sqm_calculator.profile.bias_offset
-        return (
-            sqm_calculator.profile.bias_offset
-            + sqm_calculator.profile.dark_current_rate * exposure_sec
-        )
+            return bias
+        # Dark current stays the wizard's: the intercept fit cannot separate
+        # dark from sky (both are linear in exposure).
+        return bias + sqm_calculator.profile.dark_current_rate * exposure_sec
 
     sqm_value, details = accumulator.estimate(
         sqm_calculator.profile,
@@ -233,9 +238,9 @@ def update_radiometric_sqm(
 
     if black_level_tracker is not None:
         tracked, tracked_stderr, _ = black_level_tracker.state()
-        details["black_level_tracked"] = (
-            tracked is not None and not noise.dark_current_calibrated
-        )
+        # pedestal() applies the lease; the flag must reflect what the
+        # publication actually used, not the raw last fit.
+        details["black_level_tracked"] = black_level_tracker.pedestal() is not None
         details["black_level_pedestal"] = tracked
         details["black_level_stderr"] = tracked_stderr
         details["window_black_level"] = black_level_tracker.dump()
@@ -373,16 +378,21 @@ def update_sqm(
         wing_estimator.set_scale(scale)
         mzero_correction = wing_estimator.correction()
 
-    # Track the wandering sensor pedestal from the sky-vs-exposure intercept
-    # (see sqm.black_level). Only in the zero-touch path: when the user has run
-    # the calibration wizard, its measured bias + dark-current constants are
-    # authoritative and the tracker (which fits bias only) must not override.
+    # Pedestal from the sky-vs-exposure intercept (see sqm.black_level): the
+    # in-session tracked bias supersedes any static constant, wizard-measured
+    # or profile — the OB clamp level moves with sensor state, so a stored
+    # value goes stale. The wizard's dark-current rate remains authoritative
+    # (the intercept fit cannot separate dark from sky) and is added on top,
+    # matching the calculator's own bias + dark composition.
     pedestal_override = None
-    if (
-        black_level_tracker is not None
-        and not sqm_calculator.noise_floor_estimator.dark_current_calibrated
-    ):
-        pedestal_override = black_level_tracker.pedestal()
+    if black_level_tracker is not None:
+        tracked = black_level_tracker.pedestal()
+        if tracked is not None:
+            pedestal_override = tracked
+            if sqm_calculator.noise_floor_estimator.dark_current_calibrated:
+                pedestal_override += (
+                    sqm_calculator.profile.dark_current_rate * exposure_sec
+                )
 
     try:
         # Calculate SQM from image

--- a/python/PiFinder/sqm/black_level.py
+++ b/python/PiFinder/sqm/black_level.py
@@ -140,6 +140,17 @@ class BlackLevelTracker:
                 self.bias_offset,
             )
             return
+        if abs(intercept - self.bias_offset) > 2.0 and (
+            self._pedestal is None or abs(intercept - self._pedestal) > 0.25
+        ):
+            # A tracked level this far from the static bias is exactly the
+            # case the tracker exists for — worth a visible trace.
+            logger.info(
+                "Tracked black level %.2f ADU (static bias %.1f, stderr %.2f)",
+                intercept,
+                self.bias_offset,
+                stderr,
+            )
         self._pedestal = float(intercept)
         self._stderr = stderr
         self._accepted_at = time.monotonic()

--- a/python/PiFinder/sqm/camera_profiles.py
+++ b/python/PiFinder/sqm/camera_profiles.py
@@ -156,6 +156,29 @@ class CameraProfile:
 
         return cropped
 
+    def is_full_sensor(self, raw_array) -> bool:
+        """True when an array covers the whole sensor rather than the crop.
+
+        Sweeps archive the full sensor; photometry works on the crop. Both
+        eras of archive exist on disk, so anything replaying them has to tell
+        them apart. The sizes can never collide: the crop is strictly smaller
+        on at least one axis for every profile.
+        """
+        height, width = raw_array.shape[:2]
+        return (width, height) == self.raw_size
+
+    def ensure_cropped(self, raw_array):
+        """Reduce an archived frame to what production photometry would see.
+
+        A full-sensor frame goes through the ordinary :meth:`crop_and_rotate`,
+        so the result matches the live pipeline by construction rather than by
+        a parallel reimplementation. An already-cropped frame is returned
+        untouched.
+        """
+        if self.is_full_sensor(raw_array):
+            return self.crop_and_rotate(raw_array)
+        return raw_array
+
     def __repr__(self) -> str:
         return (
             f"CameraProfile("

--- a/python/PiFinder/sqm/save_sweep_metadata.py
+++ b/python/PiFinder/sqm/save_sweep_metadata.py
@@ -103,6 +103,12 @@ def save_sweep_metadata(
                 "bias_offset": profile.bias_offset,
                 "sqm_band_offset": profile.sqm_band_offset,
                 "color_coefficient": profile.color_coefficient,
+                # Extent of the archived raw frames. Sweeps from the
+                # cropped era carry no such field; these hold the whole
+                # sensor, which a reader reduces to the crop with
+                # CameraProfile.ensure_cropped() before photometry.
+                "raw_frame_extent": "full_sensor",
+                "raw_frame_size": list(profile.raw_size),
             }
         except Exception as e:
             logger.warning(f"Could not record camera constants: {e}")

--- a/python/PiFinder/sqm/wings.py
+++ b/python/PiFinder/sqm/wings.py
@@ -28,7 +28,7 @@ instead of inventing wings.
 
 import logging
 from collections import deque
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
 
@@ -37,6 +37,10 @@ logger = logging.getLogger("SQM.Wings")
 
 class WingEstimator:
     """Rolling estimate of the aperture enclosed-flux fraction ``f``."""
+
+    # Radii at which the growth curve is read as its plateau: far enough
+    # out that real wing flux is integrated, well inside the sky region.
+    BASE_PLATEAU_RADII: Tuple[int, ...] = (10, 12, 14, 16)
 
     def __init__(
         self,
@@ -49,7 +53,8 @@ class WingEstimator:
     ):
         """
         Args:
-            aperture_radius: production photometry aperture the correction is for.
+            aperture_radius: production photometry aperture the correction is
+                for, in solve-image (512px) pixels; see :meth:`set_scale`.
             max_radius: patch half-size; sky comes from beyond ``max_radius - 4``.
             max_samples: rolling window of per-frame ``f`` samples.
             min_samples: samples needed before the correction is applied.
@@ -57,16 +62,59 @@ class WingEstimator:
             min_peak_snr: star peak must exceed this multiple of the per-pixel
                 sky noise to enter the stack (keeps noise out of the median).
         """
+        self._base_aperture_radius = aperture_radius
+        self._base_max_radius = max_radius
+        self._scale = 1.0
         self.aperture_radius = aperture_radius
         self.max_radius = max_radius
         self.max_samples = max_samples
         self.min_samples = min_samples
         self.min_stars = min_stars
         self.min_peak_snr = min_peak_snr
-        # Radii at which the growth curve is read as its plateau: far enough
-        # out that real wing flux is integrated, well inside the sky region.
-        self.plateau_radii = (10, 12, 14, 16)
+        self.plateau_radii: Tuple[int, ...] = self.BASE_PLATEAU_RADII
         self._samples: deque = deque(maxlen=max_samples)
+
+    def set_scale(self, scale: float) -> None:
+        """Adapt the patch geometry to the photometry image's pixel pitch.
+
+        All radii are defined in solve-image (512px) pixels; the photometry
+        image is ``scale`` times that pitch (imx462 green: ~0.96, full-res
+        mono imx296: 2.125). Without scaling, a high-scale sensor's PSF
+        spills past the aperture while the sky ring lands on the star's own
+        wings — the estimator then measures f~1 and never corrects.
+
+        The scale is a per-camera constant, so this is a cheap no-op after
+        the first frame. If the effective radii do change, the rolling window
+        is cleared: samples measured with a different geometry are not
+        comparable.
+        """
+        if scale == self._scale:
+            return
+        self._scale = scale
+        aperture = max(1, round(self._base_aperture_radius * scale))
+        max_r = max(aperture + 8, round(self._base_max_radius * scale))
+        plateau = tuple(
+            min(max_r - 4, max(aperture + 1, round(q * scale)))
+            for q in self.BASE_PLATEAU_RADII
+        )
+        if (aperture, max_r, plateau) == (
+            self.aperture_radius,
+            self.max_radius,
+            self.plateau_radii,
+        ):
+            return
+        self.aperture_radius = aperture
+        self.max_radius = max_r
+        self.plateau_radii = plateau
+        self._samples.clear()
+        logger.info(
+            "Wing geometry rescaled (scale %.3f): aperture=%d max_radius=%d "
+            "plateau=%s",
+            scale,
+            aperture,
+            max_r,
+            plateau,
+        )
 
     def add_frame(
         self,
@@ -163,6 +211,7 @@ class WingEstimator:
             "is_conditioned": self.is_conditioned,
             "n_samples": len(self._samples),
             "config": {
+                "scale": self._scale,
                 "aperture_radius": self.aperture_radius,
                 "max_radius": self.max_radius,
                 "max_samples": self.max_samples,

--- a/python/PiFinder/ui/sqm_calibration.py
+++ b/python/PiFinder/ui/sqm_calibration.py
@@ -29,6 +29,7 @@ from PiFinder.solver import (
     _derotate_centroids,
     _extract_raw_photometry_image,
     _scale_solution_centroids,
+    _scaled_photometry_radii,
 )
 from PiFinder.types.positioning import PointingEstimate, ReloadSqmCalibration
 from PiFinder.ui.base import UIModule
@@ -899,7 +900,14 @@ class UISQMCalibration(UIModule):
                         calc_centroids, solve_rotation, side
                     )
 
+                # Same scale-aware geometry as production SQM: radii are
+                # defined in solve-image (512px) pixels and converted to the
+                # photometry image's pitch.
+                wing_estimator.set_scale(scale)
                 wing_correction = wing_estimator.correction()
+                aperture_radius, annulus_inner_radius, annulus_outer_radius = (
+                    _scaled_photometry_radii(scale)
+                )
 
                 # Returns Tuple[Optional[float], Dict]
                 sqm_value, _details = sqm_calc.calculate(
@@ -908,6 +916,9 @@ class UISQMCalibration(UIModule):
                     image=green,
                     exposure_sec=exposure_sec,
                     altitude_deg=altitude_deg,
+                    aperture_radius=aperture_radius,
+                    annulus_inner_radius=annulus_inner_radius,
+                    annulus_outer_radius=annulus_outer_radius,
                     saturation_threshold=saturation_threshold,
                     image_pixels_per_side=green.shape[0],
                     mzero_correction=wing_correction,

--- a/python/PiFinder/ui/sqm_calibration.py
+++ b/python/PiFinder/ui/sqm_calibration.py
@@ -511,24 +511,54 @@ class UISQMCalibration(UIModule):
         self.command_queues["camera"].put(f"set_exp_transient:{exposure_us}")
 
     def _capture_and_wait(self, exposure_us: int) -> float:
-        """Request one frame and return its identifying exposure-end time."""
+        """Request one frame at ``exposure_us`` and return its exposure-end time.
+
+        Gates on the driver-reported ``actual_exposure_us``: the
+        ``exposure_time`` field echoes the committed setting, so the first
+        frames after an exposure change pass it while still carrying the
+        previous exposure (measured: ``req=1µs actual=999999µs`` for the
+        first three frames of every wizard stage). A delivered frame at the
+        wrong exposure triggers a fresh capture request rather than being
+        accepted into a calibration stack.
+        """
         previous_metadata = self.shared_state.last_image_metadata() or {}
         previous_end = float(previous_metadata.get("exposure_end", 0.0))
         self.command_queues["camera"].put("capture")
 
-        timeout = max(5.0, 3 * exposure_us / 1_000_000.0 + 1.0)
+        # Loose floor: a min-exposure request comes back at the sensor's true
+        # minimum (imx296: 29µs, imx462: 14µs), which must pass.
+        tolerance_us = max(1000, int(exposure_us * 0.05))
+        # Room for a few stale full-length frames before the change lands.
+        timeout = max(8.0, 4 * exposure_us / 1_000_000.0 + 2.0)
         deadline = time.time() + timeout
         while time.time() < deadline:
             metadata = self.shared_state.last_image_metadata() or {}
             exposure_end = float(metadata.get("exposure_end", 0.0))
-            metadata_exposure = int(metadata.get("exposure_time", 0))
-            if (
-                exposure_end > previous_end
-                and abs(metadata_exposure - exposure_us) <= 1000
-            ):
-                return exposure_end
+            if exposure_end > previous_end:
+                actual = metadata.get("actual_exposure_us")
+                delivered = int(actual if actual else metadata.get("exposure_time", 0))
+                if abs(delivered - exposure_us) <= tolerance_us:
+                    return exposure_end
+                # Stale frame from before the exposure change: ask again.
+                previous_end = exposure_end
+                self.command_queues["camera"].put("capture")
             time.sleep(0.05)
         raise TimeoutError(f"Timed out waiting for {exposure_us}µs calibration frame")
+
+    # The optical-black clamp re-settles over the first frames after an
+    # exposure change (measured on the imx296: 56 -> 59 ADU across ~3 frames
+    # at the new exposure); frames in that window measure neither the old nor
+    # the new black level.
+    CLAMP_SETTLE_DISCARD_FRAMES = 3
+
+    def _discard_clamp_settle_frames(self, exposure_us: int) -> None:
+        """Burn frames at a freshly changed exposure until the clamp settles."""
+        for _ in range(self.CLAMP_SETTLE_DISCARD_FRAMES):
+            try:
+                self._capture_and_wait(exposure_us)
+            except TimeoutError as exc:
+                logger.warning("%s", exc)
+                return
 
     def _wait_for_solution_at(self, exposure_end: float) -> PointingEstimate:
         """Return the successful plate solution for an identified frame."""
@@ -553,6 +583,7 @@ class UISQMCalibration(UIModule):
             # First frame: set exposure to minimum (closest to 0)
             self._set_calibration_exposure(1)  # Minimum exposure
             time.sleep(0.2)  # Wait for camera to apply setting
+            self._discard_clamp_settle_frames(1)
             self.bias_frames_raw = []
 
         # Set save flag if debug enabled, then capture
@@ -606,6 +637,9 @@ class UISQMCalibration(UIModule):
         exposure_us = int(exposure_schedule_us[self.current_frame])
         self._set_calibration_exposure(exposure_us)
         time.sleep(0.2)
+        # Every dark step changes the exposure, so the clamp must re-settle
+        # before the step's measurement frame.
+        self._discard_clamp_settle_frames(exposure_us)
 
         # Set save flag if debug enabled, then capture
         if self.save_frames_enabled:

--- a/python/tests/test_solver_sqm.py
+++ b/python/tests/test_solver_sqm.py
@@ -173,7 +173,7 @@ class TestUpdateSqmWiring:
         )
         assert wing.aperture_radius == max(1, round(5 * 300 / 512))
 
-    def test_no_override_when_calibrated(self, monkeypatch):
+    def test_calibrated_override_is_tracked_bias_plus_wizard_dark(self, monkeypatch):
         shared_state, calc, black_level, cloud, solution = self._harness(
             monkeypatch, calibrated=True
         )
@@ -187,7 +187,29 @@ class TestUpdateSqmWiring:
             cloud_estimator=cloud,
             black_level_tracker=black_level,
         )
-        # Wizard-measured constants are authoritative: no tracker override.
+        # Tracked in-session bias wins over the wizard's stored bias; the
+        # wizard's dark-current term is added on top.
+        expected = 237.5 + calc.profile.dark_current_rate * 0.5
+        assert calc.calculate.call_args.kwargs["pedestal_override"] == pytest.approx(
+            expected
+        )
+
+    def test_no_override_when_tracker_unconditioned(self, monkeypatch):
+        shared_state, calc, black_level, cloud, solution = self._harness(
+            monkeypatch, calibrated=True
+        )
+        black_level.pedestal.return_value = None
+        solver.update_sqm(
+            shared_state=shared_state,
+            sqm_calculator=calc,
+            centroids=[[10.0, 10.0]],
+            solution=solution,
+            exposure_sec=0.5,
+            altitude_deg=None,
+            cloud_estimator=cloud,
+            black_level_tracker=black_level,
+        )
+        # No confident fit: the calculator's own static composition applies.
         assert calc.calculate.call_args.kwargs["pedestal_override"] is None
 
     def _radiometer_harness(self, calibrated=False, pedestal=237.5, cloudy=False):
@@ -249,7 +271,7 @@ class TestUpdateSqmWiring:
         )
         assert black_level.add_sample.call_args.kwargs["stable"] is False
 
-    def test_radiometer_ignores_tracker_when_calibrated(self):
+    def test_radiometer_calibrated_uses_tracked_bias_plus_wizard_dark(self):
         shared_state, calc, black_level, sample = self._radiometer_harness(
             calibrated=True
         )
@@ -262,10 +284,32 @@ class TestUpdateSqmWiring:
             now=1001.0,
             black_level_tracker=black_level,
         )
-        # Wizard bias + dark current is authoritative over the tracker.
+        # Tracked in-session bias wins for the bias part; the wizard's
+        # dark-current rate is added on top.
         details = shared_state.set_sqm_details.call_args[0][0]
-        assert details["pedestal"] == calc.profile.bias_offset + (
-            calc.profile.dark_current_rate * 0.5
+        assert details["pedestal"] == pytest.approx(
+            237.5 + calc.profile.dark_current_rate * 0.5
+        )
+        assert details["black_level_tracked"] is True
+
+    def test_radiometer_calibrated_falls_back_when_unconditioned(self):
+        shared_state, calc, black_level, sample = self._radiometer_harness(
+            calibrated=True
+        )
+        black_level.pedestal.return_value = None
+        accumulator = solver.RadiometerAccumulator()
+        solver.update_radiometric_sqm(
+            shared_state,
+            calc,
+            accumulator,
+            sample,
+            now=1001.0,
+            black_level_tracker=black_level,
+        )
+        # No confident fit: static wizard/profile bias + dark current.
+        details = shared_state.set_sqm_details.call_args[0][0]
+        assert details["pedestal"] == pytest.approx(
+            calc.profile.bias_offset + calc.profile.dark_current_rate * 0.5
         )
         assert details["black_level_tracked"] is False
 

--- a/python/tests/test_solver_sqm.py
+++ b/python/tests/test_solver_sqm.py
@@ -56,6 +56,22 @@ class TestScaleSolutionCentroids:
 
 
 @pytest.mark.unit
+class TestScaledPhotometryRadii:
+    def test_imx462_green_scale_near_identity(self):
+        # 490px green vs 512 solve image: the tuned radii survive rounding
+        # (outer annulus shrinks by 1px, statistically negligible).
+        assert solver._scaled_photometry_radii(490 / 512) == (5, 10, 17)
+
+    def test_imx296_mono_full_res(self):
+        # 1088px mono photometry: every radius follows the 2.125x pixel pitch.
+        assert solver._scaled_photometry_radii(1088 / 512) == (11, 21, 38)
+
+    def test_geometry_stays_ordered_at_tiny_scale(self):
+        aperture, inner, outer = solver._scaled_photometry_radii(0.1)
+        assert 1 <= aperture < inner < outer
+
+
+@pytest.mark.unit
 class TestUpdateSqmWiring:
     """update_sqm threads the pedestal override and cloud/dew guard inputs."""
 
@@ -117,6 +133,45 @@ class TestUpdateSqmWiring:
         assert cloud.add_sample.call_args.kwargs["sky_brightness"] == 18.6
         # Feeding lives in the radiometric path; the diagnostic only consumes.
         black_level.add_sample.assert_not_called()
+
+    def test_passes_scaled_photometry_radii(self, monkeypatch):
+        shared_state, calc, black_level, cloud, solution = self._harness(monkeypatch)
+        solver.update_sqm(
+            shared_state=shared_state,
+            sqm_calculator=calc,
+            centroids=[[10.0, 10.0]],
+            solution=solution,
+            exposure_sec=0.5,
+            altitude_deg=None,
+            cloud_estimator=cloud,
+            black_level_tracker=black_level,
+        )
+        # Harness photometry image is 300px -> scale 300/512.
+        kwargs = calc.calculate.call_args.kwargs
+        expected = solver._scaled_photometry_radii(300 / 512)
+        assert (
+            kwargs["aperture_radius"],
+            kwargs["annulus_inner_radius"],
+            kwargs["annulus_outer_radius"],
+        ) == expected
+
+    def test_wing_estimator_gets_photometry_scale(self, monkeypatch):
+        from PiFinder.sqm.wings import WingEstimator
+
+        shared_state, calc, black_level, cloud, solution = self._harness(monkeypatch)
+        wing = WingEstimator()
+        solver.update_sqm(
+            shared_state=shared_state,
+            sqm_calculator=calc,
+            centroids=[[10.0, 10.0]],
+            solution=solution,
+            exposure_sec=0.5,
+            altitude_deg=None,
+            wing_estimator=wing,
+            cloud_estimator=cloud,
+            black_level_tracker=black_level,
+        )
+        assert wing.aperture_radius == max(1, round(5 * 300 / 512))
 
     def test_no_override_when_calibrated(self, monkeypatch):
         shared_state, calc, black_level, cloud, solution = self._harness(

--- a/python/tests/test_sqm.py
+++ b/python/tests/test_sqm.py
@@ -1663,6 +1663,44 @@ class TestWingEstimator:
         assert not est.is_conditioned
         assert est.correction() == 0.0
 
+    def test_set_scale_rescales_geometry(self):
+        est = WingEstimator()
+        # imx296 full-res mono: photometry at 1088px vs the 512 solve image.
+        est.set_scale(1088 / 512)
+        assert est.aperture_radius == round(5 * 1088 / 512)
+        assert est.max_radius == round(20 * 1088 / 512)
+        assert est.plateau_radii == tuple(
+            round(q * 1088 / 512) for q in WingEstimator.BASE_PLATEAU_RADII
+        )
+        # Every plateau radius stays outside the aperture, inside the sky ring.
+        for q in est.plateau_radii:
+            assert est.aperture_radius < q <= est.max_radius - 4
+
+    def test_set_scale_clears_window(self):
+        image, centroids, _ = _wing_star_frame()
+        est = WingEstimator(min_samples=1)
+        est.add_frame(image, centroids, saturation_threshold=1e9)
+        assert est.is_conditioned
+        est.set_scale(2.125)
+        # Samples from another geometry are not comparable.
+        assert not est.is_conditioned
+
+    def test_set_scale_same_scale_is_noop(self):
+        image, centroids, _ = _wing_star_frame()
+        est = WingEstimator(min_samples=1)
+        est.set_scale(1.0)
+        est.add_frame(image, centroids, saturation_threshold=1e9)
+        est.set_scale(1.0)
+        assert est.is_conditioned
+
+    def test_set_scale_near_unity_keeps_imx462_geometry(self):
+        # imx462 green: 490px. Rounding keeps aperture/plateau essentially
+        # unchanged, so the calibrated behavior is preserved.
+        est = WingEstimator()
+        est.set_scale(490 / 512)
+        assert est.aperture_radius == 5
+        assert est.plateau_radii[0] == 10
+
 
 @pytest.mark.unit
 class TestMzeroCorrection:

--- a/python/tests/test_sqm.py
+++ b/python/tests/test_sqm.py
@@ -1214,6 +1214,66 @@ class TestCropAndRotate:
 
 
 @pytest.mark.unit
+class TestArchivedFrameExtent:
+    """Sweeps archive the full sensor; photometry works on the crop.
+
+    Both eras of sweep exist on disk, so a reader has to tell them apart and
+    reduce the full-sensor era to the crop before measuring. These tests pin
+    that reduction to be exactly what the live pipeline produces -- the
+    guarantee that lets full-sensor sweeps reproduce every cropped-era number.
+    """
+
+    SENSORS = ["imx296", "imx462", "imx290", "hq"]
+
+    @pytest.mark.parametrize("name", SENSORS)
+    def test_full_sensor_frame_is_recognised(self, name):
+        profile = get_camera_profile(name)
+        full = np.zeros(profile.raw_size[::-1], dtype=np.uint16)
+
+        assert profile.is_full_sensor(full) is True
+
+    @pytest.mark.parametrize("name", SENSORS)
+    def test_cropped_frame_is_not_mistaken_for_full(self, name):
+        profile = get_camera_profile(name)
+        full = np.zeros(profile.raw_size[::-1], dtype=np.uint16)
+
+        assert profile.is_full_sensor(profile.crop_and_rotate(full)) is False
+
+    @pytest.mark.parametrize("name", SENSORS)
+    def test_cropping_a_full_sweep_frame_reproduces_the_live_crop(self, name):
+        """The reproducibility guarantee, asserted element for element."""
+        profile = get_camera_profile(name)
+        rng = np.random.default_rng(seed=1)
+        full = rng.integers(
+            0, 2**profile.bit_depth, size=profile.raw_size[::-1], dtype=np.uint16
+        )
+
+        np.testing.assert_array_equal(
+            profile.ensure_cropped(full), profile.crop_and_rotate(full)
+        )
+
+    @pytest.mark.parametrize("name", SENSORS)
+    def test_already_cropped_frames_pass_through_untouched(self, name):
+        """Cropped-era archives must not be cropped a second time."""
+        profile = get_camera_profile(name)
+        rng = np.random.default_rng(seed=2)
+        full = rng.integers(
+            0, 2**profile.bit_depth, size=profile.raw_size[::-1], dtype=np.uint16
+        )
+        cropped = profile.crop_and_rotate(full)
+
+        np.testing.assert_array_equal(profile.ensure_cropped(cropped), cropped)
+
+    @pytest.mark.parametrize("name", SENSORS)
+    def test_full_frame_holds_strictly_more_pixels(self, name):
+        """Nothing is lost by archiving the full sensor -- that is the point."""
+        profile = get_camera_profile(name)
+        full = np.zeros(profile.raw_size[::-1], dtype=np.uint16)
+
+        assert profile.crop_and_rotate(full).size < full.size
+
+
+@pytest.mark.unit
 class TestSaveSweepMetadata:
     """Unit tests for save_sweep_metadata.save_sweep_metadata()."""
 

--- a/python/tests/test_sqm_calibration.py
+++ b/python/tests/test_sqm_calibration.py
@@ -1,7 +1,34 @@
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
 from PiFinder.ui.sqm_calibration import UISQMCalibration
+
+
+class _CameraSim:
+    """Delivers one queued metadata frame per 'capture' command."""
+
+    def __init__(self, deliveries):
+        self.deliveries = list(deliveries)
+        self.current = {"exposure_end": 0.0}
+        self.captures = 0
+
+    def put(self, cmd):
+        if cmd == "capture":
+            if self.captures < len(self.deliveries):
+                self.current = self.deliveries[self.captures]
+            self.captures += 1
+
+    def last_image_metadata(self):
+        return self.current
+
+
+def _bare_wizard(sim):
+    ui = UISQMCalibration.__new__(UISQMCalibration)
+    ui.shared_state = SimpleNamespace(last_image_metadata=sim.last_image_metadata)
+    ui.command_queues = {"camera": sim}
+    return ui
 
 
 @pytest.mark.unit
@@ -35,3 +62,46 @@ class TestSQMCalibrationAnalysis:
         )
 
         assert fitted == 0.0
+
+
+@pytest.mark.unit
+class TestCaptureAndWait:
+    def test_accepts_frame_at_requested_exposure(self):
+        sim = _CameraSim([{"exposure_end": 1.0, "actual_exposure_us": 29}])
+        ui = _bare_wizard(sim)
+        assert ui._capture_and_wait(1) == 1.0
+        assert sim.captures == 1
+
+    def test_stale_exposure_frame_triggers_recapture(self):
+        # First frames after an exposure change still carry the previous
+        # exposure; actual_exposure_us exposes it while exposure_time echoes
+        # the committed setting.
+        sim = _CameraSim(
+            [
+                {"exposure_end": 1.0, "actual_exposure_us": 999999, "exposure_time": 1},
+                {"exposure_end": 2.0, "actual_exposure_us": 999999, "exposure_time": 1},
+                {"exposure_end": 3.0, "actual_exposure_us": 29, "exposure_time": 1},
+            ]
+        )
+        ui = _bare_wizard(sim)
+        assert ui._capture_and_wait(1) == 3.0
+        assert sim.captures == 3
+
+    def test_falls_back_to_exposure_time_without_actual(self):
+        sim = _CameraSim([{"exposure_end": 1.0, "exposure_time": 500}])
+        ui = _bare_wizard(sim)
+        assert ui._capture_and_wait(500) == 1.0
+
+    def test_tolerance_scales_with_exposure(self):
+        # 1s request delivered at 999999us (driver rounding) must pass.
+        sim = _CameraSim([{"exposure_end": 1.0, "actual_exposure_us": 999999}])
+        ui = _bare_wizard(sim)
+        assert ui._capture_and_wait(1_000_000) == 1.0
+
+    def test_discard_clamp_settle_frames_burns_frames(self):
+        sim = _CameraSim(
+            [{"exposure_end": float(i), "actual_exposure_us": 29} for i in (1, 2, 3)]
+        )
+        ui = _bare_wizard(sim)
+        ui._discard_clamp_settle_frames(1)
+        assert sim.captures == UISQMCalibration.CLAMP_SETTLE_DISCARD_FRAMES

--- a/python/tests/test_sweep_frame_record.py
+++ b/python/tests/test_sweep_frame_record.py
@@ -38,6 +38,36 @@ def test_record_with_full_metadata_and_frame():
 
 
 @pytest.mark.unit
+def test_statistics_cover_the_crop_not_the_full_sensor():
+    """Sweeps archive the whole sensor, but raw_stats must stay on the crop.
+
+    The margins are vignetted, so measuring them would shift every mean and
+    percentile and end comparability with the pre-full-sensor archive -- the
+    black-level-versus-temperature series these records exist for.
+    """
+    from PiFinder.sqm import get_camera_profile
+
+    profile = get_camera_profile("imx462")
+    full = np.full(profile.raw_size[::-1], 1000, dtype=np.uint16)
+    # Darken only what the crop discards, so a statistic computed over the
+    # full sensor cannot possibly match one computed over the crop.
+    kept = np.zeros_like(full, dtype=bool)
+    top, bottom = profile.crop_y
+    left, right = profile.crop_x
+    kept[top : full.shape[0] - bottom, left : full.shape[1] - right] = True
+    full[~kept] = 200
+
+    record = sweep_frame_record(
+        1, 100000, None, profile.crop_and_rotate(full), bit_depth=12
+    )
+
+    assert record["raw_stats"]["mean_adu"] == pytest.approx(1000.0)
+    assert record["raw_stats"]["min_adu"] == 1000.0
+    # The sibling TIFF is full-sensor, so the record must say what it covers.
+    assert record["raw_stats"]["extent"] == "crop"
+
+
+@pytest.mark.unit
 def test_record_without_metadata_or_frame():
     record = sweep_frame_record(1, 25000, None, None, bit_depth=None)
 


### PR DESCRIPTION
Three stacked fixes to the SQM pipeline, found while cross-calibrating two PiFinders (mrosseel's imx462/HQ units and rich's imx296 + imx462) against hand-held reference meters over 19 referenced sweeps.

## 1. Scale-aware photometry & wing geometry (`fix(sqm): scale photometry...`)

All photometry radii (aperture 5, annuli 10–18, wing-estimator plateau/sky ring) are tuned for the ~1.0-scale Bayer-green photometry images (imx462: 490px vs the 512px solve image). The mono imx296 does photometry on its full-res 1088px frame (scale 2.125), where that geometry sits *inside* the star profile: measured growth curves show the r=5 aperture holds only 83–94% of a star's flux, background annuli land on the PSF, and the wing estimator's own sky ring eats the wings — it measures f≈1 and stays permanently inert.

Fix: convert all radii from solve-image pixels to the photometry image's pitch, and give `WingEstimator` a `set_scale()`. imx462/imx290 round to essentially unchanged values; the imx296's median error vs the reference meter goes **−0.20 → 0.00** on the reference sweeps.

## 2. Tracked black level supersedes static bias (`fix(sqm): tracked black level...`)

The imx296's OB clamp delivered a black level of ≈**56 ADU** during the reference sweeps (background-vs-exposure intercepts 55.4–56.9; near-dark 25ms frames floor at 56) while the profile says 60 and the device's same-night wizard calibration says 58. At dark-sky signal levels a 2–4 ADU over-subtraction produces a −0.9…−1.5 mag/decade SQM-vs-exposure slope and kills short exposures outright ("background unresolved").

The `BlackLevelTracker` already measures the in-session intercept but was suppressed whenever a wizard calibration existed — backwards, since a stored bias is one moment's measurement of a moving level. This flips the priority in both SQM paths: a confidently fitted tracked intercept wins for bias; the wizard's dark-current rate stays authoritative on top. Replayed against the imx296 sweeps the tracker conditions on all four (stderr 0.26–0.32), fits 55.9–56.3, and the exposure slopes collapse to ≈0.

## 3. Wizard capture fixes (`fix(sqm): wizard captures gate on actual exposure...`)

The wizard's own calibration reports show why it measured 58 on a 56 sensor:
- the first ~3 frames of every stage report `actual_exposure_us` at the **previous** exposure (`req=1µs, actual=999999µs`) yet pass the frame gate, which checks the `exposure_time` field (echoes the committed setting, not what the sensor delivered);
- after the change lands, the OB clamp re-settles over ~3 more frames (imx296: 56→59 ADU) — and the settled clamp is genuinely exposure-dependent (~56 @ 1s vs ~59 @ 29µs min), so a min-exposure "bias" is only valid for its own regime (which is why fix 2 takes priority in operation).

Fix: gate on `actual_exposure_us` with a re-capture on stale frames, and discard clamp-settle frames after every exposure change in the bias and dark stages (~30–40s added to a wizard run).

## Cross-device validation

Full pipeline replayed offline over every referenced sweep (cloud-affected nights excluded):

| sensor | device(s) | sweeps | median err vs reference | spread |
|---|---|---|---|---|
| imx462 | mrosseel mr2 | 12 | −0.01 | ±0.15 |
| imx462 | rich | 3 | −0.21 | ±0.13 |
| imx296 | rich | 4 | −0.43* | ±0.10 |
| hq | mrosseel mr | 4 | +0.17* | ±0.20 |

\* constant, absorbed by a one-time `sqm_band_offset` refit for the new pipeline (imx296 −0.22→+0.21, hq 0.60→0.43) — deliberately **not** in this PR so the code change and the recalibration can be reviewed separately. Exposure-slope |mean| dropped from 1.20 to ~0.3 mag/decade on the imx296 and usable frames per sweep roughly doubled.

Validated: 141 tests across the SQM suites (18 new/updated); ruff + mypy clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXDxJkU5CzAegv3FcMEwEq