### PR TITLE
Extract the keypad matrix tables into an import-safe PiFinder.keypad

### DIFF
--- a/python/PiFinder/keyboard_pi.py
+++ b/python/PiFinder/keyboard_pi.py
@@ -8,6 +8,7 @@ and adds keys to the provided queue
 
 from time import sleep, time
 import libinput
+from PiFinder import keypad
 from PiFinder.keyboard_interface import KeyboardInterface
 import RPi.GPIO as GPIO
 import logging
@@ -20,40 +21,22 @@ class KeyboardPi(KeyboardInterface):
     def __init__(self, q):
         self.q = q
 
-        # GPIO pin numbers for the rows and columns of the keyboard matrix
-        self.cols = [16, 23, 26, 27, 21]
-        self.rows = [19, 17, 18, 22, 20]
-        self.power_gpio = 15
+        # Matrix wiring and keymaps live in PiFinder.keypad, which is
+        # import-safe (no RPi.GPIO / libinput) so bring-up and the unit tests
+        # can read the same tables this scanner runs on.
+        self.cols = keypad.MATRIX_COLS
+        self.rows = keypad.MATRIX_ROWS
+        self.power_gpio = keypad.POWER_GPIO
 
         # Timer for power-off debounce, and latch so we only emit
         # one POWER_BTN per physical press
         self.power_press_time = 0
         self.power_sent = False
 
-        # fmt: off
-        self.keymap = [
-            7 , 8 , 9 , self.NA, self.UP,
-            4 , 5 , 6 , self.PLUS, self.LEFT,
-            1 , 2 , 3 , self.MINUS, self.DOWN,
-            self.NA, 0 , self.NA, self.SQUARE, self.RIGHT,
-            self.LEFT, self.UP , self.DOWN , self.RIGHT, self.SQUARE,
-        ]
+        self.keymap = keypad.KEYMAP
         # If SQUARE is pressed together with key, ALT_<key> is sent
-        self.alt_keymap = [
-            self.NA, self.NA, self.NA, self.NA, self.ALT_UP,
-            self.NA, self.NA, self.NA, self.ALT_PLUS, self.ALT_LEFT,
-            self.NA, self.NA, self.NA, self.ALT_MINUS, self.ALT_DOWN,
-            self.NA, self.ALT_0, self.NA, self.NA, self.ALT_RIGHT,
-            self.ALT_LEFT, self.ALT_UP, self.ALT_DOWN, self.ALT_RIGHT, self.NA,
-        ]
-        self.long_keymap = [
-            self.NA, self.NA, self.NA, self.NA, self.LNG_UP,
-            self.NA, self.NA, self.NA, self.NA, self.LNG_LEFT,
-            self.NA, self.NA, self.NA, self.NA, self.LNG_DOWN,
-            self.NA, self.NA, self.NA, self.LNG_SQUARE, self.LNG_RIGHT,
-            self.LNG_LEFT, self.LNG_UP, self.LNG_DOWN, self.LNG_RIGHT, self.LNG_SQUARE,
-        ]
-        # fmt: on
+        self.alt_keymap = keypad.ALT_KEYMAP
+        self.long_keymap = keypad.LONG_KEYMAP
 
         # Derive keycodes from the keymap so they track the matrix layout
         # (cols/rows) rather than being hard-coded. SQUARE is the brightness/

--- a/python/PiFinder/keyboard_pi.py
+++ b/python/PiFinder/keyboard_pi.py
@@ -126,7 +126,7 @@ class KeyboardPi(KeyboardInterface):
             for i in range(len(self.rows)):
                 GPIO.setup(self.rows[i], GPIO.OUT, initial=GPIO.LOW)
                 for j in range(len(self.cols)):
-                    keycode = i * len(self.cols) + j
+                    keycode = keypad.keymap_index(i, j)
                     newval = GPIO.input(self.cols[j]) == GPIO.LOW
                     if newval and keycode not in pressed:
                         # initial press

--- a/python/PiFinder/keypad.py
+++ b/python/PiFinder/keypad.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python
+# -*- coding:utf-8 -*-
+"""
+Keypad matrix wiring: the physical truth about the keypad, shared by the
+keyboard scanner (``keyboard_pi``) and bring-up (``PiFinder.bringup``).
+
+Pure data, **import-safe everywhere** — no ``RPi.GPIO``, no ``libinput``. That
+is the whole point of the module: ``keyboard_pi`` imports both of those at
+module scope and therefore cannot be imported on a dev box or in a unit test,
+so the tables cannot live there if anything else is to read them.
+
+Two different tables describe the keypad and they must not be confused (see
+``docs/ax/bringup/CONTEXT.md``):
+
+* the **keymap** maps a matrix position to the logical **key** the UI receives
+  (``UP``, ``ALT_PLUS``, ...) — several positions can send the same key;
+* the **population map** says which matrix positions actually carry a
+  **switch** on a given board revision — the physical joints bring-up checks.
+
+The matrix is scanned identically on every revision; revisions differ only in
+which positions are populated.
+"""
+
+from typing import FrozenSet, List, Tuple
+
+from PiFinder.keyboard_interface import KeyboardInterface as K
+
+# GPIO pin numbers (BCM) for the rows and columns of the keypad matrix.
+# Rows are driven LOW one at a time as outputs; columns are read with
+# pull-ups, so a closed switch reads LOW.
+MATRIX_COLS: List[int] = [16, 23, 26, 27, 21]
+MATRIX_ROWS: List[int] = [19, 17, 18, 22, 20]
+
+# The power switch is wired to its own GPIO, not into the matrix, and has no
+# matrix position. It has its own pull-up in hardware and goes LOW when closed.
+POWER_GPIO: int = 15
+
+# fmt: off
+KEYMAP: List[int] = [
+    7 , 8 , 9 , K.NA, K.UP,
+    4 , 5 , 6 , K.PLUS, K.LEFT,
+    1 , 2 , 3 , K.MINUS, K.DOWN,
+    K.NA, 0 , K.NA, K.SQUARE, K.RIGHT,
+    K.LEFT, K.UP , K.DOWN , K.RIGHT, K.SQUARE,
+]
+# If SQUARE is pressed together with key, ALT_<key> is sent
+ALT_KEYMAP: List[int] = [
+    K.NA, K.NA, K.NA, K.NA, K.ALT_UP,
+    K.NA, K.NA, K.NA, K.ALT_PLUS, K.ALT_LEFT,
+    K.NA, K.NA, K.NA, K.ALT_MINUS, K.ALT_DOWN,
+    K.NA, K.ALT_0, K.NA, K.NA, K.ALT_RIGHT,
+    K.ALT_LEFT, K.ALT_UP, K.ALT_DOWN, K.ALT_RIGHT, K.NA,
+]
+LONG_KEYMAP: List[int] = [
+    K.NA, K.NA, K.NA, K.NA, K.LNG_UP,
+    K.NA, K.NA, K.NA, K.NA, K.LNG_LEFT,
+    K.NA, K.NA, K.NA, K.NA, K.LNG_DOWN,
+    K.NA, K.NA, K.NA, K.LNG_SQUARE, K.LNG_RIGHT,
+    K.LNG_LEFT, K.LNG_UP, K.LNG_DOWN, K.LNG_RIGHT, K.LNG_SQUARE,
+]
+# fmt: on
+
+
+def position(row: int, col: int) -> int:
+    """Matrix position -> index into :data:`KEYMAP` and friends."""
+    return row * len(MATRIX_COLS) + col
+
+
+def key_at(row: int, col: int) -> int:
+    """The logical key a switch at this matrix position sends."""
+    return KEYMAP[position(row, col)]
+
+
+def _populated(rows: range, cols: range) -> FrozenSet[Tuple[int, int]]:
+    """Positions in this row/column block that carry a switch.
+
+    A position is populated when the keymap gives it a real key; ``NA`` marks
+    a hole in the block (the calculator pad is not a full rectangle).
+    """
+    return frozenset(
+        (row, col) for row in rows for col in cols if key_at(row, col) != K.NA
+    )
+
+
+# --- Population maps: which positions carry a switch on each revision -------
+#
+#        col0  col1  col2  col3    col4
+# row0    7     8     9    (na)    UP     |
+# row1    4     5     6    PLUS    LEFT   | col4 = the directional cluster
+# row2    1     2     3    MINUS   DOWN   | added for rev4, with a centre
+# row3   (na)   0    (na)  SQUARE  RIGHT  | SQUARE of its own
+# row4    LEFT  UP    DOWN  RIGHT  SQUARE |
+#         |__ rev3 directional row __|
+#            (unpopulated on rev4)
+#
+# rev3: cols 0-3 of every row -- the calculator pad plus a directional row
+# along the bottom. 17 switches (three NA holes).
+REV3_POPULATED: FrozenSet[Tuple[int, int]] = _populated(range(5), range(4))
+
+# rev4: the directional cluster moved off the bottom row into column 4 and
+# gained a centre SQUARE, so ALL FIVE rows of col 4 are populated while only
+# rows 0-3 of cols 0-3 are. 13 + 5 = 18 switches, and two positions send
+# SQUARE -- (3,3) on the calculator pad and (4,4) in the cluster.
+REV4_POPULATED: FrozenSet[Tuple[int, int]] = _populated(range(4), range(4)) | frozenset(
+    (row, 4) for row in range(5)
+)
+
+POPULATION_MAPS = {
+    "rev3": REV3_POPULATED,
+    "rev4": REV4_POPULATED,
+}

--- a/python/PiFinder/keypad.py
+++ b/python/PiFinder/keypad.py
@@ -61,14 +61,19 @@ LONG_KEYMAP: List[int] = [
 # fmt: on
 
 
-def position(row: int, col: int) -> int:
-    """Matrix position -> index into :data:`KEYMAP` and friends."""
+def keymap_index(row: int, col: int) -> int:
+    """Matrix position ``(row, col)`` -> index into :data:`KEYMAP` and friends.
+
+    Named for what it returns. A **matrix position** is the ``(row, col)``
+    pair itself (see the glossary, which lists "index" as a word to avoid for
+    it); this is the flat offset the tables happen to be stored at.
+    """
     return row * len(MATRIX_COLS) + col
 
 
 def key_at(row: int, col: int) -> int:
     """The logical key a switch at this matrix position sends."""
-    return KEYMAP[position(row, col)]
+    return KEYMAP[keymap_index(row, col)]
 
 
 def _populated(rows: range, cols: range) -> FrozenSet[Tuple[int, int]]:
@@ -101,9 +106,12 @@ REV3_POPULATED: FrozenSet[Tuple[int, int]] = _populated(range(5), range(4))
 # gained a centre SQUARE, so ALL FIVE rows of col 4 are populated while only
 # rows 0-3 of cols 0-3 are. 13 + 5 = 18 switches, and two positions send
 # SQUARE -- (3,3) on the calculator pad and (4,4) in the cluster.
-REV4_POPULATED: FrozenSet[Tuple[int, int]] = _populated(range(4), range(4)) | frozenset(
-    (row, 4) for row in range(5)
-)
+# Both halves go through the same NA filter: col 4 has no holes today, but
+# deriving one half differently from the other is how the two tables start to
+# disagree.
+REV4_POPULATED: FrozenSet[Tuple[int, int]] = _populated(
+    range(4), range(4)
+) | _populated(range(5), range(4, 5))
 
 POPULATION_MAPS = {
     "rev3": REV3_POPULATED,

--- a/python/tests/test_keypad.py
+++ b/python/tests/test_keypad.py
@@ -1,0 +1,156 @@
+"""
+Unit tests for ``PiFinder.keypad`` — the keypad matrix wiring shared by the
+keyboard scanner and bring-up (see ``docs/ax/bringup/CONTEXT.md``).
+
+Two things are worth guarding here:
+
+* the **population maps**, which say how many switches each board revision
+  actually carries. They set bring-up's PASS gate, so an error in either
+  direction is expensive: too many expected and PASS never arrives, too few
+  and a dead switch passes silently.
+* the **extraction itself** — that ``KeyboardPi`` really reads its rows,
+  columns and keymaps from this module rather than keeping a private copy that
+  can drift.
+
+``keyboard_pi`` imports ``libinput`` and ``RPi.GPIO`` at module scope and can
+only be imported on a Pi, so the extraction test stubs both.
+"""
+
+import sys
+import types
+
+import pytest
+
+from PiFinder import keypad
+from PiFinder.keyboard_interface import KeyboardInterface as K
+
+
+@pytest.mark.unit
+def test_population_map_sizes():
+    """rev3 carries 17 switches, rev4 carries 18."""
+    assert len(keypad.REV3_POPULATED) == 17
+    assert len(keypad.REV4_POPULATED) == 18
+
+
+@pytest.mark.unit
+def test_rev3_is_the_first_four_columns():
+    """rev3 populates cols 0-3 of every row, including the bottom
+    directional row, and nothing in col 4."""
+    assert all(col < 4 for _, col in keypad.REV3_POPULATED)
+    assert {(4, col) for col in range(4)} <= keypad.REV3_POPULATED
+
+
+@pytest.mark.unit
+def test_rev4_populates_all_of_column_four_and_no_bottom_row():
+    """rev4 moved the directional cluster into col 4 -- all five rows of it,
+    including the centre SQUARE at (4,4) -- and left the rest of the bottom
+    row unpopulated."""
+    assert {(row, 4) for row in range(5)} <= keypad.REV4_POPULATED
+    assert not {(4, col) for col in range(4)} & keypad.REV4_POPULATED
+
+
+@pytest.mark.unit
+def test_rev4_has_two_square_switches():
+    """The calculator pad's SQUARE at (3,3) and the cluster's centre SQUARE
+    at (4,4) are distinct switches sending the same key."""
+    squares = {pos for pos in keypad.REV4_POPULATED if keypad.key_at(*pos) == K.SQUARE}
+    assert squares == {(3, 3), (4, 4)}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("revision", ["rev3", "rev4"])
+def test_every_populated_position_has_a_real_key(revision):
+    """A populated position must map to a non-NA keymap entry.
+
+    Catches the population maps and the keymap drifting apart -- a switch the
+    builder is asked to close that the running UI would ignore.
+    """
+    for row, col in keypad.POPULATION_MAPS[revision]:
+        assert keypad.key_at(row, col) != K.NA, f"({row},{col}) is NA in the keymap"
+
+
+@pytest.mark.unit
+def test_position_indexes_the_keymap_row_major():
+    assert keypad.position(0, 0) == 0
+    assert keypad.position(1, 0) == len(keypad.MATRIX_COLS)
+    assert keypad.position(4, 4) == len(keypad.KEYMAP) - 1
+
+
+@pytest.mark.unit
+def test_tables_are_all_one_entry_per_matrix_position():
+    expected = len(keypad.MATRIX_ROWS) * len(keypad.MATRIX_COLS)
+    assert len(keypad.KEYMAP) == expected
+    assert len(keypad.ALT_KEYMAP) == expected
+    assert len(keypad.LONG_KEYMAP) == expected
+
+
+@pytest.fixture
+def keyboard_pi_module(monkeypatch):
+    """Import ``PiFinder.keyboard_pi`` with its Pi-only imports stubbed.
+
+    ``libinput`` and ``RPi.GPIO`` are absent on a dev box; the scanner only
+    touches them at construction (``LibInput``/``assign_seat``) and inside
+    ``run_keyboard``, which this never calls.
+    """
+    libinput_stub = types.ModuleType("libinput")
+
+    class _LibInput:
+        def __init__(self, context_type=None):
+            pass
+
+        def assign_seat(self, seat):
+            pass
+
+    libinput_stub.LibInput = _LibInput
+    libinput_stub.ContextType = types.SimpleNamespace(UDEV=object())
+    libinput_stub.KeyboardEvent = object
+    libinput_stub.constant = types.SimpleNamespace(
+        KeyState=types.SimpleNamespace(RELEASED=object())
+    )
+
+    rpi_stub = types.ModuleType("RPi")
+    gpio_stub = types.ModuleType("RPi.GPIO")
+    rpi_stub.GPIO = gpio_stub
+
+    monkeypatch.setitem(sys.modules, "libinput", libinput_stub)
+    monkeypatch.setitem(sys.modules, "RPi", rpi_stub)
+    monkeypatch.setitem(sys.modules, "RPi.GPIO", gpio_stub)
+    monkeypatch.delitem(sys.modules, "PiFinder.keyboard_pi", raising=False)
+
+    import PiFinder.keyboard_pi as keyboard_pi
+
+    yield keyboard_pi
+
+    # Leave no half-stubbed module behind for later tests to import.
+    sys.modules.pop("PiFinder.keyboard_pi", None)
+
+
+@pytest.mark.unit
+def test_keyboard_pi_sources_its_wiring_from_keypad(keyboard_pi_module):
+    """Guards the extraction: the scanner must not keep a private copy."""
+    kb = keyboard_pi_module.KeyboardPi(q=None)
+
+    assert kb.rows is keypad.MATRIX_ROWS
+    assert kb.cols is keypad.MATRIX_COLS
+    assert kb.power_gpio == keypad.POWER_GPIO
+    assert kb.keymap is keypad.KEYMAP
+    assert kb.alt_keymap is keypad.ALT_KEYMAP
+    assert kb.long_keymap is keypad.LONG_KEYMAP
+
+
+@pytest.mark.unit
+def test_keyboard_pi_derived_keycodes_survive_the_extraction(keyboard_pi_module):
+    """``square_keycodes`` / ``repeat_keycodes`` are comprehensions over the
+    keymap; they must still resolve to the same keymap indices."""
+    kb = keyboard_pi_module.KeyboardPi(q=None)
+
+    assert kb.square_keycodes == {
+        keypad.position(3, 3),
+        keypad.position(4, 4),
+    }
+    assert kb.repeat_keycodes == {
+        keypad.position(0, 4),  # UP, rev4 cluster
+        keypad.position(2, 4),  # DOWN, rev4 cluster
+        keypad.position(4, 1),  # UP, rev3 bottom row
+        keypad.position(4, 2),  # DOWN, rev3 bottom row
+    }

--- a/python/tests/test_keypad.py
+++ b/python/tests/test_keypad.py
@@ -60,20 +60,31 @@ def test_rev4_has_two_square_switches():
 @pytest.mark.unit
 @pytest.mark.parametrize("revision", ["rev3", "rev4"])
 def test_every_populated_position_has_a_real_key(revision):
-    """A populated position must map to a non-NA keymap entry.
-
-    Catches the population maps and the keymap drifting apart -- a switch the
+    """A populated position must map to a non-NA keymap entry -- a switch the
     builder is asked to close that the running UI would ignore.
+
+    Honest about its own strength: the maps are *derived* from the keymap
+    through the same NA filter, so this restates the derivation rather than
+    checking it independently. What makes the pair meaningful is
+    ``test_population_map_sizes``, which states 17 and 18 independently of how
+    they are computed -- change either table and one of the two fails.
+
+    The reason the maps are derived rather than hand-listed is that the likelier
+    error is a keymap edit silently changing which positions count as switches;
+    deriving makes that impossible to do quietly. The cost is that a revision
+    fitting a switch the UI ignores could not be expressed without also editing
+    KEYMAP -- no such revision exists, and if one appears these become explicit
+    position sets.
     """
     for row, col in keypad.POPULATION_MAPS[revision]:
         assert keypad.key_at(row, col) != K.NA, f"({row},{col}) is NA in the keymap"
 
 
 @pytest.mark.unit
-def test_position_indexes_the_keymap_row_major():
-    assert keypad.position(0, 0) == 0
-    assert keypad.position(1, 0) == len(keypad.MATRIX_COLS)
-    assert keypad.position(4, 4) == len(keypad.KEYMAP) - 1
+def test_keymap_index_is_row_major():
+    assert keypad.keymap_index(0, 0) == 0
+    assert keypad.keymap_index(1, 0) == len(keypad.MATRIX_COLS)
+    assert keypad.keymap_index(4, 4) == len(keypad.KEYMAP) - 1
 
 
 @pytest.mark.unit
@@ -145,12 +156,12 @@ def test_keyboard_pi_derived_keycodes_survive_the_extraction(keyboard_pi_module)
     kb = keyboard_pi_module.KeyboardPi(q=None)
 
     assert kb.square_keycodes == {
-        keypad.position(3, 3),
-        keypad.position(4, 4),
+        keypad.keymap_index(3, 3),
+        keypad.keymap_index(4, 4),
     }
     assert kb.repeat_keycodes == {
-        keypad.position(0, 4),  # UP, rev4 cluster
-        keypad.position(2, 4),  # DOWN, rev4 cluster
-        keypad.position(4, 1),  # UP, rev3 bottom row
-        keypad.position(4, 2),  # DOWN, rev3 bottom row
+        keypad.keymap_index(0, 4),  # UP, rev4 cluster
+        keypad.keymap_index(2, 4),  # DOWN, rev4 cluster
+        keypad.keymap_index(4, 1),  # UP, rev3 bottom row
+        keypad.keymap_index(4, 2),  # DOWN, rev3 bottom row
     }


### PR DESCRIPTION
PR 2 of 3 in the `PiFinder.bringup` sequence (plan §11). Docs and plan landed
in #550; the bring-up tool itself is #552, which is stacked on this branch.

## What

`keyboard_pi` imports `libinput` and `RPi.GPIO` at module scope, so the matrix
wiring buried in `KeyboardPi.__init__` couldn't be read by anything else — not
by unit tests, and not by the bring-up tool, which needs the same tables to
scan the keypad on a bare board.

- **New `python/PiFinder/keypad.py`** — `MATRIX_ROWS` / `MATRIX_COLS` /
  `POWER_GPIO` / `KEYMAP` / `ALT_KEYMAP` / `LONG_KEYMAP` moved verbatim, plus
  `keymap_index()` / `key_at()` helpers. Imports only `KeyboardInterface`, so it
  is import-safe on a dev box.
- **`keyboard_pi.py`** reads the tables from it, and uses `keymap_index()` in
  its scan loop rather than recomputing `i * len(self.cols) + j` inline.
  **Zero behaviour change** — the derived `square_keycodes` / `repeat_keycodes`
  comprehensions still read `self.keymap` and resolve to the same indices.
- **New `REV3_POPULATED` / `REV4_POPULATED`** population maps — which matrix
  positions actually carry a switch on each revision. Derived from the keymap
  through a single shared NA filter rather than hand-listed, so the two tables
  can't drift apart silently.
- **New `python/tests/test_keypad.py`** — 10 unit tests covering the population
  maps and guarding the extraction itself (it stubs `libinput`/`RPi.GPIO` and
  asserts `KeyboardPi` really sources its wiring from `keypad`, rather than
  keeping a private copy).

Landed on its own so any keypad regression stays bisectable in isolation from
the new tool.

**On the name:** the plan sketched this helper as `position()`, but the Bring-up
glossary defines a **matrix position** as the `(row, col)` pair and lists
"index" under *Avoid* for it — so `position(3,3) == 18` would have introduced
two meanings for one word in the same change. `keymap_index()` matches the
plan's own docstring ("Matrix position -> keymap index").

## ⚠️ Please confirm against a real rev4 board before merging

`REV4_POPULATED` currently says **18 switches**: rows 0–3 of cols 0–3 (the
calculator pad, 13) plus **all five** rows of col 4 (the directional cluster,
including its own centre `SQUARE` at `(4,4)`). Verified arithmetically against
the 25-entry keymap, but not against hardware.

The competing reading: commit e82b809d (#498) says its fix "enables repeat on
**both** directional clusters", which would mean rev4 populates the rev3 bottom
row *as well as* col 4 → **22 switches**.

This matters because it sets bring-up's PASS gate: too many expected and PASS
never arrives, too few and a dead switch passes silently. It is one constant, so
correcting it is a one-line change with no redesign — and #552's bring-up screen
reports any closure at a position *outside* the map, which is exactly how to
settle it on the first board.

## A note on deriving the maps

Deriving the population maps from the keymap means `NA` carries two meanings
("sends nothing to the UI" and "no switch fitted here"), which makes
`test_every_populated_position_has_a_real_key` partly a restatement of the
derivation rather than an independent check. Kept anyway, because the likelier
error is a keymap edit silently changing which positions count as switches, and
`test_population_map_sizes` states 17 and 18 independently of how they are
computed — so change either table and one of the two fails. If a revision ever
fits a switch the UI ignores, these become explicit position sets.

## Verification

`ruff check` · `ruff format` · `mypy PiFinder` (145 files, clean) · `pytest -m unit`
(993 passed). No hardware available on the dev machine; the extraction guard
test covers the part that hardware would otherwise be needed for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)