### PR TITLE
Low-battery warnings latch once per discharge; only a charger re-arms

### DIFF
--- a/python/PiFinder/battery_bq25895.py
+++ b/python/PiFinder/battery_bq25895.py
@@ -207,12 +207,6 @@ LOW_BATTERY_SHUTDOWN_POLLS = 4
 # the typical load.
 LOW_BATTERY_WARNING_PCTS = (10, 5)
 
-# A warning threshold re-arms once the state of charge climbs this many
-# points clear of it. One BATV LSB (20 mV) is ~2% near the bottom knots,
-# so without hysteresis quantisation jitter around a threshold would
-# re-fire the warning on every poll.
-LOW_BATTERY_WARNING_REARM_PCT = 2
-
 
 class LowBatteryShutdownTrigger:
     """Debounced trigger for the low-battery shutdown (ADR 0021).
@@ -244,20 +238,28 @@ class LowBatteryShutdownTrigger:
 
 
 class LowBatteryWarner:
-    """Once-per-crossing advisory warnings at the low state-of-charge
+    """Once-per-discharge advisory warnings at the low state-of-charge
     thresholds (ADR 0021: 10% and 5% precede the blind-floor shutdown).
 
     Feed it each published battery sample; it returns the threshold to
     warn for — the lowest newly-crossed one, so a fast drop through both
     yields a single (most severe) warning — or ``None``. The state of
     charge is ``None`` while charging or ADC-blind, which suppresses
-    warnings there. Every threshold re-arms on external power (so the
-    next discharge warns afresh) or once the estimate climbs
-    ``LOW_BATTERY_WARNING_REARM_PCT`` points clear of it
-    (quantisation-jitter hysteresis). A ``None`` estimate alone never
-    re-arms: conversions fail *intermittently* in the twilight just
-    above the blind floor, and re-arming on each blind poll would
-    re-fire the 5% warning on every interleaved sane poll.
+    warnings there.
+
+    Each threshold fires at most once per discharge: crossings *latch*,
+    and thresholds re-arm only on external power (so the next discharge
+    warns afresh). Nothing within a discharge re-arms them — not a
+    climbing estimate, not a ``None`` sample. The first cut shipped a
+    2-point climb-clear hysteresis instead, and the bench campaign
+    refuted it: near the discharge curve's flat knee one BATV LSB
+    (20 mV) is ~3 SoC points, and under a varying load the published
+    estimate bounced across 4-23% for the final ~90 minutes of every
+    run, re-firing the warning earcon ~90 times per discharge
+    (2026-07-24, both units). No percent-based hysteresis clears
+    quantisation noise that large while still re-arming on any genuine
+    recovery a single-cell battery can produce, so the crossing latches
+    until a charger appears.
 
     PURE, and strictly advisory UI — SoC is never a control input; the
     shutdown itself is :class:`LowBatteryShutdownTrigger`'s job.
@@ -274,9 +276,6 @@ class LowBatteryWarner:
             return None
         if state_of_charge_pct is None:
             return None
-        for t in self._thresholds:
-            if state_of_charge_pct > t + LOW_BATTERY_WARNING_REARM_PCT:
-                self._armed.add(t)
         crossed = [t for t in self._armed if state_of_charge_pct <= t]
         if not crossed:
             return None

--- a/python/PiFinder/battery_fake.py
+++ b/python/PiFinder/battery_fake.py
@@ -5,17 +5,19 @@ Fake battery monitor — the ``-fh`` (fake-hardware) twin of
 ``battery_bq25895``.
 
 Emits a deterministic, slowly-discharging :class:`BatteryState` so the
-rest of the system can be exercised without a real BQ25895. It always
-reports running from the battery (``on_external_power=False``,
-``charge_status=NOT_CHARGING``), so state of charge is always estimated
-via the same LUT as the real driver.
+rest of the system can be exercised without a real BQ25895. While
+discharging it reports running from the battery
+(``on_external_power=False``, ``charge_status=NOT_CHARGING``), so state
+of charge is estimated via the same LUT as the real driver.
 
 Each sweep ends the way a real discharge does (ADR 0021): after the
 voltage reaches the bottom of the sweep the fake goes **ADC-blind**
 (``battery_voltage=None``) for a few polls — enough to trip the
-low-battery shutdown debounce — then wraps back to full for the next
-lap. A dev run with ``-fh -fb`` therefore crosses the 10%/5% warnings
-and the blind-floor shutdown warning within a few minutes, end to end.
+low-battery shutdown debounce — then shows a brief **charging** phase
+(which re-arms the warner's once-per-discharge warning latches) and
+wraps back to full for the next lap. A dev run with ``-fh -fb``
+therefore crosses the 10%/5% warnings and the blind-floor shutdown
+warning within a few minutes, end to end — on every lap.
 The main loop shows the shutdown warning but skips the actual OS
 power-off on the Fake hardware platform, so a lap never powers off the
 host (which may be a real Pi running ``-fh`` for docs screenshots).
@@ -52,6 +54,12 @@ FAKE_VOLTAGE_STEP = 0.02
 # shutdown debounce, plus margin so the blind state is visible in the UI.
 FAKE_BLIND_POLLS = LOW_BATTERY_SHUTDOWN_POLLS + 2
 
+# Charging polls between laps: the warner's thresholds latch for a whole
+# discharge and re-arm only on external power, so each lap ends with a
+# brief fake "recharge" — otherwise the 10%/5% warnings would fire on the
+# first lap only and every later lap would run silent.
+FAKE_CHARGING_POLLS = 2
+
 
 def battery_monitor(shared_state, console_queue, ui_queue, log_queue):
     """Process entry mirroring ``battery_bq25895.battery_monitor``."""
@@ -61,6 +69,7 @@ def battery_monitor(shared_state, console_queue, ui_queue, log_queue):
     shutdown_trigger = LowBatteryShutdownTrigger()
     voltage = FAKE_VOLTAGE_FULL
     blind_polls_left = 0
+    charging_polls_left = 0
     while True:
         if blind_polls_left > 0:
             # ADC-blind tail: what the real decoder publishes below the
@@ -77,7 +86,23 @@ def battery_monitor(shared_state, console_queue, ui_queue, log_queue):
             )
             blind_polls_left -= 1
             if blind_polls_left == 0:
+                charging_polls_left = FAKE_CHARGING_POLLS
                 voltage = FAKE_VOLTAGE_FULL
+        elif charging_polls_left > 0:
+            # Between-laps "recharge": on external power with SoC None
+            # (never estimated while charging), which re-arms the
+            # warner's latched thresholds for the next lap.
+            state = BatteryState(
+                battery_voltage=FAKE_VOLTAGE_FULL,
+                charge_status=ChargeStatus.FAST_CHARGING,
+                on_external_power=True,
+                state_of_charge_pct=None,
+                charge_current_ma=1500.0,
+                vbus_voltage=5.1,
+                sys_voltage=FAKE_VOLTAGE_FULL,
+                timestamp=time.time(),
+            )
+            charging_polls_left -= 1
         else:
             state = BatteryState(
                 battery_voltage=voltage,

--- a/python/tests/test_battery_low_battery.py
+++ b/python/tests/test_battery_low_battery.py
@@ -9,7 +9,8 @@ Both are PURE (no hardware, no clock, no queues), following the module's
   on battery and fires once per sustained blind episode. It keys on the
   ADC-validity signal only — the estimated state of charge never feeds it.
 * ``LowBatteryWarner`` watches the estimated state of charge fall through
-  the 10%/5% thresholds, once per crossing, on battery only.
+  the 10%/5% thresholds, once per discharge, on battery only; the
+  crossings latch and only external power re-arms them.
 """
 
 import pytest
@@ -17,7 +18,6 @@ import pytest
 from PiFinder.battery_bq25895 import (
     LOW_BATTERY_SHUTDOWN_POLLS,
     LOW_BATTERY_WARNING_PCTS,
-    LOW_BATTERY_WARNING_REARM_PCT,
     LowBatteryShutdownTrigger,
     LowBatteryWarner,
 )
@@ -127,23 +127,68 @@ def test_fast_drop_through_both_thresholds_warns_most_severe_once():
 
 @pytest.mark.unit
 def test_quantisation_jitter_does_not_refire():
-    """One BATV LSB (20 mV) is ~2% near the bottom knots; bouncing inside
-    the re-arm hysteresis around a fired threshold must stay quiet."""
+    """One BATV LSB (20 mV) is ~3 SoC points near the flat knee of the
+    discharge curve, and load transients swing several LSBs. However far
+    the estimate bounces back up mid-discharge, a fired threshold stays
+    quiet."""
     warner = LowBatteryWarner()
     assert warner.update(10, on_external_power=False) == 10
-    for soc in (11, 12, 10, 11, 10, 9):
+    for soc in (13, 9, 16, 8, 23, 10, 9):
         assert warner.update(soc, on_external_power=False) is None
 
 
 @pytest.mark.unit
-def test_rearm_after_climbing_clear_of_threshold():
-    """Climbing past the hysteresis band genuinely re-arms the threshold
-    (e.g. the load dropped and the estimate recovered)."""
+def test_climb_never_rearms_within_a_discharge():
+    """Crossings latch for the whole discharge: even a large recovery of
+    the estimate does not re-arm a fired threshold — only external power
+    does. (The first cut re-armed on a 2-point climb; field data showed
+    quantisation noise re-firing the earcon ~90 times per discharge.)"""
     warner = LowBatteryWarner()
     assert warner.update(10, on_external_power=False) == 10
-    rearm_soc = 10 + LOW_BATTERY_WARNING_REARM_PCT + 1
-    assert warner.update(rearm_soc, on_external_power=False) is None
-    assert warner.update(10, on_external_power=False) == 10
+    assert warner.update(50, on_external_power=False) is None
+    assert warner.update(10, on_external_power=False) is None
+    assert warner.update(9, on_external_power=False) is None
+
+
+# Published state-of-charge samples from the 2026-07-24 bench discharge
+# (unit pf4-dev, 20:00-21:15, every 12th telemetry row ≈ one per minute):
+# the final 75 minutes before the blind-floor shutdown, showing the real
+# quantisation bounce across the 10% and 5% thresholds. The shipped
+# 2-point hysteresis re-fired 93 warnings on this discharge.
+# fmt: off
+FIELD_SOC_TAIL_2026_07_24 = (
+    19, 16, 23, 19, 16, 23, 13, 19, 19, 16, 13, 13, 16, 13, 16, 16, 10,
+    16, 16, 16, 13, 13, 13, 13, 16, 10, 13, 13, 13, 16, 13, 10, 13, 13,
+    13, 8, 10, 10, 8, 10, 10, 10, 10, 10, 10, 13, 8, 10, 4, 10, 6,
+    8, 8, 8, 6, 8, 6, 4, 6, 10, 8, 4, 6, 6, 4, 6, 4, 4,
+    6, 8, 4, 4, 0,
+)
+# fmt: on
+
+
+@pytest.mark.unit
+def test_field_discharge_tail_warns_exactly_twice():
+    """Regression on the real 2026-07-24 discharge tail: exactly one 10%
+    and one 5% warning across the whole noisy descent."""
+    warner = LowBatteryWarner()
+    fires = [
+        warner.update(soc, on_external_power=False) for soc in FIELD_SOC_TAIL_2026_07_24
+    ]
+    assert [f for f in fires if f is not None] == [10, 5]
+
+
+@pytest.mark.unit
+def test_field_discharge_repeats_after_a_charge():
+    """The same field tail warns afresh after a charge — the latch is
+    per-discharge, not forever."""
+    warner = LowBatteryWarner()
+    for soc in FIELD_SOC_TAIL_2026_07_24:
+        warner.update(soc, on_external_power=False)
+    assert warner.update(None, on_external_power=True) is None
+    fires = [
+        warner.update(soc, on_external_power=False) for soc in FIELD_SOC_TAIL_2026_07_24
+    ]
+    assert [f for f in fires if f is not None] == [10, 5]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## The bug (heard in the field)

During the 2026-07-24 bench discharge runs the 10%/5% low-battery warning earcon fired **~90 times per run** (replaying the telemetry through `LowBatteryWarner` reproduces 93 fires on one unit, 86 on the other — every 30–90 s for the final ~90 minutes). Design intent was once at 10% and once at 5%.

## Why the hysteresis failed

The shipped guard re-armed a threshold when the estimate climbed 2 points clear of it. But near the discharge curve's flat knee, one BATV ADC step (20 mV) is worth ~3 SoC points, and under the varying solve load the published estimate bounced across 4–23% for the whole tail of the discharge. Every two-step upward bounce re-armed a threshold; the next dip re-fired it. The published SoC values in that window were `{4, 6, 8, 10, 13, 16, 19, 23}` — swings of 6+ points between 5-second samples. No percent-based hysteresis clears quantisation noise that large while still re-arming on any genuine recovery a single-cell battery can produce.

## The fix

Crossings **latch for the whole discharge**; thresholds re-arm **only on external power** (so the next discharge warns afresh). Nothing within a discharge re-arms them — not a climbing estimate, not a blind (`None`) sample. The blind-twilight guard from #541 is unchanged (and the field data confirmed it worked — zero re-fires from blind samples).

`battery_fake` gains a two-poll charging phase between laps, since with the latch a `-fh -fb` dev run would otherwise demo the warnings on the first lap only.

## Tests

- `test_field_discharge_tail_warns_exactly_twice` — replays the actual pf4-dev discharge tail (one sample per minute, 20:00–21:15, embedded as a fixture): exactly one 10% and one 5% warning across the full noisy descent. The old code re-fires many times on this same sequence.
- `test_field_discharge_repeats_after_a_charge` — the latch is per-discharge, not forever.
- `test_climb_never_rearms_within_a_discharge`, updated jitter test with realistic (multi-LSB) bounces; all other #541 warner semantics (fast-drop most-severe-once, twilight guard, charging re-arm) unchanged and still covered.

Full suite: 990 unit+smoke passed; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)