### PR TITLE
Serve the raw sensor frame intact, and add /api/camera/rawfull

### DIFF
--- a/python/PiFinder/api_extensions.py
+++ b/python/PiFinder/api_extensions.py
@@ -46,6 +46,28 @@ def _png_response(img: Image.Image) -> Response:
     return Response(_pil_to_png_bytes(img), content_type="image/png")
 
 
+def _raw_to_png(raw):
+    """Render a raw sensor frame as a PNG without destroying its values.
+
+    Sensor frames are 10/12-bit held in uint16. Handing that buffer to
+    Image.fromarray(..., mode="L") reinterprets it as 8-bit and produces
+    interleaved-byte noise rather than an image -- which looked plausible
+    enough to waste a night's captures on. 16-bit frames therefore become
+    mode "I;16" PNGs, preserving every ADU for offline analysis.
+    """
+    if hasattr(raw, "save"):  # already a PIL image
+        return raw
+
+    import numpy as np
+
+    arr = np.asarray(raw)
+    if arr.ndim == 3:
+        return Image.fromarray(arr)
+    if arr.dtype == np.uint16:
+        return Image.fromarray(arr, mode="I;16")
+    return Image.fromarray(arr.astype(np.uint8), mode="L")
+
+
 def _pointing_to_dict(p):
     """Serialize a :class:`Pointing` (or ``None``) to a plain
     ``{RA, Dec, Roll}`` dict of floats."""
@@ -699,25 +721,44 @@ def register_api_routes(app, server_instance, require_auth=False):
 
     @app.route("/api/camera/raw")
     def api_camera_raw():
-        """Return the raw CMOS image, if available"""
+        """The cropped raw sensor frame -- what photometry measures."""
         try:
             raw = server_instance.shared_state.cam_raw()
             if raw is None:
                 return _json_response({"note": "No raw image available"}, 503)
-            # raw may be a PIL Image or a NumPy array
-            if hasattr(raw, "save"):
-                img = raw.convert("RGB") if raw.mode != "RGB" else raw
-            else:
-                import numpy as np
-
-                arr = np.asarray(raw)
-                if arr.ndim == 2:
-                    img = Image.fromarray(arr, mode="L").convert("RGB")
-                else:
-                    img = Image.fromarray(arr)
-            return _png_response(img)
+            return _png_response(_raw_to_png(raw))
         except Exception as e:
             logger.error("api/camera/raw error: %s", e)
+            return _json_response({"error": str(e)}, 500)
+
+    @app.route("/api/camera/rawfull")
+    def api_camera_rawfull():
+        """The whole sensor, uncropped -- margins included.
+
+        Published on demand (the full frame is ~4 MB), so this asks the camera
+        for one and waits for the next capture to deliver it. Naming matches
+        the exposure sweep's "rawfull" TIFFs: raw is the crop, rawfull is
+        everything.
+        """
+        import time as _time
+
+        try:
+            state = server_instance.shared_state
+            state.set_cam_raw_full(None)
+            state.request_cam_raw_full()
+            # Long exposures make a capture cycle seconds long, so wait
+            # generously rather than reporting an absence that is just latency.
+            deadline = _time.time() + 15.0
+            while _time.time() < deadline:
+                raw = state.cam_raw_full()
+                if raw is not None:
+                    return _png_response(_raw_to_png(raw))
+                _time.sleep(0.25)
+            return _json_response(
+                {"note": "Timed out waiting for a full-sensor frame"}, 504
+            )
+        except Exception as e:
+            logger.error("api/camera/rawfull error: %s", e)
             return _json_response({"error": str(e)}, 500)
 
     @app.route("/api/camera/debug")

--- a/python/PiFinder/camera_pi.py
+++ b/python/PiFinder/camera_pi.py
@@ -109,6 +109,16 @@ class CameraPI(CameraInterface):
 
         _request.release()
 
+        # Serve a pending request for the uncropped sensor frame before the
+        # crop discards the margins. On demand only: the full frame is ~4 MB
+        # and would cost that across the state manager on every capture.
+        if hasattr(self, "shared_state"):
+            try:
+                if self.shared_state.cam_raw_full_requested():
+                    self.shared_state.set_cam_raw_full(raw_capture.copy())
+            except (BrokenPipeError, ConnectionResetError, AttributeError):
+                pass
+
         # Apply camera-specific crop and rotation
         raw_capture = self.profile.crop_and_rotate(raw_capture)
 

--- a/python/PiFinder/state.py
+++ b/python/PiFinder/state.py
@@ -309,6 +309,8 @@ class SharedStateObj:
         # to the stored raw frame (PIL CCW). None until the camera reports.
         self.__solve_image_rotation = None
         self.__cam_raw = None
+        self.__cam_raw_full = None
+        self.__cam_raw_full_requested = False
         self.__sqm_radiometer_sample = None
         # Are we prepared to do alt/az math
         # We need gps lock and datetime
@@ -562,6 +564,27 @@ class SharedStateObj:
 
     def set_cam_raw(self, v):
         self.__cam_raw = v
+
+    def cam_raw_full(self):
+        return self.__cam_raw_full
+
+    def set_cam_raw_full(self, v):
+        # Fulfilling the request clears it, so one request yields one frame
+        # rather than leaving the camera publishing 4 MB every capture.
+        self.__cam_raw_full = v
+        self.__cam_raw_full_requested = False
+
+    def cam_raw_full_requested(self) -> bool:
+        return self.__cam_raw_full_requested
+
+    def request_cam_raw_full(self) -> None:
+        """Ask the camera to publish the next frame uncropped.
+
+        The full sensor frame is ~4 MB and would cost that on every capture if
+        published unconditionally, so it is served on demand: a caller sets
+        this flag, the camera fulfils it once and clears it.
+        """
+        self.__cam_raw_full_requested = True
 
     def sqm_radiometer_sample(self):
         return self.__sqm_radiometer_sample

--- a/python/tests/test_api_extensions.py
+++ b/python/tests/test_api_extensions.py
@@ -96,3 +96,44 @@ def test_diagnostics_and_timing_keys_preserved():
     assert d["solve_time"] == 1234.5
     assert d["cam_solve_time"] == 1234.5
     json.dumps(d, default=str)  # full payload is JSON-serializable
+
+
+@pytest.mark.unit
+def test_raw_png_preserves_16bit_values():
+    """A 12-bit sensor frame must survive the PNG round trip intact.
+
+    Rendering uint16 via Image.fromarray(..., mode="L") reinterprets the
+    16-bit buffer as 8-bit and yields interleaved-byte noise that still looks
+    like a plausible image -- convincing enough to waste a night of captures
+    before anyone checks the histogram. Pin the values.
+    """
+    import io
+
+    import numpy as np
+    from PIL import Image
+
+    from PiFinder.api_extensions import _raw_to_png as to_png
+
+    frame = np.array([[0, 1, 255, 256], [4095, 2048, 300, 65535]], dtype=np.uint16)
+
+    buf = io.BytesIO()
+    to_png(frame).save(buf, format="PNG")
+    buf.seek(0)
+    restored = np.asarray(Image.open(buf))
+
+    np.testing.assert_array_equal(restored, frame)
+
+
+@pytest.mark.unit
+def test_full_raw_request_is_one_shot():
+    """One request yields one frame; the camera must not keep publishing 4 MB."""
+    from PiFinder.state import SharedStateObj
+
+    state = SharedStateObj()
+    assert state.cam_raw_full_requested() is False
+
+    state.request_cam_raw_full()
+    assert state.cam_raw_full_requested() is True
+
+    state.set_cam_raw_full(object())
+    assert state.cam_raw_full_requested() is False


### PR DESCRIPTION
Two changes so the frames the pipeline actually works on can be retrieved from a running device.

## `/api/camera/raw` was returning noise

It rendered the uint16 sensor frame with:

```python
img = Image.fromarray(arr, mode="L").convert("RGB")
```

`mode="L"` reinterprets the 16-bit buffer as 8-bit, so you get interleaved high/low bytes rather than an image. The failure is nasty because the output still *looks* like a plausible frame — I pulled 40-odd captures off a device with it while debugging a solve failure and only noticed when the histogram made no sense: median 1.0, p90 80, over 1% of pixels at 255. Bimodal byte noise, not sky.

16-bit frames now render as `I;16` PNGs, preserving every ADU for offline analysis. A test pins the round trip on real 12-bit values.

## `/api/camera/rawfull` (new)

The whole sensor, including the margins the square crop discards. Naming follows the exposure sweep's TIFFs — `raw` is the crop, `rawfull` is everything.

The full frame is ~4 MB, so publishing it on every capture would put that across the state manager continuously. It's served **on demand** instead: the endpoint sets a request flag, the camera fulfils it on the next capture and clears it, so one request yields exactly one frame. A test pins that one-shot behaviour.

## Why

Debugging a plate-solve failure in the field currently offers no way to see what the sensor actually delivered. The cropped frame was corrupt and the full frame was unreachable, so the only diagnosis available was indirect — inferring from radiometer telemetry that light was being attenuated somewhere ahead of the sensor. Being able to fetch both frames turns that into looking at the picture.

## Testing

ruff and mypy clean, 1077 unit+smoke tests pass, including the two new ones.