### PR TITLE
Survive logind RemoveIPC: recover when the cedar shmem segment vanishes

### DIFF
--- a/migration_source/v2.6.1.sh
+++ b/migration_source/v2.6.1.sh
@@ -1,0 +1,14 @@
+# Keep POSIX shared memory alive across SSH logouts: logind's default
+# RemoveIPC=yes deletes all IPC owned by the pifinder user (including the
+# solver's cedar-detect /dev/shm segment) the moment that user's last login
+# session ends — the PiFinder services run as pifinder but hold no login
+# session of their own, so a plain SSH logout used to degrade solving until
+# restart. The solver also recovers in software (PFCedarDetectClient), but
+# this keeps the fast shared-memory handoff in place. Mirrors the same
+# drop-in written by pifinder_setup.sh for fresh installs.
+sudo mkdir -p /etc/systemd/logind.conf.d
+printf '[Login]\nRemoveIPC=no\n' | sudo tee /etc/systemd/logind.conf.d/pifinder-removeipc.conf
+# Apply without waiting for a reboot; harmless if logind isn't running.
+# (Restarting logind does not end sessions, and RemoveIPC only acts at
+# session end, so nothing is reaped by the restart itself.)
+sudo systemctl try-restart systemd-logind.service || true

--- a/pifinder_post_update.sh
+++ b/pifinder_post_update.sh
@@ -55,6 +55,14 @@ then
     touch /home/pifinder/PiFinder_data/migrations/v2.6.0
 fi
 
+# v2.6.1
+# RemoveIPC=no so SSH logouts can't reap the solver's shared memory
+if ! [ -f "/home/pifinder/PiFinder_data/migrations/v2.6.1" ]
+then
+    source /home/pifinder/PiFinder/migration_source/v2.6.1.sh
+    touch /home/pifinder/PiFinder_data/migrations/v2.6.1
+fi
+
 # DONE
 echo "Post Update Complete"
 

--- a/pifinder_setup.sh
+++ b/pifinder_setup.sh
@@ -79,6 +79,16 @@ sudo systemctl mask serial-getty@ttyAMA0.service
 
 # Note: camera types are added lateron by python/PiFinder/switch_camera.py
 
+# Keep POSIX shared memory alive across SSH logouts: logind's default
+# RemoveIPC=yes deletes all IPC owned by the pifinder user (including the
+# solver's cedar-detect /dev/shm segment) the moment that user's last login
+# session ends — the PiFinder services run as pifinder but hold no login
+# session of their own, so a plain SSH logout used to degrade solving.
+# The solver also survives this in software (PFCedarDetectClient._del_shmem),
+# but this keeps the fast shared-memory handoff in place.
+sudo mkdir -p /etc/systemd/logind.conf.d
+printf '[Login]\nRemoveIPC=no\n' | sudo tee /etc/systemd/logind.conf.d/pifinder-removeipc.conf
+
 # Disable unwanted services
 sudo systemctl disable ModemManager
 

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -684,6 +684,11 @@ class PFCedarDetectClient(cedar_detect_client.CedarDetectClient):
                 max_size=max_size,
                 return_binned=False,
                 use_binned_for_star_candidates=use_binned,
+                # Must be passed here too: detect_hot_pixels is a proto3 bool,
+                # so leaving it out sends false and hot pixels start being
+                # detected as stars. Losing the shared-memory handoff should
+                # cost throughput, not detection quality.
+                detect_hot_pixels=detect_hot_pixels,
             )
             try:
                 centroids_result = self._get_stub().ExtractCentroids(req)

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -655,7 +655,18 @@ class PFCedarDetectClient(cedar_detect_client.CedarDetectClient):
                 centroids_result = self._get_stub().ExtractCentroids(req)
             except grpc.RpcError as err:
                 if err.code() == grpc.StatusCode.INTERNAL:
-                    # Shared memory issue, fall back to non-shmem
+                    # Shared memory issue, fall back to non-shmem. The flag
+                    # latches for the life of the process, so this logs once --
+                    # but without it the downgrade is silent and the only
+                    # symptom is a slower extract time.
+                    logger.warning(
+                        "Cedar shared-memory handoff failed (%s); passing the "
+                        "image inline over gRPC from now on. If %s was removed "
+                        "out from under us, check for the RemoveIPC=no drop-in "
+                        "in /etc/systemd/logind.conf.d/.",
+                        err.details(),
+                        _CEDAR_DETECT_SHMEM_NAME,
+                    )
                     self._del_shmem()
                     self._use_shmem = False
                 else:

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -591,6 +591,28 @@ class PFCedarDetectClient(cedar_detect_client.CedarDetectClient):
             _CEDAR_DETECT_SHMEM_NAME,
         )
 
+    def _del_shmem(self):
+        """Release the shared-memory segment, tolerating one that has
+        already vanished from /dev/shm.
+
+        systemd-logind's ``RemoveIPC=yes`` (the default) deletes every
+        POSIX shared-memory segment a user owns the moment that user's
+        last login session ends — an SSH logout is enough, because the
+        PiFinder service runs as the same user but holds no login
+        session of its own. The upstream cleanup then raises
+        ``FileNotFoundError`` from ``unlink()``, which escaped before
+        ``extract_centroids`` could flip ``_use_shmem`` off — so instead
+        of falling back to passing the image over gRPC, every subsequent
+        solve repeated the crash until restart (bench finding: "solves
+        die at the cable pull", which was really the SSH logout beside
+        it). A segment that is already gone is this method's goal state:
+        treat it as released.
+        """
+        try:
+            super()._del_shmem()
+        except FileNotFoundError:
+            self._shmem = None
+
     def _get_stub(self):
         if self._stub is None:
             channel = grpc.insecure_channel("127.0.0.1:%d" % self._port)

--- a/python/tests/test_solver_cedar_client.py
+++ b/python/tests/test_solver_cedar_client.py
@@ -16,6 +16,7 @@ No cedar-detect server is needed: the gRPC stub is faked, but the
 shared-memory segment and the protobuf requests are real.
 """
 
+import logging
 import types
 
 import grpc
@@ -24,7 +25,7 @@ import pytest
 
 from multiprocessing import shared_memory
 
-from PiFinder.solver import PFCedarDetectClient
+from PiFinder.solver import _CEDAR_DETECT_SHMEM_NAME, PFCedarDetectClient
 
 
 def _bare_client():
@@ -76,7 +77,7 @@ def test_del_shmem_without_segment_is_a_noop():
 
 
 @pytest.mark.unit
-def test_extract_centroids_falls_back_when_segment_vanishes():
+def test_extract_centroids_falls_back_when_segment_vanishes(caplog):
     """The RemoveIPC scenario end to end: the shmem RPC fails INTERNAL,
     the (externally unlinked) segment is released without an exception,
     and the same call retries with the image inlined in the request —
@@ -102,9 +103,10 @@ def test_extract_centroids_falls_back_when_segment_vanishes():
         vanish.close()
         vanish.unlink()
 
-        centroids = client.extract_centroids(
-            image, sigma=8, max_size=10, use_binned=True
-        )
+        with caplog.at_level(logging.WARNING, logger="Solver"):
+            centroids = client.extract_centroids(
+                image, sigma=8, max_size=10, use_binned=True
+            )
     finally:
         # The segment name is gone; make teardown tolerant either way.
         try:
@@ -118,3 +120,9 @@ def test_extract_centroids_falls_back_when_segment_vanishes():
     # First call went over shmem and failed; the retry carried the pixels.
     assert len(calls) == 2
     assert calls[1].input_image.image_data == image.tobytes()
+    # The downgrade is permanent for this process, so it has to be visible in
+    # the logs -- otherwise the only symptom is a slower extract time.
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "shared-memory handoff failed" in warnings[0].getMessage()
+    assert _CEDAR_DETECT_SHMEM_NAME in warnings[0].getMessage()

--- a/python/tests/test_solver_cedar_client.py
+++ b/python/tests/test_solver_cedar_client.py
@@ -120,6 +120,11 @@ def test_extract_centroids_falls_back_when_segment_vanishes(caplog):
     # First call went over shmem and failed; the retry carried the pixels.
     assert len(calls) == 2
     assert calls[1].input_image.image_data == image.tobytes()
+    # ...and the retry keeps hot-pixel rejection on. The proto3 default is
+    # false, so an omitted field would silently let hot pixels be detected as
+    # stars for the rest of the run.
+    assert calls[0].detect_hot_pixels is True
+    assert calls[1].detect_hot_pixels is True
     # The downgrade is permanent for this process, so it has to be visible in
     # the logs -- otherwise the only symptom is a slower extract time.
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]

--- a/python/tests/test_solver_cedar_client.py
+++ b/python/tests/test_solver_cedar_client.py
@@ -1,0 +1,120 @@
+"""
+Unit tests for PFCedarDetectClient's shared-memory failure recovery.
+
+Field condition being modelled: systemd-logind's ``RemoveIPC=yes`` (the
+default) deletes every POSIX shared-memory segment the ``pifinder`` user
+owns as soon as that user's last login session ends — a plain SSH logout
+is enough, because the PiFinder services run as that user without a
+login session of their own. The cedar-detect server then can't open the
+segment by name (gRPC INTERNAL), and the client's cleanup used to raise
+``FileNotFoundError`` from ``unlink()`` before it could disable the
+shared-memory path — wedging every subsequent solve until restart
+(discovered in the battery-runtime bench campaign as "solves die at the
+cable pull": the SSH logout happened seconds beside the pull).
+
+No cedar-detect server is needed: the gRPC stub is faked, but the
+shared-memory segment and the protobuf requests are real.
+"""
+
+import types
+
+import grpc
+import numpy as np
+import pytest
+
+from multiprocessing import shared_memory
+
+from PiFinder.solver import PFCedarDetectClient
+
+
+def _bare_client():
+    """A PFCedarDetectClient without __init__ (no server, no subprocess)."""
+    client = PFCedarDetectClient.__new__(PFCedarDetectClient)
+    client._subprocess = None
+    client._stub = None
+    client._shmem = None
+    client._shmem_size = 0
+    client._use_shmem = True
+    return client
+
+
+class _VanishedSegment:
+    """Stands in for a segment logind already removed from /dev/shm."""
+
+    def close(self):
+        pass
+
+    def unlink(self):
+        raise FileNotFoundError(2, "No such file or directory")
+
+
+class _InternalRpcError(grpc.RpcError):
+    """The status the server returns when the shmem name can't be opened."""
+
+    def code(self):
+        return grpc.StatusCode.INTERNAL
+
+    def details(self):
+        return 'Could not open shared memory at "/cedar_detect_image": errno 2'
+
+
+@pytest.mark.unit
+def test_del_shmem_tolerates_vanished_segment():
+    """A segment already gone from /dev/shm is the goal state of
+    _del_shmem — releasing it must not raise."""
+    client = _bare_client()
+    client._shmem = _VanishedSegment()
+    client._del_shmem()
+    assert client._shmem is None
+
+
+@pytest.mark.unit
+def test_del_shmem_without_segment_is_a_noop():
+    client = _bare_client()
+    client._del_shmem()
+    assert client._shmem is None
+
+
+@pytest.mark.unit
+def test_extract_centroids_falls_back_when_segment_vanishes():
+    """The RemoveIPC scenario end to end: the shmem RPC fails INTERNAL,
+    the (externally unlinked) segment is released without an exception,
+    and the same call retries with the image inlined in the request —
+    so the frame that hits the error still gets centroids."""
+    client = _bare_client()
+
+    calls = []
+
+    def fake_extract(req):
+        calls.append(req)
+        if len(calls) == 1:
+            raise _InternalRpcError()
+        return types.SimpleNamespace(star_candidates=[])
+
+    client._stub = types.SimpleNamespace(ExtractCentroids=fake_extract)
+
+    image = np.zeros((32, 32), dtype=np.uint8)
+    try:
+        # Let the client create its real segment, then delete its name
+        # out from under it, exactly as logind's RemoveIPC does.
+        client._alloc_shmem(size=image.size)
+        vanish = shared_memory.SharedMemory(client._shmem.name)
+        vanish.close()
+        vanish.unlink()
+
+        centroids = client.extract_centroids(
+            image, sigma=8, max_size=10, use_binned=True
+        )
+    finally:
+        # The segment name is gone; make teardown tolerant either way.
+        try:
+            client._del_shmem()
+        except Exception:
+            pass
+
+    assert centroids == []
+    assert client._use_shmem is False
+    assert client._shmem is None
+    # First call went over shmem and failed; the retry carried the pixels.
+    assert len(calls) == 2
+    assert calls[1].input_image.image_data == image.tobytes()


### PR DESCRIPTION
## The bug

systemd-logind's default `RemoveIPC=yes` deletes every POSIX shared-memory segment a user owns the moment that user's **last login session ends**. A plain SSH logout is enough — the PiFinder services run as `pifinder` but hold no login session of their own. When that happens, `/dev/shm/cedar_detect_image` vanishes under the running solver:

- the cedar-detect server can't open the segment by name → gRPC `INTERNAL`
- `PFCedarDetectClient.extract_centroids`'s recovery path calls the upstream `_del_shmem()`, whose `unlink()` raises `FileNotFoundError` **before** `_use_shmem = False` is reached
- the designed fallback (image inlined in the gRPC request) never engages, and **every subsequent solve repeats the crash until the app restarts**

Any field user who SSHes into their unit and logs out silently loses plate solving.

## How it was found

The battery-runtime bench campaign: all four discharge runs across both campaigns "lost camera solving at the cable pull" — which turned out to be the operator's SSH logout seconds beside the pull. Device logs show ~28,000 identical solver exceptions per night (`FileNotFoundError: '//cedar_detect_image'` + server `errno 2`), first occurrence 3 s apart on two independent units. This also retro-explains campaign 1's degraded runs, which had been attributed to IMU pseudo-motion blanking.

## The fix (three layers)

- **`PFCedarDetectClient._del_shmem` override**: a segment already gone from `/dev/shm` is the method's goal state — treat it as released. The same `extract_centroids` call then retries with the image inlined, so even the frame that hits the error still gets centroids.
- **`pifinder_setup.sh`** (fresh installs): drop `RemoveIPC=no` into `/etc/systemd/logind.conf.d/` so provisioned units keep the fast shared-memory handoff instead of falling back after the first logout.
- **Migration `v2.6.1`** (existing units): delivers the same logind drop-in on the next software update via the standard one-shot mechanism in `pifinder_post_update.sh`, with a `try-restart` of logind so it applies without waiting for a reboot (logind restart does not end sessions, and RemoveIPC only acts at session end). *Naming note: the migration marker is just a label — if the next release ships under a different number, feel free to rename `v2.6.1` before merge.*

## Tests

`python/tests/test_solver_cedar_client.py`:
- vanished-segment release doesn't raise; no-segment release is a no-op
- end-to-end fallback: real shm segment created, unlinked out from under the client (exactly what logind does), faked gRPC stub returns `INTERNAL` then succeeds — asserts recovery in the same call, `_use_shmem` disabled, pixels inlined in the retry

Verified the test guards a real regression: with `_del_shmem` rebound to the upstream implementation the same scenario raises `FileNotFoundError` and never falls back.

Full suite: 991 unit+smoke passed; ruff + mypy clean; both shell scripts pass `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)