### PR TITLE
Exposure sweeps archive the full sensor, not the square crop

### DIFF
--- a/docs/ax/camera/CONTEXT.md
+++ b/docs/ax/camera/CONTEXT.md
@@ -58,6 +58,36 @@ The number of consecutive zero-match solve attempts required before recovery act
 Zero-match recovery was briefly a plugin point with four selectable strategies (Sweep, Exponential, Reset, Histogram) behind the Experimental "AE Algo" menu. [ADR 0010](../../adr/0010-zero-match-recovery-single-ladder.md) kept the Sweep ladder as the only behavior and removed the rest, the plugin seam, the menu, and the `auto_exposure_zero_star_handler` config key. Recovery is now the single concrete `ZeroMatchRecovery` class.
 _Avoid_: AE algo, zero-star handler, handler, plugin.
 
+### Frame extents
+
+Two regions of the sensor are in play at once, and confusing them is the
+standing hazard in this area. Always say which one you mean.
+
+**Full-sensor frame**:
+Every pixel the sensor delivers, uncropped. Written by `capture_raw_file()` —
+always, with no option to write anything narrower — and archived by the
+exposure sweep capture as `*_rawfull_*.tiff`. Nothing measures it: it exists so
+the margins are on disk for later analysis, because a margin not captured is
+gone for good.
+_Avoid_: raw frame (unqualified — the crop is equally raw).
+
+**Crop**:
+The centred square region of the sensor. This is what `cam_raw()` holds, what
+SQM photometry measures, and what each sweep frame's `raw_stats` covers. The
+crop is a plain slice of the full-sensor frame, so
+`CameraProfile.ensure_cropped()` recovers it exactly from an archived
+full-sensor frame — that equivalence is what lets full-sensor sweeps reproduce
+every number the cropped-era archive produced.
+
+The asymmetry inside a single sweep frame is deliberate and worth stating
+plainly: **the TIFF is full-sensor, its `raw_stats` are crop-only.** Those
+statistics are the black-level-versus-temperature series, and the vignetted
+margins would shift every mean and percentile, ending comparability with sweeps
+taken before the archive went full-sensor. New records carry
+`raw_stats.extent: "crop"` and `sweep_metadata.json` carries
+`camera.raw_frame_extent: "full_sensor"`, so an archive states which is which
+instead of relying on anyone remembering.
+
 ### Cross-context terms
 
 - **`Matches`** — defined in [Positioning](../positioning/CONTEXT.md): count of stars tetra3 matched in the most recent solve attempt, published on every attempt (success or failure) because auto-exposure depends on it. The feedback signal for solver-driven auto-exposure.

--- a/docs/ax/sqm/CONTEXT.md
+++ b/docs/ax/sqm/CONTEXT.md
@@ -40,6 +40,10 @@ The processed 512×512 image used by Cedar and tetra3. It can be display-rotated
 **Raw photometry image**:
 The linear cropped raw mono frame, or the mean of both Bayer-green sites. Star
 flux and sky background are measured here, not on the processed solve image.
+Always the **crop**, never the full-sensor frame that exposure sweeps archive —
+see [Camera](../camera/CONTEXT.md) for the two extents. The margins are
+vignetted with no optical black, so measuring them would bias the sky
+background and break continuity with every calibrated sweep.
 
 **Derotation**:
 Mapping solve-image `(y, x)` centroids back to the orientation of the stored

--- a/python/PiFinder/camera_interface.py
+++ b/python/PiFinder/camera_interface.py
@@ -68,10 +68,14 @@ def _json_safe(value):
     return str(value)
 
 
-def sweep_frame_record(index, exp_us, driver_metadata, raw_frame, bit_depth):
+def sweep_frame_record(index, exp_us, driver_metadata, cropped_frame, bit_depth):
     """Build one sweep image's metadata record: the camera settings actually
-    applied (from driver metadata) plus ADU statistics of the raw frame as
-    saved in the TIFF (pre-bias-subtraction)."""
+    applied (from driver metadata) plus ADU statistics of the raw frame
+    (pre-bias-subtraction).
+
+    The statistics cover the square crop, while the TIFF alongside holds the
+    whole sensor. Keeping them on the crop is what makes the black-level
+    series comparable with sweeps taken before the archive went full-sensor."""
     camera_metadata = {
         key: _json_safe(driver_metadata.get(key)) if driver_metadata else None
         for key in SWEEP_FRAME_METADATA_KEYS
@@ -90,10 +94,16 @@ def sweep_frame_record(index, exp_us, driver_metadata, raw_frame, bit_depth):
             _json_safe(driver_metadata) if driver_metadata else None
         ),
     }
-    if raw_frame is not None:
-        frame = raw_frame.astype(np.float64)
+    if cropped_frame is not None:
+        frame = cropped_frame.astype(np.float64)
         p = np.percentile(frame, [1, 5, 25, 50, 75, 95, 99])
         record["raw_stats"] = {
+            # Which pixels these numbers cover. The sibling TIFF is
+            # full-sensor, so without this the two would silently be
+            # assumed to describe the same pixels. Sweeps from before the
+            # archive went full-sensor have no such key; there the TIFF
+            # was the crop too, so it meant the same thing either way.
+            "extent": "crop",
             "mean_adu": float(frame.mean()),
             "median_adu": float(p[3]),
             "std_adu": float(frame.std()),
@@ -110,7 +120,7 @@ def sweep_frame_record(index, exp_us, driver_metadata, raw_frame, bit_depth):
         }
         if bit_depth:
             record["raw_stats"]["saturated_fraction"] = float(
-                np.mean(raw_frame >= 2**bit_depth - 1)
+                np.mean(cropped_frame >= 2**bit_depth - 1)
             )
     return record
 
@@ -757,9 +767,16 @@ class CameraInterface:
                                 )  # Returns 8-bit PIL Image
                                 processed_img.save(str(processed_filename))
 
-                                # Save RAW TIFF (16-bit, from camera.capture_raw_file())
+                                # Save RAW TIFF (16-bit, from
+                                # camera.capture_raw_file()), always the full
+                                # sensor. The "rawfull" name keeps these out of
+                                # readers globbing the cropped era's
+                                # "*_raw_RGGB.tiff", so an un-updated tool finds
+                                # nothing rather than silently scaling centroids
+                                # against the wrong frame size.
                                 raw_filename = (
-                                    sweep_dir / f"img_{i:03d}_{exp_ms:.2f}ms_raw.tiff"
+                                    sweep_dir
+                                    / f"img_{i:03d}_{exp_ms:.2f}ms_rawfull.tiff"
                                 )
                                 self.capture_raw_file(str(raw_filename))
 
@@ -772,8 +789,8 @@ class CameraInterface:
                                 frame_record = sweep_frame_record(
                                     i,
                                     exp_us,
-                                    getattr(self, "last_raw_frame_metadata", None),
-                                    getattr(self, "last_raw_frame", None),
+                                    getattr(self, "last_frame_driver_metadata", None),
+                                    getattr(self, "last_cropped_frame", None),
                                     getattr(
                                         getattr(self, "profile", None),
                                         "bit_depth",

--- a/python/PiFinder/camera_pi.py
+++ b/python/PiFinder/camera_pi.py
@@ -204,6 +204,12 @@ class CameraPI(CameraInterface):
         For RGB sensors:
         - Converts to grayscale
         - Saves without Bayer pattern suffix
+
+        The square crop is never applied here, and there is deliberately no
+        option to apply it. The crop is a plain slice, so the full frame is a
+        superset and ``profile.ensure_cropped()`` reproduces the cropped frame
+        from it exactly -- while margins not written now are gone for good.
+        Live photometry is unaffected: it reads ``cam_raw()``, still the crop.
         """
         _request = self.camera.capture_request()
         # raw is actually 16 bit
@@ -220,14 +226,18 @@ class CameraPI(CameraInterface):
 
         _request.release()
 
-        # Apply camera-specific crop and rotation (preserves Bayer pattern alignment)
-        raw_capture = self.profile.crop_and_rotate(raw_capture)
-
-        # Expose this frame's driver metadata and cropped raw pixels so the
+        # Expose this frame's driver metadata and its CROPPED pixels so the
         # sweep capture can record per-image radiometry (exposure sweeps are
         # the only caller; both are overwritten on every raw capture).
-        self.last_raw_frame_metadata = metadata
-        self.last_raw_frame = raw_capture
+        #
+        # Note the asymmetry, and that it is deliberate: the TIFF written below
+        # is full-sensor, while these statistics cover the crop. They are the
+        # black-level-versus-temperature series, and the vignetted margins
+        # would shift every mean and percentile, silently ending comparability
+        # with the archive taken before sweeps went full-sensor. Full-sensor
+        # statistics stay computable from the TIFF.
+        self.last_frame_driver_metadata = metadata
+        self.last_cropped_frame = self.profile.crop_and_rotate(raw_capture)
 
         # Determine if we need to flag for debayering
         needs_debayer = False

--- a/python/PiFinder/sqm/camera_profiles.py
+++ b/python/PiFinder/sqm/camera_profiles.py
@@ -156,6 +156,29 @@ class CameraProfile:
 
         return cropped
 
+    def is_full_sensor(self, raw_array) -> bool:
+        """True when an array covers the whole sensor rather than the crop.
+
+        Sweeps archive the full sensor; photometry works on the crop. Both
+        eras of archive exist on disk, so anything replaying them has to tell
+        them apart. The sizes can never collide: the crop is strictly smaller
+        on at least one axis for every profile.
+        """
+        height, width = raw_array.shape[:2]
+        return (width, height) == self.raw_size
+
+    def ensure_cropped(self, raw_array):
+        """Reduce an archived frame to what production photometry would see.
+
+        A full-sensor frame goes through the ordinary :meth:`crop_and_rotate`,
+        so the result matches the live pipeline by construction rather than by
+        a parallel reimplementation. An already-cropped frame is returned
+        untouched.
+        """
+        if self.is_full_sensor(raw_array):
+            return self.crop_and_rotate(raw_array)
+        return raw_array
+
     def __repr__(self) -> str:
         return (
             f"CameraProfile("

--- a/python/PiFinder/sqm/save_sweep_metadata.py
+++ b/python/PiFinder/sqm/save_sweep_metadata.py
@@ -103,6 +103,12 @@ def save_sweep_metadata(
                 "bias_offset": profile.bias_offset,
                 "sqm_band_offset": profile.sqm_band_offset,
                 "color_coefficient": profile.color_coefficient,
+                # Extent of the archived raw frames. Sweeps from the
+                # cropped era carry no such field; these hold the whole
+                # sensor, which a reader reduces to the crop with
+                # CameraProfile.ensure_cropped() before photometry.
+                "raw_frame_extent": "full_sensor",
+                "raw_frame_size": list(profile.raw_size),
             }
         except Exception as e:
             logger.warning(f"Could not record camera constants: {e}")

--- a/python/tests/test_sqm.py
+++ b/python/tests/test_sqm.py
@@ -1214,6 +1214,66 @@ class TestCropAndRotate:
 
 
 @pytest.mark.unit
+class TestArchivedFrameExtent:
+    """Sweeps archive the full sensor; photometry works on the crop.
+
+    Both eras of sweep exist on disk, so a reader has to tell them apart and
+    reduce the full-sensor era to the crop before measuring. These tests pin
+    that reduction to be exactly what the live pipeline produces -- the
+    guarantee that lets full-sensor sweeps reproduce every cropped-era number.
+    """
+
+    SENSORS = ["imx296", "imx462", "imx290", "hq"]
+
+    @pytest.mark.parametrize("name", SENSORS)
+    def test_full_sensor_frame_is_recognised(self, name):
+        profile = get_camera_profile(name)
+        full = np.zeros(profile.raw_size[::-1], dtype=np.uint16)
+
+        assert profile.is_full_sensor(full) is True
+
+    @pytest.mark.parametrize("name", SENSORS)
+    def test_cropped_frame_is_not_mistaken_for_full(self, name):
+        profile = get_camera_profile(name)
+        full = np.zeros(profile.raw_size[::-1], dtype=np.uint16)
+
+        assert profile.is_full_sensor(profile.crop_and_rotate(full)) is False
+
+    @pytest.mark.parametrize("name", SENSORS)
+    def test_cropping_a_full_sweep_frame_reproduces_the_live_crop(self, name):
+        """The reproducibility guarantee, asserted element for element."""
+        profile = get_camera_profile(name)
+        rng = np.random.default_rng(seed=1)
+        full = rng.integers(
+            0, 2**profile.bit_depth, size=profile.raw_size[::-1], dtype=np.uint16
+        )
+
+        np.testing.assert_array_equal(
+            profile.ensure_cropped(full), profile.crop_and_rotate(full)
+        )
+
+    @pytest.mark.parametrize("name", SENSORS)
+    def test_already_cropped_frames_pass_through_untouched(self, name):
+        """Cropped-era archives must not be cropped a second time."""
+        profile = get_camera_profile(name)
+        rng = np.random.default_rng(seed=2)
+        full = rng.integers(
+            0, 2**profile.bit_depth, size=profile.raw_size[::-1], dtype=np.uint16
+        )
+        cropped = profile.crop_and_rotate(full)
+
+        np.testing.assert_array_equal(profile.ensure_cropped(cropped), cropped)
+
+    @pytest.mark.parametrize("name", SENSORS)
+    def test_full_frame_holds_strictly_more_pixels(self, name):
+        """Nothing is lost by archiving the full sensor -- that is the point."""
+        profile = get_camera_profile(name)
+        full = np.zeros(profile.raw_size[::-1], dtype=np.uint16)
+
+        assert profile.crop_and_rotate(full).size < full.size
+
+
+@pytest.mark.unit
 class TestSaveSweepMetadata:
     """Unit tests for save_sweep_metadata.save_sweep_metadata()."""
 

--- a/python/tests/test_sweep_frame_record.py
+++ b/python/tests/test_sweep_frame_record.py
@@ -38,6 +38,36 @@ def test_record_with_full_metadata_and_frame():
 
 
 @pytest.mark.unit
+def test_statistics_cover_the_crop_not_the_full_sensor():
+    """Sweeps archive the whole sensor, but raw_stats must stay on the crop.
+
+    The margins are vignetted, so measuring them would shift every mean and
+    percentile and end comparability with the pre-full-sensor archive -- the
+    black-level-versus-temperature series these records exist for.
+    """
+    from PiFinder.sqm import get_camera_profile
+
+    profile = get_camera_profile("imx462")
+    full = np.full(profile.raw_size[::-1], 1000, dtype=np.uint16)
+    # Darken only what the crop discards, so a statistic computed over the
+    # full sensor cannot possibly match one computed over the crop.
+    kept = np.zeros_like(full, dtype=bool)
+    top, bottom = profile.crop_y
+    left, right = profile.crop_x
+    kept[top : full.shape[0] - bottom, left : full.shape[1] - right] = True
+    full[~kept] = 200
+
+    record = sweep_frame_record(
+        1, 100000, None, profile.crop_and_rotate(full), bit_depth=12
+    )
+
+    assert record["raw_stats"]["mean_adu"] == pytest.approx(1000.0)
+    assert record["raw_stats"]["min_adu"] == 1000.0
+    # The sibling TIFF is full-sensor, so the record must say what it covers.
+    assert record["raw_stats"]["extent"] == "crop"
+
+
+@pytest.mark.unit
 def test_record_without_metadata_or_frame():
     record = sweep_frame_record(1, 25000, None, None, bit_depth=None)
 


### PR DESCRIPTION
Sweeps saved the same square crop that photometry measures, so the sensor margins were discarded at capture. Every archived sweep is cropped, which makes questions about the margins — how far illumination falls off out there, whether any usable optical black exists — unanswerable from the frames we already have.

The crop is a plain slice, so the full frame is a **superset**: cropping later is exact and free, while margins not captured now are gone for good.

## What changes

| | Before | After |
|---|---|---|
| Sweep TIFF on disk | square crop | **full sensor**, named `*_rawfull_*.tiff` |
| Live SQM photometry (`cam_raw()`) | crop | **crop — unchanged** |
| Per-frame `raw_stats` | crop | **crop — unchanged** |
| Existing calibration constants | | **unchanged** |

`capture_raw_file()` always writes the whole sensor, with no option to write the crop instead. Readers reduce it with `CameraProfile.ensure_cropped()`, which routes through the ordinary `crop_and_rotate()`, so a replayed full-sensor sweep reproduces the cropped era's numbers *by construction* rather than by a parallel reimplementation. Tests pin that equivalence element for element.

## Two things deliberately stay on the crop

- **Live photometry** reads `cam_raw()`, untouched, so existing calibration stays valid.
- **`raw_stats`** stay crop-only. They are the black-level-versus-temperature series, and the vignetted margins would shift every mean and percentile, silently ending comparability with the existing archive. The TIFF holds everything, so full-sensor statistics remain computable later.

That asymmetry — full-sensor TIFF, crop-only statistics beside it — is easy to forget and expensive to get wrong, so it is named rather than implied:

- `CameraPI.last_cropped_frame`, `sweep_frame_record(cropped_frame=...)`
- `raw_stats.extent: "crop"` in each frame record
- `camera.raw_frame_extent: "full_sensor"` in `sweep_metadata.json`
- a **Frame extents** section in `docs/ax/camera/CONTEXT.md` defining *full-sensor frame* vs *crop*, cross-referenced from SQM's *raw photometry image*

`raw_stats` keeps its key name: existing archives use it, and forking the schema is the thing this change exists to avoid. Records from before this change simply lack `extent` — correctly, since back then the TIFF was the crop too.

## Compatibility

Full-sensor frames are named `rawfull` so they fall **outside** the glob readers use for the cropped era's `*_raw_RGGB.tiff`. An un-updated reader finds nothing rather than silently scaling centroids against the wrong frame size — a loud failure instead of a quiet wrong answer.

## Testing

`ruff` clean, 1002 unit+smoke tests pass. New coverage: full-sensor/crop era detection, exact reduction to the live crop across all four sensor profiles, cropped-era passthrough, and that `raw_stats` cover the crop when the sibling TIFF is full-sensor.