### PR TITLE
Docs: quick start focus — small-turn technique and touch-up guidance

### DIFF
--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -299,6 +299,12 @@ number means tighter, sharper stars: slowly screw the lens in or out and chase t
 stable number.  A readout of ``?.?`` means no star could be measured on the current frame —
 keep adjusting, and it returns as the stars tighten.
 
+Work in small steps.  The whole journey from stars too soft to see on screen to good focus
+is only a few turns of the lens, and the difference between fair and good focus is less
+than half a turn.  Turn the lens an eighth to a quarter of a turn at a time, then take your
+hand away for a moment so any vibration settles and the readout catches up.  Bigger or
+continuous turns make it easy to sweep straight through best focus without ever seeing it.
+
 A trace of the last 10 seconds of HFD runs along the divider on either side of the number,
 with lower (sharper) values below the line.  As you sweep the focuser slowly through best
 focus the trace falls and rises again — go back to the low point.  Good focus means the
@@ -323,6 +329,11 @@ Hold **SQUARE** in any view to open the :ref:`user_guide:quick menu`, which offe
 camera exposure setting.  With dark enough skies and good focus, the camera icon appears in
 the top right and the current constellation shows in the title bar.  Congratulations — the
 PiFinder knows where it's pointing!
+
+If you touch up focus on a later night, judge it here on the Focus screen rather than by
+the camera icon — a solve takes a second or so to catch up with each change of the lens, so
+the icon always lags a little behind.  The HFD readout responds much faster, and the
+technique is the same: a small turn, then a pause to let things settle.
 
 
 .. note::

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -95,7 +95,10 @@ often not tight enough.
 Work through these in order:
 
 - **Focus, properly.**  On the Focus screen, rotate the lens until the four magnified stars
-  are as small as possible and the central HFD reaches its lowest value.  Tight focus matters *even
+  are as small as possible and the central HFD reaches its lowest value.  The difference
+  between fair and good focus is less than half a turn, so work in steps of an eighth to a
+  quarter of a turn with a pause for vibration to settle, and judge by the HFD rather than
+  the camera icon, which lags a second or so behind each change of the lens.  Tight focus matters *even
   more* under bright, light-polluted skies, where slightly soft dim stars vanish into the
   background.  If you're starting from way off, set the lens so about 6 mm of thread is
   showing — roughly a pencil's width — which is close to in focus.


### PR DESCRIPTION
## Summary

Folds hard-won guidance from a recent support exchange into the docs, to raise first-night focus success rates:

**`quick_start.rst` — Setting Focus & First Solve**

- **Work in small steps** — a new paragraph right after the HFD readout description explaining that the whole range from badly defocused to sharp is only a few lens turns, fair-to-good is under half a turn, and the winning technique is 1/8–1/4 turn at a time with a pause for vibration to settle. Larger or continuous turns sweep straight through best focus.
- **Touch-up guidance** — a paragraph noting that a solve takes a second or so to catch up with the lens, so the camera icon lags; later-night touch-ups should be judged on the Focus screen's faster HFD readout, with the same small-turn-then-pause technique.

**`troubleshooting.rst` — It won't plate solve**

- The "Focus, properly" step now carries the same technique: half-turn window, 1/8–1/4 turn steps with a settle pause, and judge by the HFD rather than the lagging camera icon.

## Verification

- `sphinx-build -b html -n` (nitpicky mode) with the pinned `docs/source/requirements.txt` — clean, no warnings or errors, after each change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)