### PR TITLE
Bring-up: end the run and shut the card down on a power hold

### DIFF
--- a/docs/ax/bringup/CONTEXT.md
+++ b/docs/ax/bringup/CONTEXT.md
@@ -11,8 +11,12 @@ The first power-on validation of a newly assembled board, done at the bench befo
 _Avoid_: "smoke test" (that names a pytest marker in this repo), "QA", "burn-in" (that's a soak, which this is not).
 
 **Bring-up run**:
-One execution of `python -m PiFinder.bringup` against one board. A run is interactive and open-ended: it keeps reporting until the builder ends it.
+One execution of `python -m PiFinder.bringup` against one board. A run is interactive and open-ended: it keeps reporting until the builder ends it — with Ctrl-C, with `--timeout`, or with the **power hold**.
 _Avoid_: "test run", "session".
+
+**Power hold**:
+The power switch held closed for one second, which ends the run and asks the OS for a clean shutdown. It exists because bring-up happens at a bench with no keyboard and often no terminal in sight, and pulling power on a mounted filesystem is how a builder corrupts an image between the first board and the tenth. The threshold matches the one `keyboard_pi` uses for the same switch in the running application, so the gesture is learned once. Distinct from a **tap**, which is all the `SWITCHES` check needs: bring-up is the one place where how *long* the power switch is closed changes what happens. Removed by `--no-power-shutdown`; a tap still counts either way.
+_Avoid_: "power off" / "kill" (the run asks the OS to shut down and never drives the **power-off latch** itself — that stays the kernel's, see [Battery](../battery/CONTEXT.md)), "long press" (that names the UI context's `LNG_*` keys, which the power switch does not produce).
 
 **Builder**:
 The person assembling and validating the board — the audience for a bring-up run. Distinct from the **observer**, the person using a finished PiFinder at the eyepiece, who is the audience for everything in the [UI](../ui/CONTEXT.md) context.
@@ -51,7 +55,7 @@ One physical pushbutton on the board, identified by where it sits in the wiring 
 _Avoid_: "button" (fine in prose to a builder, too loose in code), "key" (that's the logical event).
 
 **Matrix position**:
-A switch's `(row, column)` coordinate in the scanned keypad matrix — a switch's identity for bring-up purposes. The **power switch** is the exception: it is wired to its own line rather than into the matrix, and so has no matrix position.
+A switch's `(row, column)` coordinate in the scanned keypad matrix — a switch's identity for bring-up purposes. The **power switch** is the exception: it is wired to its own line rather than into the matrix, and so has no matrix position. It is also the only switch whose *duration* means anything (see **power hold**); every matrix position is judged purely on whether it was observed closing.
 _Avoid_: "keycode" (that's the logical key), "index".
 
 **Population map**:
@@ -84,3 +88,11 @@ _Avoid_: "keymap" (that maps positions to logical **keys**, a different table), 
 > **Dev:** The charger didn't answer on this board. Should the run bail out?
 >
 > **Domain:** No. It reports `CHARGER` as failed and carries on with everything else — you still want to know whether the switches and the IMU are good before you desolder anything. And it must never let that probe decide which panel to open, or a dead charger would look like a dead screen.
+>
+> **Dev:** I pressed power to tick off the last switch and the thing shut down on me.
+>
+> **Domain:** You held it. A tap is what the `SWITCHES` check wants — the closure registers on the first scan that sees it — and a second's hold is the **power hold**, which ends the run and shuts the card down cleanly. The power cell fills a bar for that whole second so you can let go; if you'd rather not have the gesture at all, `--no-power-shutdown` takes it away and the tap still counts.
+>
+> **Dev:** Why does bring-up get to shut the machine down when nothing else in it touches power?
+>
+> **Domain:** It asks the OS to shut down — the same `shutdown now` the app's menu ends up running. It still doesn't touch the **power-off latch**; GPIO14 is the kernel's to drive at power-off and no Python here or anywhere else goes near it. What bring-up avoids is a builder at a bench with no terminal open reaching for the barrel jack on a mounted filesystem.

--- a/python/PiFinder/bringup.py
+++ b/python/PiFinder/bringup.py
@@ -29,6 +29,27 @@ Only **probed** and **exercised** checks gate the verdict and the exit status.
 A witnessed check is reported as *emitted*: the program drove the hardware, and
 whether light or sound came out is not something it can know.
 
+Ending a run
+------------
+
+A run is open-ended; it ends on Ctrl-C, on ``--timeout``, or on the **power
+hold** — the power switch held closed for :data:`SHUTDOWN_HOLD_SECONDS`, which
+shuts the card down cleanly. That last one exists because a bring-up run
+happens at a bench with no keyboard and no SSH session in sight: the board is
+on a mat with a bare card in it, and pulling power on a mounted filesystem is
+how a builder corrupts an image between the first board and the tenth.
+
+*Tap* and *hold* therefore mean different things to the power switch, and both
+are wanted: a tap is what the ``SWITCHES`` check needs (it registers the
+closure like any other switch), and a hold ends the run. The power cell shows a
+filling bar for the whole second so the boundary is visible and an accidental
+hold can be released before it arms; ``--no-power-shutdown`` removes the
+gesture for a builder who would rather not risk it at all.
+
+The threshold matches ``keyboard_pi.run_keyboard``'s, which is also one second
+— the same press ends a bring-up run and opens the shutdown menu in the running
+application, so a builder learns the gesture once.
+
 Why the panel is not auto-detected
 ----------------------------------
 
@@ -62,6 +83,7 @@ import argparse
 import logging
 import os
 import signal
+import subprocess
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -131,6 +153,18 @@ CHARGER_POLL_SECONDS = 1.0
 
 PATTERN_SECONDS = 1.5  # per pattern; three of them
 STATUS_ROWS = 3  # IMU / CHARGER / SWITCHES lines under the title bar
+
+# How long the power switch must stay closed to end the run and shut the card
+# down. One second, matching keyboard_pi.run_keyboard's power threshold, so the
+# gesture is the same one the finished unit answers to.
+SHUTDOWN_HOLD_SECONDS = 1.0
+# Segments in the hold bar drawn in the power cell. Four puts the label at six
+# characters ("[####]"), which is 30 px in the 34 px power cell on the
+# narrowest panel bring-up supports -- see test_bringup.
+HOLD_BAR_SEGMENTS = 4
+# The clean-shutdown command, spelled out rather than imported: see
+# request_shutdown.
+SHUTDOWN_COMMAND = ("sudo", "shutdown", "now")
 
 DEFAULT_REVISION = "rev4"
 # Panel per revision. Keyed by keypad.POPULATION_MAPS, which is where the set of
@@ -449,6 +483,55 @@ class GridState:
         return not self.missing and self.power_seen
 
 
+class PowerHold:
+    """How long the power switch has been closed, and whether that has crossed
+    the shutdown threshold. PURE — the clock is injected.
+
+    Kept apart from :class:`GridState`, which records what the *switch check*
+    saw: a closure is a closure there whether it lasted 20 ms or 20 s, and
+    folding the gesture in would let "the builder is shutting down" and "the
+    power switch conducts" turn into one flag. They are separate findings.
+
+    Rearms on release, so a hold that is let go re-arms rather than firing
+    again on the next scan, and a held-down (or shorted) power line fires
+    exactly once instead of every frame for the rest of the run.
+    """
+
+    def __init__(
+        self, threshold: float = SHUTDOWN_HOLD_SECONDS, enabled: bool = True
+    ) -> None:
+        self.threshold = threshold
+        self.enabled = enabled
+        self.progress = 0.0  # 0.0 -> 1.0 across the hold; 0.0 while open
+        self._since: Optional[float] = None
+        self._fired = False
+
+    def update(self, closed: bool, now: float) -> bool:
+        """Feed one scan; True on the single frame the hold arms."""
+        if not closed:
+            self._since = None
+            self._fired = False
+            self.progress = 0.0
+            return False
+
+        if self._since is None:
+            self._since = now
+        if not self.enabled:
+            # No bar either: a run with the gesture off must not draw something
+            # that looks like it is about to arm.
+            self.progress = 0.0
+            return False
+
+        elapsed = now - self._since
+        self.progress = (
+            1.0 if self.threshold <= 0 else min(1.0, elapsed / self.threshold)
+        )
+        if self._fired or elapsed < self.threshold:
+            return False
+        self._fired = True
+        return True
+
+
 # --- Labels -----------------------------------------------------------------
 
 # One character per key, for the grid cells. ASCII on purpose: the UI fonts
@@ -480,6 +563,28 @@ def cell_label(row: int, col: int) -> str:
     if key == K.NA:
         return ""
     return KEY_LABELS.get(key, str(key))
+
+
+def power_cell_label(progress: float) -> str:
+    """The power cell's label: ``PWR`` at rest, a hold bar while held. PURE.
+
+    Feedback has to survive a 10 px cell on the 128 px panel, where the small
+    font is 9 px tall and leaves no room to draw a progress bar *under* the
+    text. So the bar **is** the text, rendered by the same centred-label path
+    every other cell uses — nothing new in the draw path, and it lays out
+    identically on all three panels.
+
+    The hold maps onto *one segment to full*, not zero to full. One segment
+    lights on the first frame the switch closes, because the bar's job is to
+    say "this is going somewhere" while there is still nearly a second left to
+    let go — and the last segment lights only at the threshold itself, so a
+    full bar never sits there for a quarter of the hold implying more time
+    remains than there is.
+    """
+    if progress <= 0.0:
+        return "PWR"
+    filled = min(HOLD_BAR_SEGMENTS, 1 + int(progress * (HOLD_BAR_SEGMENTS - 1)))
+    return "[" + "#" * filled + "-" * (HOLD_BAR_SEGMENTS - filled) + "]"
 
 
 def key_name(row: int, col: int) -> str:
@@ -652,6 +757,9 @@ class Dashboard:
     status_lines: List[str]
     grid: GridState
     passed: bool
+    # How far into the shutdown hold the power switch is, 0.0 when it is open
+    # or when --no-power-shutdown took the gesture away.
+    power_progress: float = 0.0
 
 
 def _text_width(font, text: str) -> int:
@@ -758,7 +866,8 @@ def draw_dashboard(
             )
 
     # The power switch is wired to its own line rather than into the matrix, so
-    # it gets its own wider cell -- but the same four states.
+    # it gets its own wider cell -- but the same four states. Its label doubles
+    # as the shutdown hold's progress bar.
     _draw_cell(
         draw,
         display_class,
@@ -766,12 +875,40 @@ def draw_dashboard(
         layout.power.y,
         layout.power.widths[0],
         layout.cell,
-        "PWR",
+        power_cell_label(dashboard.power_progress),
         populated=True,
         seen=grid.power_seen,
         held=grid.power_held,
     )
 
+    return image
+
+
+def notice_image(
+    display_class: displays.DisplayBase, lines: Sequence[str]
+) -> Image.Image:
+    """A full-panel message, centred. PURE (builds an image; draws nothing).
+
+    Used for the last thing a run puts on the glass when the power hold arms.
+    The builder is looking at the panel, not at a terminal — over SSH the
+    session is about to drop, and at the bench there may be no terminal at all.
+    """
+    image = Image.new("RGB", (display_class.resX, display_class.resY), (0, 0, 0))
+    draw = ImageDraw.Draw(image)
+    font = display_class.fonts.bold
+    ink = display_class.colors.get(255)
+    block = len(lines) * font.height
+    top = max(0, (display_class.resY - block) // 2)
+    for index, line in enumerate(lines):
+        draw.text(
+            (
+                max(0, (display_class.resX - _text_width(font, line)) // 2),
+                top + index * font.height,
+            ),
+            line,
+            font=font.font,
+            fill=ink,
+        )
     return image
 
 
@@ -863,15 +1000,52 @@ class MatrixScanner:
     def power_closed(self) -> bool:
         """The power switch, read directly and active low.
 
-        Never acted on: no shutdown, no jump to a label, and nothing anywhere
-        near GPIO14. Pressing power during a bring-up run only lights a cell —
-        and there is no 1 s hold requirement, so a brief tap is enough, which
-        also keeps the press short in case the LTC2954 kills on a long hold.
+        Read only — this line is an input for the whole run, and nothing here
+        goes anywhere near GPIO14. The power *hold* ends the run by asking the
+        OS to shut down (:func:`request_shutdown`); the kill line is the
+        kernel's to drive at power-off, exactly as in the running application
+        (ADR 0007).
+
+        A **tap** is all the ``SWITCHES`` check needs — the closure registers
+        on the first scan that sees it — which also keeps the press short, in
+        case the LTC2954 kills on a long hold. That is still unconfirmed on
+        hardware, and it is the reason the shutdown hold is one second rather
+        than the several a "hold to power off" gesture would usually take.
         """
         return not self._gpio.input(keypad.POWER_GPIO)
 
     def stop(self) -> None:
         self._gpio.cleanup()
+
+
+def request_shutdown(
+    runner: Optional[Callable[[List[str]], int]] = None,
+) -> int:
+    """Ask the OS to shut down cleanly. The last thing a run does.
+
+    Runs the same command ``sys_utils.shutdown()`` runs, spelled out here
+    rather than imported: ``sys_utils`` pulls in ``pam``, ``requests`` and
+    ``sh``, and resolves ``wpa_cli`` / ``unzip`` / ``passwd`` at import time.
+    None of those are guaranteed on a card that has only just been imaged, and
+    a bring-up tool that fails to import on a bare card is useless — the whole
+    point is to run before the unit is configured. ``test_bringup`` asserts the
+    two spellings stay in step.
+
+    What happens after it returns is the kernel's business: on rev4 its
+    power-off handler drives GPIO14 low, tripping the LTC2954's KILL input and
+    dropping the SYS boost (ADR 0007). No Python touches that line.
+
+    Returns the command's exit status. A non-zero one is worth saying out loud
+    rather than swallowing: a card whose sudoers file does not grant passwordless
+    ``shutdown`` leaves the builder staring at a panel reading SHUTTING DOWN on a
+    board that is still very much up, and the obvious next move — reaching for
+    the power — is the one thing the gesture exists to avoid.
+    """
+    logger.info("bring-up: power hold -- requesting shutdown")
+    status = (runner or subprocess.call)(list(SHUTDOWN_COMMAND))
+    if status:
+        logger.error("bring-up: shutdown returned %s", status)
+    return status
 
 
 class ImuProbe:
@@ -1181,9 +1355,17 @@ def run_loop(
     hardware: Hardware,
     grid: GridState,
     pattern_count: int,
-) -> None:
-    """Scan, drive and redraw until Ctrl-C (or ``--timeout``)."""
+) -> bool:
+    """Scan, drive and redraw until Ctrl-C, ``--timeout`` or the power hold.
+
+    Returns True when the power hold armed, meaning the caller should shut the
+    card down once it has cleaned up and reported. The shutdown itself is not
+    issued here: ``main`` still has a summary to print and a buzzer to silence,
+    and a loop that could pull the floor out from under its own caller would
+    make that ordering impossible to see.
+    """
     layout = grid_layout(display_class)
+    power_hold = PowerHold(enabled=not args.no_power_shutdown)
 
     def draw() -> None:
         dashboard = Dashboard(
@@ -1199,6 +1381,7 @@ def run_loop(
             passed=compute_verdict(
                 build_results(hardware, grid, pattern_count, args.backlight_max)
             ),
+            power_progress=power_hold.progress,
         )
         show(display_class, draw_dashboard(display_class, dashboard, layout))
 
@@ -1216,16 +1399,31 @@ def run_loop(
     while True:
         now = time.monotonic()
         if args.timeout and now - started >= args.timeout:
-            return
+            return False
 
         if hardware.scanner is not None:
-            edges = grid.update(
-                hardware.scanner.scan(), hardware.scanner.power_closed()
-            )
+            power_closed = hardware.scanner.power_closed()
+            edges = grid.update(hardware.scanner.scan(), power_closed)
             if edges.any_pressed and hardware.buzzer is not None:
                 # Re-proves the buzzer once per closure -- ~18 times over a
                 # full keypad sweep.
                 play_earcon(hardware.buzzer, Earcon.KEYPRESS, args.volume)
+
+            # Timed with `now`, taken immediately before the power line was
+            # read -- not with a fresh clock here, which would be on the far
+            # side of the matrix scan and of a keypress earcon that blocks for
+            # its own duration. The hold has to measure the switch, not the
+            # cue the switch set off.
+            if power_hold.update(power_closed, now):
+                # Say so on the panel first: the builder is watching the glass,
+                # and the earcon holds the frame up for its own duration.
+                show(
+                    display_class,
+                    notice_image(display_class, ["SHUTTING", "DOWN"]),
+                )
+                if hardware.buzzer is not None:
+                    play_earcon(hardware.buzzer, Earcon.SHUTDOWN, args.volume)
+                return True
 
         # Each step is an open/write/close on a sysfs file, so step the ramp
         # well below the scan rate; the eye cannot tell the difference.
@@ -1329,6 +1527,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Buzzer master volume for the earcons (default 5)",
     )
     parser.add_argument(
+        "--no-power-shutdown",
+        action="store_true",
+        help=(
+            "Do not end the run and shut the card down when the power switch "
+            "is held. Tapping it still counts toward the SWITCHES check"
+        ),
+    )
+    parser.add_argument(
         "--timeout",
         type=float,
         default=None,
@@ -1371,28 +1577,44 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     frames = [] if args.no_patterns else pattern_images(display_class)
     pattern_count = len(frames)
+    shutting_down = False
     try:
         if frames:
             run_patterns(display_class, frames, args)
         # The frames are only needed while they are being shown; a full-panel
         # RGB image each is ~90 KB, and the dashboard run is open-ended.
         frames = []
-        run_loop(display_class, args, hardware, grid, pattern_count)
+        shutting_down = run_loop(display_class, args, hardware, grid, pattern_count)
     except (KeyboardInterrupt, SystemExit):
         pass
     finally:
         hardware.close()
-        try:
-            blank = Image.new("RGB", (display_class.resX, display_class.resY))
-            show(display_class, blank)
-        except Exception:  # noqa: BLE001 - blanking is best-effort
-            logger.debug("bring-up: could not blank the panel", exc_info=True)
+        # A run that is shutting down leaves its notice up instead: the card
+        # has seconds of unmounting left and a blank panel during them looks
+        # exactly like a board that just died.
+        if not shutting_down:
+            try:
+                blank = Image.new("RGB", (display_class.resX, display_class.resY))
+                show(display_class, blank)
+            except Exception:  # noqa: BLE001 - blanking is best-effort
+                logger.debug("bring-up: could not blank the panel", exc_info=True)
 
     results = build_results(hardware, grid, pattern_count, args.backlight_max)
     verdict = compute_verdict(results)
     print()
     print(format_preflight(preflight))
     print(format_summary(results, verdict))
+
+    # Last, so the summary is on the terminal before the session drops -- and
+    # after hardware.close(), so nothing is left driving the buzzer if the
+    # shutdown stalls.
+    if shutting_down:
+        print("\nPower switch held -- shutting down.")
+        if request_shutdown():
+            print(
+                f"{' '.join(SHUTDOWN_COMMAND)} failed -- the board is still up. "
+                "Shut it down before pulling power."
+            )
     return 0 if verdict else 1
 
 

--- a/python/tests/test_bringup.py
+++ b/python/tests/test_bringup.py
@@ -28,6 +28,7 @@ from PiFinder.bringup import (
     CheckResult,
     GridState,
     Kind,
+    PowerHold,
     Status,
     backlight_duty,
     compute_verdict,
@@ -35,6 +36,8 @@ from PiFinder.bringup import (
     format_summary,
     grid_layout,
     parse_pwm_overlay,
+    power_cell_label,
+    request_shutdown,
 )
 
 PYTHON_DIR = Path(__file__).resolve().parents[1]
@@ -290,6 +293,163 @@ def test_describe_positions_names_the_key_each_switch_sends():
     assert describe_positions(many).endswith("+1 more")
 
 
+# --- The power hold --------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_power_hold_arms_only_after_the_threshold():
+    hold = PowerHold(threshold=1.0)
+
+    assert not hold.update(True, 100.0)  # closes
+    assert not hold.update(True, 100.5)  # halfway
+    assert not hold.update(True, 100.99)
+    assert hold.update(True, 101.0)  # threshold reached
+
+
+@pytest.mark.unit
+def test_power_hold_arms_exactly_once_while_held():
+    """A power line that reads closed forever -- a stuck switch or a short --
+    must not re-request a shutdown on every frame of the loop."""
+    hold = PowerHold(threshold=1.0)
+    hold.update(True, 0.0)
+    assert hold.update(True, 1.0)
+    for step in range(2, 20):
+        assert not hold.update(True, float(step))
+
+
+@pytest.mark.unit
+def test_a_released_hold_rearms_and_does_not_fire():
+    """Releasing before the threshold is how an accidental hold is aborted;
+    the next press then starts a fresh second rather than resuming."""
+    hold = PowerHold(threshold=1.0)
+    hold.update(True, 0.0)
+    hold.update(True, 0.9)
+    assert not hold.update(False, 0.95)
+    assert hold.progress == 0.0
+
+    # A new press does not inherit the 0.9 s already served.
+    assert not hold.update(True, 1.0)
+    assert not hold.update(True, 1.5)
+    assert hold.update(True, 2.0)
+
+
+@pytest.mark.unit
+def test_a_tap_never_arms_the_hold():
+    """The SWITCHES check needs the power switch closed; a tap has to satisfy
+    it without shutting the card down mid-run."""
+    hold = PowerHold(threshold=1.0)
+    for press in range(10):
+        now = press * 0.5
+        assert not hold.update(True, now)
+        assert not hold.update(False, now + 0.05)
+
+
+@pytest.mark.unit
+def test_power_hold_progress_tracks_the_hold():
+    hold = PowerHold(threshold=1.0)
+    assert hold.progress == 0.0
+    hold.update(True, 10.0)
+    assert hold.progress == pytest.approx(0.0)
+    hold.update(True, 10.25)
+    assert hold.progress == pytest.approx(0.25)
+    hold.update(True, 10.75)
+    assert hold.progress == pytest.approx(0.75)
+    # Never overshoots, even on a hold that outlives the threshold.
+    hold.update(True, 20.0)
+    assert hold.progress == 1.0
+
+
+@pytest.mark.unit
+def test_disabled_hold_never_arms_and_shows_no_bar():
+    """``--no-power-shutdown``: the switch still reads closed for the SWITCHES
+    check, but nothing arms and the cell must not draw a filling bar that
+    promises a shutdown which will never come."""
+    hold = PowerHold(threshold=1.0, enabled=False)
+    for step in range(20):
+        assert not hold.update(True, float(step))
+        assert hold.progress == 0.0
+
+
+@pytest.mark.unit
+def test_the_hold_threshold_matches_the_running_application():
+    """Bring-up and ``keyboard_pi`` answer the same gesture, so a builder
+    learns "hold power" once. ``keyboard_pi`` spells its threshold inline."""
+    source = (PYTHON_DIR / "PiFinder" / "keyboard_pi.py").read_text()
+    assert (
+        "time() - self.power_press_time > 1" in source
+    ), "keyboard_pi's power threshold moved -- retune SHUTDOWN_HOLD_SECONDS"
+    assert bringup.SHUTDOWN_HOLD_SECONDS == 1.0
+
+
+@pytest.mark.unit
+def test_power_cell_label_is_a_bar_only_while_held():
+    assert power_cell_label(0.0) == "PWR"
+    # One segment on the very first frame: the bar has to say "something is
+    # happening" while there is still time to let go.
+    assert power_cell_label(0.01) == "[#---]"
+    assert power_cell_label(0.5) == "[##--]"
+    assert power_cell_label(0.9) == "[###-]"
+    # ...and full only at the threshold, never a moment before it.
+    assert power_cell_label(0.99) != "[####]"
+    assert power_cell_label(1.0) == "[####]"
+
+
+@pytest.mark.unit
+def test_power_cell_label_fits_the_cell_on_every_panel():
+    """The label is drawn by the ordinary centred-cell path, so it has to fit
+    the power cell at its narrowest -- the 128 px panel's 34 px cell."""
+    labels = [power_cell_label(step / 20.0) for step in range(21)]
+    # Every bar state is the same width, so the label never reflows mid-hold.
+    assert {len(label) for label in labels if label != "PWR"} == {
+        bringup.HOLD_BAR_SEGMENTS + 2
+    }
+
+    for display_cls in HEADLESS_DISPLAYS:
+        display = display_cls()
+        layout = grid_layout(display)
+        for label in labels:
+            assert label.isascii()  # the UI fonts carry no box-drawing glyphs
+            width = display.fonts.small.width * len(label)
+            assert width <= layout.power.widths[0], (
+                f"{label!r} is {width}px in a {layout.power.widths[0]}px cell "
+                f"on {display_cls.__name__}"
+            )
+
+
+@pytest.mark.unit
+def test_shutdown_command_matches_sys_utils():
+    """``bringup`` spells the shutdown command out instead of importing
+    ``sys_utils`` (which needs ``pam`` / ``requests`` / ``sh`` and resolves
+    ``wpa_cli`` at import time -- none guaranteed on a freshly imaged card).
+    This is what keeps the two spellings in step.
+    """
+    source = (PYTHON_DIR / "PiFinder" / "sys_utils.py").read_text()
+    assert (
+        'sh.sudo("shutdown", "now")' in source
+    ), "sys_utils.shutdown changed -- update SHUTDOWN_COMMAND"
+    assert bringup.SHUTDOWN_COMMAND == ("sudo", "shutdown", "now")
+
+
+@pytest.mark.unit
+def test_request_shutdown_runs_the_command():
+    calls = []
+
+    def runner(command):
+        calls.append(command)
+        return 0
+
+    assert request_shutdown(runner=runner) == 0
+    assert calls == [["sudo", "shutdown", "now"]]
+
+
+@pytest.mark.unit
+def test_request_shutdown_reports_a_refusal():
+    """A card without passwordless ``shutdown`` in sudoers leaves the builder
+    reading SHUTTING DOWN on a board that is still up -- and reaching for the
+    power, which is the one thing the gesture exists to prevent."""
+    assert request_shutdown(runner=lambda command: 1) == 1
+
+
 # --- The report ------------------------------------------------------------
 
 
@@ -399,6 +559,51 @@ def test_dashboard_renders_on_every_panel(display_cls):
         )
         image = bringup.draw_dashboard(display, dashboard, layout)
         assert image.size == (display.resX, display.resY)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("display_cls", HEADLESS_DISPLAYS, ids=lambda cls: cls.__name__)
+def test_the_hold_bar_lights_the_power_cell_progressively(display_cls):
+    """The bar has to be visibly different frame to frame -- it is the only
+    warning a builder gets before the card shuts down."""
+    display = display_cls()
+    layout = grid_layout(display)
+    grid = GridState(keypad.REV4_POPULATED)
+    grid.update(set(), power_closed=True)
+
+    def power_cell(progress):
+        dashboard = bringup.Dashboard(
+            revision="rev4",
+            status_lines=["IMU  --", "CHG  --", "SW 0/18"],
+            grid=grid,
+            passed=False,
+            power_progress=progress,
+        )
+        image = bringup.draw_dashboard(display, dashboard, layout)
+        assert image.size == (display.resX, display.resY)
+        return image.crop(
+            (
+                layout.power.xs[0],
+                layout.power.y,
+                layout.power.xs[0] + layout.power.widths[0],
+                layout.power.y + layout.cell,
+            )
+        ).tobytes()
+
+    # Resting, then each of the four bar states in turn.
+    frames = [power_cell(progress) for progress in (0.0, 0.01, 0.4, 0.7, 1.0)]
+    assert len(set(frames)) == len(frames), "the bar does not change as it fills"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("display_cls", HEADLESS_DISPLAYS, ids=lambda cls: cls.__name__)
+def test_shutdown_notice_fills_the_panel(display_cls):
+    """What the glass says while the card unmounts -- over SSH the session is
+    about to drop, and at the bench there may be no terminal at all."""
+    display = display_cls()
+    image = bringup.notice_image(display, ["SHUTTING", "DOWN"])
+    assert image.size == (display.resX, display.resY)
+    assert image.getextrema()[0][1] > 0, "the notice rendered nothing"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Stacked on #552 (`bringup-tool`) — targets that branch, not `main`, so the diff stays to the power-hold change.

## What

Holding the power switch closed for **one second** ends a bring-up run and asks the OS for a clean shutdown. Until now the only ways out were Ctrl-C and `--timeout`, which on a bare card with no SSH session in sight means reaching for the power on a mounted filesystem.

## Why a hold, and why one second

`keyboard_pi.run_keyboard` already uses a 1 s power hold on the finished unit (to open the shutdown menu), so the same gesture ends a bring-up run and a builder learns it once. It also keeps the press short — whether the LTC2954 kills on a long hold is still unconfirmed on hardware (item 3 of the plan's "to confirm on the first board").

A quick double-press was the alternative; the long press won because it already exists in the shipping app.

## Tap vs hold

The `SWITCHES` check *requires* the builder to close the power switch, so the two gestures share the one switch a builder is obliged to press:

- **tap** → registers the closure for `SWITCHES`, nothing else
- **hold ≥ 1 s** → SHUTDOWN earcon, `SHUTTING DOWN` on the panel, clean shutdown

The `PWR` cell's label becomes a filling bar for the whole second so the boundary is visible and an accidental hold can be released:

```
PWR  →  [#---]  →  [##--]  →  [###-]  →  [####]
```

It's the *label*, not a drawn rectangle: the power cell is 10 px tall on the 128 px panel under a 9 px font, with no room to draw beneath the text. As a label it goes through the same centred-cell path every other cell uses and fits all three panels (verified by test against the actual layout geometry). One segment lights on the first frame; full lands only at the threshold, so it never sits full implying more time remains than there is.

`--no-power-shutdown` removes the gesture entirely; a tap still counts either way.

## GPIO14 is still untouched

The run asks the OS to shut down; the kernel's power-off handler drives the latch, exactly as on a finished unit (ADR 0007). No Python goes near the kill line.

`request_shutdown` spells `sudo shutdown now` out rather than importing `sys_utils` — that module pulls in `pam`, `requests` and `sh` and resolves `wpa_cli`/`passwd` at import time, none of which are guaranteed on a card that has only just been imaged, and a bring-up tool that can't import on a bare card is useless. A test pins the two spellings together. A non-zero exit is reported rather than swallowed: a card without passwordless `shutdown` would otherwise leave the builder reading SHUTTING DOWN on a board that is still up, and reaching for the power.

## Testing

- 60 unit tests pass (`tests/test_bringup.py`), 15 of them new — hold arming/rearming, tap-never-arms, the disabled path, bar geometry on every panel, the `sys_utils` command pin, and a render test asserting the bar actually changes as it fills.
- The import-safety guard still passes: no new hardware import at module scope.
- `ruff format`, `ruff check`, `mypy PiFinder/bringup.py` all clean.
- Full `-m "unit or smoke"` suite: 1096 passed. One pre-existing unrelated failure in `test_sqm.py::TestPedestalOverride::test_factory_pedestal_does_not_apply_unmeasured_dark_estimate`, which fails identically on an untouched checkout.

Not exercised on a board — the gesture shuts the machine down, so bench verification is yours.

## Docs

`docs/ax/bringup/CONTEXT.md` gains **power hold** as a term (with the tap distinction and the "avoid *long press*" note, since that names the UI context's `LNG_*` keys, which the power switch doesn't produce) and two dialogue entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)