### PR TITLE
ci(nixos): write the manifest from the PR's base, not the default branch

### DIFF
--- a/.github/workflows/nixos-pr-build.yml
+++ b/.github/workflows/nixos-pr-build.yml
@@ -169,7 +169,18 @@ jobs:
       group: manifest-write
       cancel-in-progress: false
     steps:
+      # Check out the PR's BASE branch explicitly. A bare checkout under
+      # pull_request_target lands on the repository's default branch, which
+      # may carry this workflow (so the event fires) without carrying the
+      # scripts below -- the job then dies after a successful build, leaving
+      # an image in Attic that no device can reach because the manifest was
+      # never written. The base branch is the branch this workflow file itself
+      # came from, so the scripts are always beside it, and it stays
+      # maintainer-controlled: never check out the PR head here, which would
+      # run contributor code with contents:write and the Attic token.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Update generated manifest branch
         env:


### PR DESCRIPTION
One line: give `update-manifest`'s checkout an explicit `ref`.

```yaml
- uses: actions/checkout@v4
  with:
    ref: ${{ github.event.pull_request.base.ref }}
```

## Why

A bare `actions/checkout` under `pull_request_target` lands on the repository's **default branch** — not the PR's base. So the job runs whatever `.github/scripts/` the default branch happens to carry.

Today that works here by coincidence: `release` and `main` both carry the scripts. It bites in two ways anyway.

**It is silently the wrong tooling.** A PR based on `main` gets its manifest entry written by `release`'s copy of `update_manifest.py`. While the two agree that is invisible — the moment the manifest schema moves on one branch it is a mismatch nobody is looking for.

**It is fragile against a branch that carries the workflow but not the scripts.** The workflow file has to exist on a branch for `pull_request_target` to fire there at all, so registering it somewhere new is exactly the thing that triggers this. In my fork I hit precisely that: a successful **19-minute** build, then

```
bash: .github/scripts/publish_manifest.sh: No such file or directory
Process completed with exit code 127
```

The image was built and pushed to Attic. No device could ever see it, because the manifest was never written. A green build plus an unreachable artifact is about the worst shape a failure can take — nothing looks wrong until someone goes looking for the build in the update view.

## Why the base ref specifically

It is the branch this workflow file itself came from, so its scripts are always beside it, and it stays maintainer-controlled.

Deliberately **not** the PR head: this job holds `contents: write` and the Attic token. The build jobs check out the head — that is their purpose, gated behind the `testable` label — but the manifest writer must not.

## Testing

Running on my fork's branches since this morning; the first `testable` build after the change published its manifest entry correctly, where the previous run had failed at exactly this step. `build-native` and `build-emulated` still check out the PR head — verified by parsing the YAML, unchanged by this patch.