### PR TITLE
Docs: focus technique guidance for quick start and troubleshooting (release backport)

### DIFF
--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -321,11 +321,22 @@ If the image is too far out of focus to measure, the readout shows ``keep going`
 into range.  The strip works at every zoom level, since the HFD doesn't depend on zoom, and you can
 press the **SQUARE** button to hide or show it if you'd rather see the bare image.
 
+Work in small steps.  The whole journey from stars too soft to see on screen to good focus is only a
+few turns of the lens, and the difference between fair and good focus is less than half a turn.  Turn
+the lens an eighth to a quarter of a turn at a time, then take your hand away for a moment so any
+vibration settles and the readout catches up.  Bigger or continuous turns make it easy to sweep
+straight through best focus without ever seeing it.
+
 Good focus means the quickest solves.  Close will work, but it's worth driving the HFD down to its
 lowest point — use the **+/-** keys to zoom the view to 2x and 4x and get the stars as tight as you
 reasonably can.  With dark enough skies and good focus, the camera icon appears in the top right and
 the current constellation shows in the title bar.  Congratulations — the PiFinder knows where it's
 pointing!
+
+If you touch up focus on a later night, judge it here on the Focus screen rather than by the camera
+icon — a solve takes a second or so to catch up with each change of the lens, so the icon always
+lags a little behind.  The HFD readout responds much faster, and the technique is the same: a small
+turn, then a pause to let things settle.
 
 
 .. note::

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -91,10 +91,13 @@ often not tight enough.
 Work through these in order:
 
 - **Focus, properly.**  On the Focus screen, use **+/-** to zoom to 2x and 4x and rotate
-  the lens until the stars are as small as you can make them.  Tight focus matters *even
-  more* under bright, light-polluted skies, where slightly soft dim stars vanish into the
-  background.  If you're starting from way off, set the lens so about 6 mm of thread is
-  showing — roughly a pencil's width — which is close to in focus.
+  the lens until the stars are as small as you can make them.  The difference between fair
+  and good focus is less than half a turn, so work in steps of an eighth to a quarter of a
+  turn with a pause for vibration to settle, and judge by the HFD readout rather than the
+  camera icon, which lags a second or so behind each change of the lens.  Tight focus
+  matters *even more* under bright, light-polluted skies, where slightly soft dim stars
+  vanish into the background.  If you're starting from way off, set the lens so about 6 mm
+  of thread is showing — roughly a pencil's width — which is close to in focus.
 - **Lens cap off, and hold still.**  The PiFinder can only solve a sharp, stationary
   image.
 - **Exposure.**  The PiFinder defaults to **AUTO**, setting the exposure itself from each


### PR DESCRIPTION
## Summary

Docs-only backport of #546 so the published manual (Read the Docs builds from `release`) picks up the focus guidance now, adapted to this branch's focus-strip version of the Focus screen:

**`quick_start.rst` — Setting Focus & First Solve**

- **Work in small steps** — the whole range from badly defocused to sharp is only a few lens turns, fair-to-good is under half a turn, so adjust 1/8–1/4 turn at a time with a pause for vibration to settle; larger or continuous turns sweep straight through best focus.
- **Touch-up guidance** — a solve takes a second or so to catch up with the lens, so the camera icon lags; judge later-night touch-ups on the Focus screen's faster HFD readout with the same small-turn-then-pause technique.

**`troubleshooting.rst` — It won't plate solve**

- The "Focus, properly" step carries the same technique: half-turn window, small steps with a settle pause, judge by the HFD rather than the lagging camera icon.

Opened against `release` at the maintainer's request (normally changes promote from `main`); the `main` counterpart is #546.

## Verification

- `sphinx-build -b html -n` (nitpicky mode) with this branch's pinned `docs/source/requirements.txt` — clean, no warnings or errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)