### PR TITLE
SQM: sky-colour-dependent radiometric zero point + band-offset refit (follow-up to #544)

### DIFF
--- a/docs/adr/0026-radiometric-zero-point-keyed-to-sky-colour.md
+++ b/docs/adr/0026-radiometric-zero-point-keyed-to-sky-colour.md
@@ -1,0 +1,179 @@
+# SQM: radiometric zero point keyed to measured sky colour
+
+ADR 0022 made the radiometer the published SQM source, calibrated by one
+constant per sensor: `radiometric_zero_point`. Re-deriving that constant over
+23 referenced imx462 sweeps spanning 17.5–20.9 mag skies, every attempt to fit
+a single value disagreed with itself. The shipped `15.25` read about **0.10 mag
+dark** at the light-polluted reference site and about **0.85 mag bright** at a
+dark one. Averaging the two regimes produced a constant that was wrong at both
+ends, and no amount of refitting fixed that, because the thing being fitted was
+not a constant.
+
+The cause is physical rather than statistical. The radiometer measures sky in
+the **sensor's** passband; the reference meter measures **V**. The conversion
+between them depends on the sky's *spectrum*: light pollution is sodium/LED and
+green-weighted, airglow is grey and NIR-rich, and a bare Bayer sensor sees that
+NIR while a V-band meter does not. Sky brightness is only a proxy for spectrum —
+a bright airglow sky and a dim urban sky are not the same colour. **Sky colour
+measures it directly**, and it is already in the frame: measured R/G runs
+0.83–0.89 at the light-polluted site and 1.00–1.04 at the dark one.
+
+| model for the zero point | residual sd |
+|---|---|
+| constant (previously shipped) | 0.337 |
+| linear in sky brightness | 0.185 |
+| **linear in measured sky colour (R/G)** | **0.079** |
+
+## The decision
+
+**The radiometric zero point is a function of measured sky colour, not a
+constant.**
+
+```text
+effective_zero_point = radiometric_zero_point
+                       + radiometric_colour_slope × (clamp(R/G) − radiometric_colour_pivot)
+```
+
+1. **`radiometric_colour_slope = 0` is a plain constant**, and is the default.
+   Mono sensors have no colour to measure; a factory IR-cut sensor has
+   essentially no NIR leak to correct. Both keep the previous behaviour exactly,
+   so this change is scoped to the sensors whose physics calls for it — imx462
+   and imx290 (`5.544` mag per unit R/G, pivot `0.85`).
+
+2. **R/G is clamped to the calibrated range, never extrapolated.** The fit is
+   evidence about the colours it saw (`0.83–1.04`) and nothing else. Both the
+   raw and clamped ratios are recorded so an out-of-range site is visible in the
+   archive rather than silently absorbed.
+
+3. **The pivot is where the correction is zero**, chosen so a frame carrying no
+   colour falls back to a sensible light-pollution-regime constant rather than
+   to the fit's intercept. Mono sensors, and any frame whose mosaic phase cannot
+   be trusted, take that path.
+
+4. **`radiometric_zero_point` keeps meaning the profile constant.** The value
+   actually applied is reported separately as
+   `radiometric_zero_point_effective`, always present whether or not a
+   correction was made, so archives stay comparable across this change.
+
+5. **Mosaic phase is checked, not assumed.** Reading the red plane is more
+   fragile than reading green, and the difference is not obvious: a 180°
+   rotation maps the block `R G / G B` to `B G / G R`, so the two green sites
+   are invariant while red and blue swap. An odd crop origin does the same.
+   `crop_and_rotate` runs before the radiometer, so both are reachable from
+   profile configuration alone. `_mosaic_phase_is_rggb` requires RGGB order (not
+   merely "some Bayer format"), zero rotation, and even crop origins, and
+   reports *no colour* rather than a wrong colour. A wrong R/G does not fail
+   loudly — it returns a plausible number that is up to the clamp width wrong.
+
+## Why this is not just a spare parameter
+
+A free parameter always reduces in-sample scatter, so in-sample residuals cannot
+justify one. Two things do.
+
+**Leave-one-night-out cross-validation: MAE 0.247 → 0.108.** The load-bearing
+row is holding out `20260720`, the only dark night. Trained on light-polluted
+data alone, the colour model predicts an unseen regime at **0.312** against the
+constant's **0.944**. It extrapolates rather than interpolating between fitted
+points.
+
+**The same fit on the HQ is rejected by cross-validation** (0.234 with colour vs
+0.182 constant), and its colour slope measures **20× smaller** (+0.272 vs
++5.544). That is precisely what a NIR-leak term must do on a sensor with a
+factory IR-cut filter. A model that won everywhere would be suspicious; one that
+wins only where the physics predicts it should is a negative control, and it is
+the strongest evidence here.
+
+Against the archive, after the change:
+
+| | before | after |
+|---|---|---|
+| imx462 median residual | −0.045 | **+0.005** |
+| imx462 spread | −0.23 … **+1.08** | −0.18 … **+0.16** |
+| the three dark-site sweeps | +0.76, +0.77, +1.08 | +0.16, −0.02, +0.005 |
+| hq median residual | +0.181 | **+0.000** |
+
+The ~1 mag dark-site error is gone and the light-polluted regime got *tighter*,
+not traded away.
+
+`scripts/evaluate_radiometer_archive.py` re-derives both models from the archive
+and cross-validates them, so these claims can be reproduced or refuted rather
+than taken on trust; `PiFinder/sqm/radiometric_fit.py` holds the fit and is unit
+tested on synthetic sweeps with known answers.
+
+### Clamping and the extrapolation claim
+
+These are two different questions and they do not have the same answer. When
+cross-validation holds out the only night of a given regime, clamping to the
+*training* colour range pins the prediction at the edge of the fitted span, so
+the model cannot extrapolate at all. The tool therefore reports both:
+`colour_mae` (clamped — what shipping the model would actually have done) and
+`colour_mae_unclamped` (whether the physical relation itself extrapolates), and
+flags nights that fell outside the training range. The verdict is taken from the
+clamped figure because that is the conservative one and the behaviour that
+ships. The practical consequence: at a site *outside* `0.83–1.04`, the clamp
+deliberately under-corrects rather than trusting the fit off its own end.
+
+## Considered and rejected
+
+- **Refit a single constant** (what this change was originally scoped to be).
+  Tried first; it is what surfaced the problem. A constant cannot represent a
+  quantity that takes two values, and the residual it leaves is not noise —
+  it is structured by site.
+- **Key the zero point to sky brightness** instead of colour. Better than a
+  constant (sd 0.185 vs 0.337) and worse than colour (0.079), because brightness
+  is only a proxy for spectrum. It also cannot extrapolate: a bright airglow sky
+  would be corrected as though it were urban.
+- **A colour term on every sensor.** Rejected by cross-validation on the HQ, and
+  keeping it would have destroyed the negative control that makes the imx462
+  result credible. The mono imx296 cannot use it at all.
+- **Extrapolating the fit past its calibrated colour range.** A two-cluster fit
+  with nothing between them constrains a line, not a physical law valid
+  everywhere. Clamping under-corrects at the edges, which is the failure we
+  prefer.
+- **Measuring spectrum properly** (a filter, or a second sensor). Correct, and
+  not available on hardware already in the field. R/G is what the existing
+  sensor can report for free.
+
+## Consequences
+
+- Published SQM changes on imx462/imx290 and hq. Prior radiometric logs from
+  those sensors are not directly comparable; `radiometric_zero_point_effective`
+  in the archive is what makes future comparisons possible.
+- **The dark-site anchor is one night (3 sweeps).** The cross-validation result
+  is what makes the slope credible, not the sample size. A single systematic
+  peculiar to that night — observer, meter, dew — maps directly onto the slope,
+  because the slope is set by the lever arm between two colour clusters with
+  essentially nothing in between. Treat `5.544` as provisional.
+- **Sky colour is a proxy for spectrum, not a measurement of it.** Two different
+  spectra with the same R/G are conflated. This is the model's known blind spot.
+- **imx296 keeps a constant and is the weakest of the three.** It is mono, so it
+  cannot use the colour model at all, and its calibration rests on 4 sweeps from
+  one night and one observer. Its radiometric zero point is deliberately
+  untouched here. A dark-site sweep from that camera is the single most useful
+  thing anyone could add to the archive.
+- Colour sensors that do not *use* the correction still record `background_red`
+  and `background_green`. The HQ gets real values that its zero point ignores,
+  which costs nothing and accumulates the data a future refit would need.
+- Sweep metadata records the whole model, not just a constant, so a later refit
+  can tell which model produced a given archive.
+
+## Also settled here: the stellar band offsets
+
+`sqm_band_offset` is read only by the stellar path, which is a diagnostic — the
+published SQM comes from the radiometer — so these do not change what users see.
+The values shipped before this change did not reproduce:
+
+| profile | shipped | re-derived | evidence |
+|---|---|---|---|
+| imx296 | −0.22 | **−0.02** | 4 sweeps, residuals +0.13…+0.22 — tight |
+| hq | 0.60 | **0.99** | 9 sweeps, 0.67 mag scatter → 0.99 ± 0.2 |
+| imx462 | 0.53 | 0.514 | **control** — validates the replay method |
+
+The HQ figure argues with the physics and is recorded as fitted, not physical.
+The offset is nominally a passband term and the factory IR-cut implies ≈0, yet 0
+puts the stellar SQM a full magnitude bright. Roughly a magnitude of the HQ
+*stellar* chain is therefore unaccounted for and this constant is absorbing it.
+Whoever finds the real error should refit rather than assume this number
+transfers. Zeroing the median of a chain known to be broken also costs a
+diagnostic signal, which is an accepted trade here only because the value is not
+published.

--- a/docs/ax/sqm.md
+++ b/docs/ax/sqm.md
@@ -228,14 +228,43 @@ After converting solve-independent background ADU per pixel to ADU per square
 arcsecond using the factory field width:
 
 ```text
-sqm = radiometric_zero_point
+sqm = effective_zero_point
       + 2.5 log10(exposure_seconds)
       − 2.5 log10((sky − pedestal) / arcsec²_per_pixel)
+
+effective_zero_point = radiometric_zero_point
+                       + radiometric_colour_slope
+                         × (clamp(R/G) − radiometric_colour_pivot)
 ```
 
-The fixed zero point includes the passband mapping to the SQM-L scale. Current
-defaults are imx462/imx290 `15.25`, HQ `14.79`, and imx296 `14.07`. Factory field
-widths are 10.38°, 10.34°, and 13.71° respectively.
+The zero point includes the passband mapping to the SQM-L scale. On bare
+sensors that mapping is not a constant: the radiometer measures sky in the
+sensor's passband while the reference meter measures V, and converting between
+them depends on the sky's spectrum. Sky colour measures that directly and is
+already in the frame, so the zero point is keyed to the measured red/green
+ratio of the sky background. See ADR 0026 for the derivation and the evidence.
+
+`radiometric_colour_slope = 0` makes this a plain constant, which is the case
+for mono sensors (no colour to measure) and for the IR-cut HQ (no NIR leak to
+correct). Current defaults:
+
+| profile | `radiometric_zero_point` | colour slope | pivot / range | field width |
+|---|---|---|---|---|
+| imx462, imx290 | `15.159` | `5.544` | `0.85`, clamped to `0.83–1.04` | 10.38° |
+| hq | `14.971` | `0.0` (constant) | — | 10.34° |
+| imx296 (mono) | `14.07` | `0.0` (constant) | — | 13.71° |
+
+`radiometric_zero_point` in the sample details keeps meaning the profile
+constant across this change so archives stay comparable; the value actually
+applied is reported alongside it as `radiometric_zero_point_effective`, and is
+always present whether or not a colour correction was made.
+
+Sampling the red plane assumes the frame reaching the radiometer is still in
+RGGB phase. Red is more fragile here than green: a 180° rotation maps `R G /
+G B` to `B G / G R`, leaving the green sites alone but swapping red and blue,
+and an odd crop origin does the same. `_mosaic_phase_is_rggb` checks CFA order,
+rotation and crop parity, and reports no colour rather than a wrong colour —
+a wrong R/G would not fail loudly, it would just move the published value.
 
 The radiometric value is the published reading and intentionally has no
 atmospheric altitude correction. It measures the sky actually in the camera's

--- a/docs/ax/sqm/CONTEXT.md
+++ b/docs/ax/sqm/CONTEXT.md
@@ -21,8 +21,12 @@ Latest published `value`, `source`, and `last_update` in shared state. The UI
 reads this state and does not calculate photometry.
 
 **Radiometric SQM**:
-The published fixed-calibration measurement from diffuse raw background,
-exposure, pedestal, factory field width, and `radiometric_zero_point`.
+The published factory-calibration measurement from diffuse raw background,
+exposure, pedestal, factory field width, and the effective radiometric zero
+point. On bare sensors that zero point is not a constant — it moves with
+measured **sky colour** (see *Radiometric colour term*). Avoid calling it the
+"fixed-calibration" value; the calibration is fixed per sensor, the zero point
+applied to a given frame is not.
 
 **Stellar SQM (`sqm_star_calibrated`)**:
 The former per-frame stellar-zero-point result. Retained as a transmission and
@@ -165,8 +169,32 @@ Per-sensor trim mapping catalog colour into the camera's stellar passband.
 
 **SQM band offset (`sqm_band_offset`)**:
 Additive mapping from sensor-band sky brightness to the reference SQM-L scale
-for the calibrated sky regime. It is coupled to the catalog transform, wing
-model, and local-annulus background estimator.
+for the calibrated sky regime, on the **stellar** path only. It is coupled to
+the catalog transform, wing model, and local-annulus background estimator.
+Diagnostic: the published value comes from the radiometer, not from here.
+
+**Sky colour (`R/G`)**:
+Ratio of median red to median green sky background, measured off the raw
+mosaic. A *measurement of the scene*, not a sensor property — it is the
+project's proxy for sky spectrum, and the thing that distinguishes a
+sodium/LED-dominated light-polluted sky (green-weighted, R/G ≈ 0.83–0.89) from
+a dark airglow sky (grey and NIR-rich, R/G ≈ 1.00–1.04). Say "sky colour" or
+"R/G", not "colour temperature" or "white balance" — neither is what this is.
+
+**Radiometric colour term (`radiometric_colour_slope` / `_pivot` / `_range`)**:
+Sky-colour dependence of the radiometric zero point, in mag per unit R/G. It
+exists because the sensor-band to V-band conversion depends on the sky's
+spectrum, which a single constant cannot represent across regimes. Slope `0`
+means a plain constant, which is correct for mono sensors and for IR-cut
+sensors with no NIR leak. R/G is clamped to `_range` rather than extrapolated.
+Distinct from **colour coefficient**, which trims *catalog star* colour on the
+stellar path; this one trims *sky* colour on the radiometric path. See ADR 0026.
+
+**Mosaic phase**:
+The property that pixel `(0, 0)` of the frame reaching photometry is still a
+red CFA site. Rotation by 180° and odd crop origins both break it while leaving
+the green sites unchanged, so the colour term checks it and reports no colour
+rather than blue-as-red.
 
 **Airmass / altitude correction**:
 Pickering (2002) airmass and `0.28 mag/airmass`. Comparison-only; unknown

--- a/python/PiFinder/sqm/camera_profiles.py
+++ b/python/PiFinder/sqm/camera_profiles.py
@@ -102,6 +102,8 @@ class CameraProfile:
     # wrong at one end or the other. Measured per sensor; 0.0 disables the
     # correction and keeps a plain constant (mono sensors have no colour, and
     # an IR-cut sensor has almost no NIR leak to correct).
+    # Derivation, evidence and caveats: docs/adr/0026. Re-derive with
+    # scripts/evaluate_radiometer_archive.py rather than by hand.
     radiometric_colour_slope: float = 0.0
 
     # R/G at which radiometric_zero_point is exactly right, so a frame with no

--- a/python/PiFinder/sqm/camera_profiles.py
+++ b/python/PiFinder/sqm/camera_profiles.py
@@ -93,6 +93,26 @@ class CameraProfile:
     # square arcseconds when no current plate solve is available.
     radiometric_fov_degrees: float = 0.0
 
+    # Sky-colour dependence of the radiometric zero point, in mag per unit of
+    # sky R/G. The radiometer measures sky in the sensor's passband while the
+    # reference meter measures V, and the conversion between them depends on
+    # the sky's spectrum: light pollution is sodium/LED and green-weighted,
+    # airglow is grey and NIR-rich. On a bare sensor that difference is worth
+    # ~0.8 mag between an LP site and a dark one, so a single constant is
+    # wrong at one end or the other. Measured per sensor; 0.0 disables the
+    # correction and keeps a plain constant (mono sensors have no colour, and
+    # an IR-cut sensor has almost no NIR leak to correct).
+    radiometric_colour_slope: float = 0.0
+
+    # R/G at which radiometric_zero_point is exactly right, so a frame with no
+    # colour information falls back to a sensible constant rather than to the
+    # fit's intercept.
+    radiometric_colour_pivot: float = 0.0
+
+    # R/G range the slope was calibrated over. Values outside are clamped
+    # rather than extrapolated.
+    radiometric_colour_range: Tuple[float, float] = (0.0, 10.0)
+
     # Catalog reference band for the photometric zero point:
     # "gaia_g"  -- Gaia G with a BP-RP trim (bare sensors: G's passband is
     #              nearly the sensor's own; measured 24-29% less star scatter)
@@ -233,7 +253,12 @@ CAMERA_PROFILES: Dict[str, CameraProfile] = {
         # 2025-10-31 sweep vs its 17.8-17.9 hand-held reference (+/-0.2).
         # Near zero is physically consistent: the Pregius mono passband is
         # the closest of the three sensors to the meter's.
-        sqm_band_offset=-0.22,
+        # Re-derived 2026-07-31 from Rich's four referenced imx296 sweeps
+        # (34 frames): per-sweep median stellar SQM against reference_sqm gives
+        # a median residual of +0.199 mag, tight across all four (+0.13..+0.22).
+        # The method reproduces imx462's shipped 0.53 to within 0.02, so it is
+        # not a systematic of the replay. See the PR for the full derivation.
+        sqm_band_offset=-0.02,
     ),
     "imx462": CameraProfile(
         # Hardware configuration
@@ -256,7 +281,20 @@ CAMERA_PROFILES: Dict[str, CameraProfile] = {
         # night to night); clear-sky SQM ~18.5 at the Ghent test site.
         clear_zero_point=14.81,
         clear_sky_brightness=18.5,
-        radiometric_zero_point=15.25,
+        radiometric_zero_point=15.159,
+        # Re-derived 2026-07-31 over 23 referenced sweeps spanning 17.5-20.9
+        # mag skies. A single constant left the published value ~0.10 mag dark
+        # at the LP site and ~0.85 mag bright at a dark one; keying the zero
+        # point to measured sky colour collapses both regimes into one model
+        # (residual sd 0.337 -> 0.079). Leave-one-night-out CV: MAE 0.247 ->
+        # 0.108, and holding out the only dark night -- so the model never saw
+        # that regime -- 0.944 -> 0.312, i.e. it extrapolates rather than
+        # interpolates. The same fit on the IR-cut HQ is rejected by CV, which
+        # is the expected result for a NIR-leak term and the reason to believe
+        # this one.
+        radiometric_colour_slope=5.544,
+        radiometric_colour_pivot=0.85,
+        radiometric_colour_range=(0.83, 1.04),
         radiometric_fov_degrees=10.38,
         reference_band="gaia_g",
         # BP-RP trim on the Gaia G reference, fit on 6 clear sweeps
@@ -289,7 +327,20 @@ CAMERA_PROFILES: Dict[str, CameraProfile] = {
         # Same sensor family/optics as imx462 (driver-compatible): mirror seeds.
         clear_zero_point=14.81,
         clear_sky_brightness=18.5,
-        radiometric_zero_point=15.25,
+        radiometric_zero_point=15.159,
+        # Re-derived 2026-07-31 over 23 referenced sweeps spanning 17.5-20.9
+        # mag skies. A single constant left the published value ~0.10 mag dark
+        # at the LP site and ~0.85 mag bright at a dark one; keying the zero
+        # point to measured sky colour collapses both regimes into one model
+        # (residual sd 0.337 -> 0.079). Leave-one-night-out CV: MAE 0.247 ->
+        # 0.108, and holding out the only dark night -- so the model never saw
+        # that regime -- 0.944 -> 0.312, i.e. it extrapolates rather than
+        # interpolates. The same fit on the IR-cut HQ is rejected by CV, which
+        # is the expected result for a NIR-leak term and the reason to believe
+        # this one.
+        radiometric_colour_slope=5.544,
+        radiometric_colour_pivot=0.85,
+        radiometric_colour_range=(0.83, 1.04),
         radiometric_fov_degrees=10.38,
         # Same sensor family/optics as imx462 (driver-compatible), same NIR leak.
         reference_band="gaia_g",
@@ -318,7 +369,12 @@ CAMERA_PROFILES: Dict[str, CameraProfile] = {
         # clear-sky SQM ~18.5 at the reference sites.
         clear_zero_point=14.19,
         clear_sky_brightness=18.5,
-        radiometric_zero_point=14.79,
+        # Re-derived 2026-07-31 over 11 referenced sweeps: the shipped 14.79
+        # read bright on 10 of 11 (median +0.181). Stays a constant -- the
+        # factory IR-cut leaves almost no NIR leak, its colour slope measures
+        # 20x smaller than the imx462's, and leave-one-night-out CV rejects
+        # the colour term outright (MAE 0.182 constant vs 0.234 with colour).
+        radiometric_zero_point=14.971,
         radiometric_fov_degrees=10.34,
         # Measured on-sky: -0.05 ± 0.01 -> effectively 0. HQ ships with a factory
         # IR-cut filter, so no NIR leak and the green passband ~ Johnson V.
@@ -330,7 +386,20 @@ CAMERA_PROFILES: Dict[str, CameraProfile] = {
         # shared 2025-11-16 reading remains the outlier. Non-zero despite the
         # IR-cut: the residual absorbs passband + optics differences vs the
         # meter. Coupled to the estimator -- recalibrate together.
-        sqm_band_offset=0.60,
+        # Re-derived 2026-07-31 over 9 referenced hq sweeps: the shipped 0.60
+        # left every sweep reading brighter than the meter (residuals +0.01 to
+        # +0.68, median +0.386); 0.99 zeroes that median.
+        #
+        # Note this fights the physics. The offset is meant to be a passband
+        # term, and the HQ's factory IR-cut means it should be near zero -- but
+        # zero puts the stellar SQM ~1 mag bright. So roughly a magnitude of
+        # the HQ stellar chain is unaccounted for and this constant is
+        # absorbing it. The value is fitted, not physical; if the real error is
+        # found, refit rather than assuming this number transfers.
+        #
+        # Sweep-to-sweep scatter is 0.67 mag (dew/throughput), so treat this as
+        # 0.99 +/- 0.2 rather than a precise figure.
+        sqm_band_offset=0.99,
     ),
 }
 

--- a/python/PiFinder/sqm/radiometer.py
+++ b/python/PiFinder/sqm/radiometer.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import math
 from collections import deque
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
 
@@ -33,16 +33,47 @@ def extract_photometry_image(raw, profile) -> Optional[np.ndarray]:
     return arr.astype(np.float32)
 
 
-def _sky_red_green(raw, profile, border_fraction, stride):
+def _mosaic_phase_is_rggb(profile) -> bool:
+    """True when pixel (0, 0) of a ``crop_and_rotate`` frame is still red.
+
+    Red is far more phase-fragile than green, which is why this guard is new
+    with the colour term and ``extract_photometry_image`` never needed it. A
+    180-degree rotation maps the block ``R G / G B`` to ``B G / G R``: the two
+    green sites are invariant, but red and blue swap. An odd crop origin
+    shifts the mosaic by one site with the same effect. Either would make the
+    sampler read blue as red, and a wrong R/G does not fail loudly -- it just
+    moves the published zero point by up to the width of the clamp.
+
+    So require the three invariants the sampler assumes rather than trusting
+    them to stay true: RGGB order (not merely "some Bayer format"), no
+    rotation, and an even crop origin on both axes.
+    """
+    if not str(getattr(profile, "format", "")).upper().startswith("SRGGB"):
+        return False  # mono, or a CFA order this sampler cannot read
+    if int(getattr(profile, "rotation_90", 0) or 0) % 4 != 0:
+        return False  # 90/270 transpose the CFA; 180 swaps red and blue
+    crop_y = getattr(profile, "crop_y", (0, 0))
+    crop_x = getattr(profile, "crop_x", (0, 0))
+    return crop_y[0] % 2 == 0 and crop_x[0] % 2 == 0
+
+
+def _sky_red_green(
+    raw, profile, border_fraction: float, stride: int
+) -> Tuple[Optional[float], Optional[float]]:
     """Median red and green sky level from an RGGB mosaic, or (None, None).
 
     Sky colour is what converts the sensor's passband to the meter's V band:
     light pollution is sodium/LED and green-weighted, airglow is grey and
-    NIR-rich. Mono sensors carry no colour, and IR-cut sensors barely respond
-    to it, so both simply return None and fall back to a constant zero point.
+    NIR-rich. Mono sensors carry no colour and return (None, None), which
+    falls back to a constant zero point.
+
+    Colour sensors that do not *use* the correction still report here: the HQ
+    is RGGB and gets real values, which its zero point then ignores because
+    its colour slope is 0. That costs nothing and accumulates the colour data
+    a future refit would need.
     """
-    if not str(getattr(profile, "format", "")).upper().startswith("S"):
-        return None, None  # not a colour filter array
+    if not _mosaic_phase_is_rggb(profile):
+        return None, None
     a = np.asarray(raw)
     if a.ndim != 2 or min(a.shape) < 64:
         return None, None

--- a/python/PiFinder/sqm/radiometer.py
+++ b/python/PiFinder/sqm/radiometer.py
@@ -33,6 +33,40 @@ def extract_photometry_image(raw, profile) -> Optional[np.ndarray]:
     return arr.astype(np.float32)
 
 
+def _sky_red_green(raw, profile, border_fraction, stride):
+    """Median red and green sky level from an RGGB mosaic, or (None, None).
+
+    Sky colour is what converts the sensor's passband to the meter's V band:
+    light pollution is sodium/LED and green-weighted, airglow is grey and
+    NIR-rich. Mono sensors carry no colour, and IR-cut sensors barely respond
+    to it, so both simply return None and fall back to a constant zero point.
+    """
+    if not str(getattr(profile, "format", "")).upper().startswith("S"):
+        return None, None  # not a colour filter array
+    a = np.asarray(raw)
+    if a.ndim != 2 or min(a.shape) < 64:
+        return None, None
+    by = int(a.shape[0] * border_fraction)
+    bx = int(a.shape[1] * border_fraction)
+    by += by % 2  # keep mosaic phase: (0, 0) must stay red
+    bx += bx % 2
+    c = a[by : a.shape[0] - by, bx : a.shape[1] - bx]
+    if min(c.shape) < 32:
+        return None, None
+    red = float(np.median(c[0::2, 0::2][::stride, ::stride]))
+    green = float(
+        np.median(
+            np.concatenate(
+                [
+                    c[0::2, 1::2][::stride, ::stride].ravel(),
+                    c[1::2, 0::2][::stride, ::stride].ravel(),
+                ]
+            )
+        )
+    )
+    return red, green
+
+
 def collect_radiometer_sample(
     raw,
     profile,
@@ -75,7 +109,7 @@ def collect_radiometer_sample(
     )
     quadrant_medians = [float(np.median(part)) for part in quadrants if part.size]
 
-    return {
+    sample = {
         "sequence": int(sequence),
         "captured_at": float(captured_at),
         "exposure_sec": float(exposure_sec),
@@ -87,6 +121,11 @@ def collect_radiometer_sample(
         "pixels_per_side": int(image.shape[0]),
         "method": "sparse_central_median",
     }
+    red, green = _sky_red_green(raw, profile, border_fraction, stride)
+    if red is not None:
+        sample["background_red"] = red
+        sample["background_green"] = green
+    return sample
 
 
 def radiometric_sqm(
@@ -115,16 +154,32 @@ def radiometric_sqm(
         details["failure_reason"] = "radiometric_factory_calibration_unavailable"
         return None, details
 
+    # Sky colour sets the sensor-band to V-band conversion, so the effective
+    # zero point moves with it. Slope 0 (mono, or an IR-cut sensor with no NIR
+    # leak to correct) leaves this a plain constant. R/G is clamped to the
+    # calibrated range rather than extrapolated off the end of the fit.
+    zero_point = float(profile.radiometric_zero_point)
+    slope = float(getattr(profile, "radiometric_colour_slope", 0.0) or 0.0)
+    red = sample.get("background_red")
+    green = sample.get("background_green")
+    if slope and red is not None and green is not None and (green - pedestal) > 1.0:
+        ratio = (red - pedestal) / (green - pedestal)
+        lo, hi = profile.radiometric_colour_range
+        clamped = min(max(ratio, lo), hi)
+        zero_point += slope * (clamped - profile.radiometric_colour_pivot)
+        details["sky_red_over_green"] = ratio
+        details["sky_red_over_green_clamped"] = clamped
+    # radiometric_zero_point keeps meaning the profile constant, so archives
+    # stay comparable across this change; the applied value is reported
+    # alongside it and is always present, corrected or not.
+    details["radiometric_zero_point_effective"] = zero_point
+
     pixels_per_side = int(sample["pixels_per_side"])
     arcsec_squared_per_pixel = (
         profile.radiometric_fov_degrees * 3600.0
     ) ** 2 / pixels_per_side**2
     flux_density = signal / arcsec_squared_per_pixel
-    value = (
-        profile.radiometric_zero_point
-        + 2.5 * math.log10(exposure_sec)
-        - 2.5 * math.log10(flux_density)
-    )
+    value = zero_point + 2.5 * math.log10(exposure_sec) - 2.5 * math.log10(flux_density)
     details.update(
         {
             "background_flux_density": flux_density,

--- a/python/PiFinder/sqm/radiometric_fit.py
+++ b/python/PiFinder/sqm/radiometric_fit.py
@@ -1,0 +1,266 @@
+"""Fit the radiometric zero-point model that ``camera_profiles.py`` ships.
+
+Offline calibration support, imported by ``scripts/evaluate_radiometer_archive.py``
+and by nothing on the capture path.
+
+The shipped model is
+
+    zero_point = radiometric_zero_point
+                 + radiometric_colour_slope * (clamp(R/G) - radiometric_colour_pivot)
+
+so a tool that re-derives only a single constant cannot check it, and would
+quietly disagree with the profile on any sensor whose slope is non-zero. These
+helpers fit both forms and score them against each other, which is what decides
+whether a sensor should carry a colour term at all.
+
+Two things make the comparison honest rather than decorative:
+
+* **Per-sweep, not per-frame.** Frames within a sweep share a sky, an observer
+  and a reference reading; pooling them would let a long sweep outvote a whole
+  night and shrink every error bar by a factor it has not earned.
+* **Leave-one-night-out, not in-sample residuals.** A free parameter always
+  reduces in-sample scatter. Only holding out an entire night tests whether the
+  colour term *extrapolates* to a sky regime it never saw, which is the claim
+  being made. On a sensor where the physics says there is nothing to correct
+  (a factory IR-cut leaves almost no NIR leak) this is expected to reject the
+  colour model, and that rejection is the control that makes acceptance
+  elsewhere meaningful.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+
+# A colour fit needs both enough sweeps to constrain two parameters and enough
+# spread in R/G to define a slope. Below these the fit is an interpolation
+# between two clusters at best, and noise amplification at worst.
+MIN_SWEEPS_FOR_COLOUR = 6
+MIN_COLOUR_SPREAD = 0.05
+
+
+@dataclass
+class SweepPoint:
+    """One sweep reduced to what a zero-point fit needs.
+
+    ``implied_zero_point`` is the constant that would have made this sweep read
+    exactly its reference meter, i.e. ``reference - 2.5log10(t) + 2.5log10(F)``.
+    Fitting it directly means the fit never has to re-derive the geometry, and
+    an error in the fitted zero point is by construction an error in published
+    SQM of the same size.
+    """
+
+    sweep: str
+    night: str
+    implied_zero_point: float
+    red_over_green: Optional[float] = None
+
+
+def _sd(values: Sequence[float]) -> float:
+    return float(statistics.pstdev(values)) if len(values) > 1 else 0.0
+
+
+def fit_constant(points: Sequence[SweepPoint]) -> Optional[Dict]:
+    """Median implied zero point, and the scatter a constant leaves behind."""
+    if not points:
+        return None
+    zps = [p.implied_zero_point for p in points]
+    centre = float(statistics.median(zps))
+    return {
+        "zero_point": centre,
+        "residual_sd": _sd([z - centre for z in zps]),
+        "sweeps": len(zps),
+    }
+
+
+def _coloured(points: Sequence[SweepPoint]) -> List[SweepPoint]:
+    return [p for p in points if p.red_over_green is not None]
+
+
+def fit_colour(
+    points: Sequence[SweepPoint], pivot: Optional[float] = None
+) -> Optional[Dict]:
+    """Least-squares zero point against sky colour, expressed about ``pivot``.
+
+    ``pivot`` defaults to the median colour of the sample. Pass the profile's
+    pivot when checking a sensor that already ships a colour model; leave it
+    None when exploring one that does not, since those profiles carry pivot
+    0.0 and an intercept quoted at R/G = 0 is an extrapolation far outside any
+    real sky, not a number anyone can compare against.
+
+    Returns None when the sample cannot support two parameters -- too few
+    sweeps, or all of them at effectively one colour, where any slope fits.
+    """
+    usable = _coloured(points)
+    if len(usable) < MIN_SWEEPS_FOR_COLOUR:
+        return None
+    ratios = np.array([p.red_over_green for p in usable], dtype=float)
+    zps = np.array([p.implied_zero_point for p in usable], dtype=float)
+    lo, hi = float(ratios.min()), float(ratios.max())
+    if hi - lo < MIN_COLOUR_SPREAD:
+        return None
+    if pivot is None:
+        pivot = float(np.median(ratios))
+    slope, intercept = np.polyfit(ratios - pivot, zps, 1)
+    residuals = zps - (intercept + slope * (ratios - pivot))
+    return {
+        "zero_point_at_pivot": float(intercept),
+        "colour_slope": float(slope),
+        "pivot": float(pivot),
+        "colour_range": [lo, hi],
+        "residual_sd": _sd(residuals.tolist()),
+        "sweeps": len(usable),
+    }
+
+
+def _predict_colour(model: Dict, ratio: Optional[float], clamp: bool = True) -> float:
+    """Zero point for one sweep.
+
+    ``clamp`` mirrors production, which pins R/G to the calibrated range rather
+    than extrapolating off the end of the fit. Turning it off answers a
+    different question -- see :func:`leave_one_night_out`.
+    """
+    if ratio is None:
+        # No colour on the frame falls back to the pivot value, matching
+        # radiometric_sqm's behaviour rather than extrapolating an intercept.
+        return model["zero_point_at_pivot"]
+    if clamp:
+        lo, hi = model["colour_range"]
+        ratio = min(max(ratio, lo), hi)
+    return model["zero_point_at_pivot"] + model["colour_slope"] * (
+        ratio - model["pivot"]
+    )
+
+
+def leave_one_night_out(
+    points: Sequence[SweepPoint], pivot: Optional[float] = None
+) -> Optional[Dict]:
+    """Hold out each night in turn; report MAE for both models.
+
+    An error in predicted zero point is an error in predicted SQM of the same
+    size, so these numbers read directly as "how far off would this model have
+    been on a night it never saw".
+
+    Colour is scored twice, because two different questions get conflated here
+    and they do not have the same answer:
+
+    * ``colour_mae`` clamps to the *training* colour range, so it measures what
+      shipping the model would actually have done. When the held-out night is
+      the only one of its regime, the clamp pins the prediction at the edge of
+      the fitted span and most of the theoretical gain is unavailable.
+    * ``colour_mae_unclamped`` lets the fit run past its own range, which is
+      the only way to ask whether the physical relation *extrapolates* to an
+      unseen regime rather than interpolating between fitted points.
+
+    The verdict uses the clamped figure: it is the conservative one, and it is
+    the behaviour that would ship.
+    """
+    nights = sorted({p.night for p in points})
+    if len(nights) < 2:
+        return None
+
+    per_night = []
+    constant_errors: List[float] = []
+    colour_errors: List[float] = []
+    colour_errors_unclamped: List[float] = []
+
+    for night in nights:
+        train = [p for p in points if p.night != night]
+        test = [p for p in points if p.night == night]
+        const_model = fit_constant(train)
+        colour_model = fit_colour(train, pivot)
+        if const_model is None:
+            continue
+
+        c_err = [abs(const_model["zero_point"] - p.implied_zero_point) for p in test]
+        row = {
+            "night": night,
+            "sweeps": len(test),
+            "constant_mae": float(np.mean(c_err)),
+        }
+        constant_errors.extend(c_err)
+        if colour_model is not None:
+            k_err = [
+                abs(
+                    _predict_colour(colour_model, p.red_over_green)
+                    - p.implied_zero_point
+                )
+                for p in test
+            ]
+            u_err = [
+                abs(
+                    _predict_colour(colour_model, p.red_over_green, clamp=False)
+                    - p.implied_zero_point
+                )
+                for p in test
+            ]
+            row["colour_mae"] = float(np.mean(k_err))
+            row["colour_mae_unclamped"] = float(np.mean(u_err))
+            # Flags the case above: this night sat outside the training span,
+            # so the clamped figure understates what the relation can do.
+            row["outside_training_colour_range"] = any(
+                p.red_over_green is not None
+                and not (
+                    colour_model["colour_range"][0]
+                    <= p.red_over_green
+                    <= colour_model["colour_range"][1]
+                )
+                for p in test
+            )
+            colour_errors.extend(k_err)
+            colour_errors_unclamped.extend(u_err)
+        per_night.append(row)
+
+    if not constant_errors:
+        return None
+    result = {
+        "nights": len(per_night),
+        "constant_mae": float(np.mean(constant_errors)),
+        "per_night": per_night,
+    }
+    if colour_errors:
+        result["colour_mae"] = float(np.mean(colour_errors))
+        result["colour_mae_unclamped"] = float(np.mean(colour_errors_unclamped))
+    return result
+
+
+def evaluate_profile(
+    points: Sequence[SweepPoint], pivot: Optional[float] = None
+) -> Dict:
+    """Fit both models, cross-validate, and say which one the data supports.
+
+    The verdict is deliberately decided by held-out error, not by in-sample
+    residual scatter, which the colour model wins by construction.
+    """
+    constant = fit_constant(points)
+    colour = fit_colour(points, pivot)
+    cv = leave_one_night_out(points, pivot)
+
+    verdict = "constant"
+    reason = "no colour data, or too few sweeps/too little colour spread to fit"
+    if colour is None:
+        pass
+    elif cv is None or "colour_mae" not in cv:
+        verdict = "constant"
+        reason = "colour model fits, but too few nights to cross-validate it"
+    elif cv["colour_mae"] < cv["constant_mae"]:
+        verdict = "colour"
+        reason = f"held-out MAE {cv['constant_mae']:.3f} -> {cv['colour_mae']:.3f}"
+    else:
+        reason = (
+            f"colour rejected by CV: held-out MAE {cv['constant_mae']:.3f} "
+            f"constant vs {cv['colour_mae']:.3f} with colour"
+        )
+
+    return {
+        "sweeps": len(points),
+        "nights": len(sorted({p.night for p in points})),
+        "constant": constant,
+        "colour": colour,
+        "leave_one_night_out": cv,
+        "verdict": verdict,
+        "verdict_reason": reason,
+    }

--- a/python/PiFinder/sqm/save_sweep_metadata.py
+++ b/python/PiFinder/sqm/save_sweep_metadata.py
@@ -103,6 +103,15 @@ def save_sweep_metadata(
                 "bias_offset": profile.bias_offset,
                 "sqm_band_offset": profile.sqm_band_offset,
                 "color_coefficient": profile.color_coefficient,
+                # The radiometric zero point is no longer a constant you can
+                # look up by camera type: on bare sensors it moves with the
+                # measured sky colour. Record the whole model, or a later
+                # refit cannot tell which one produced these frames.
+                "radiometric_zero_point": profile.radiometric_zero_point,
+                "radiometric_colour_slope": profile.radiometric_colour_slope,
+                "radiometric_colour_pivot": profile.radiometric_colour_pivot,
+                "radiometric_colour_range": list(profile.radiometric_colour_range),
+                "radiometric_fov_degrees": profile.radiometric_fov_degrees,
                 # Extent of the archived raw frames. Sweeps from the
                 # cropped era carry no such field; these hold the whole
                 # sensor, which a reader reduces to the crop with

--- a/python/scripts/evaluate_radiometer_archive.py
+++ b/python/scripts/evaluate_radiometer_archive.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python3
-"""Replay the shipped solve-independent radiometer over archived raw sweeps."""
+"""Replay the shipped solve-independent radiometer over archived raw sweeps.
+
+Two jobs, and they answer different questions:
+
+* ``sweeps`` -- how the *currently shipped* profile constants score against
+  each referenced sweep. These residuals already include the colour term on
+  any sensor that carries one, so they say whether what we ship is right.
+* ``radiometric_models`` -- re-derives the constant and sky-colour models from
+  the archive and cross-validates them against each other, so the choice of
+  model recorded in ``camera_profiles.py`` can be reproduced or refuted rather
+  than taken on trust. See ADR 0026.
+
+The model fit deliberately runs per sweep rather than per frame, and scores by
+leave-one-night-out error rather than in-sample scatter; ``radiometric_fit``
+explains why.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +22,7 @@ import argparse
 import csv
 import json
 import math
+import re
 import statistics
 from collections import defaultdict
 from pathlib import Path
@@ -16,10 +32,22 @@ from PIL import Image
 
 from PiFinder.sqm.camera_profiles import get_camera_profile
 from PiFinder.sqm.radiometer import collect_radiometer_sample, radiometric_sqm
+from PiFinder.sqm.radiometric_fit import SweepPoint, evaluate_profile
 
 
 def _sweep_index(root: Path) -> dict[str, Path]:
     return {path.name: path for path in root.glob("*/sweep_*") if path.is_dir()}
+
+
+def _night(sweep_name: str) -> str:
+    """Group sweeps by observing night.
+
+    Sweeps are named ``sweep_YYYYMMDD_HHMMSS``. Nights are the unit of
+    independence here -- sweeps within one share sky, observer and reference
+    meter -- so cross-validation holds out whole nights, never single sweeps.
+    """
+    match = re.search(r"(\d{8})", sweep_name)
+    return match.group(1) if match else sweep_name
 
 
 def _reference(row: dict, sweep: Path):
@@ -57,6 +85,11 @@ def main() -> None:
     }
     results = defaultdict(list)
     fitted_zero_points = defaultdict(list)
+    # Per-frame values kept keyed by sweep so the model fit can reduce each
+    # sweep to one point before fitting, rather than letting a long sweep
+    # outvote a whole night.
+    implied_by_sweep = defaultdict(list)
+    ratio_by_sweep = defaultdict(list)
     missing = []
     sequence = 0
 
@@ -94,29 +127,85 @@ def main() -> None:
         density = signal / details["arcsec_squared_per_pixel"]
         quality_key = sweep_keys.get(row["sweep"])
         annotation = quality.get(quality_key, {})
+        key = (row["profile"], row["sweep"])
+        # Recorded pre-clamp for every sweep, fit-eligible or not: the fit
+        # needs the colour actually measured, and clamping is applied later at
+        # prediction time. Reporting it on rejected sweeps too is what shows
+        # whether a bad sweep was off-colour or just off.
+        if "sky_red_over_green" in details:
+            ratio_by_sweep[key].append(details["sky_red_over_green"])
         if annotation.get("use_for_factory_fit", False):
-            fitted_zero_points[row["profile"]].append(
+            # The zero point that would have made this frame match its
+            # reference exactly. Independent of whichever model is shipped,
+            # so it is the right quantity to fit either model against.
+            implied = (
                 reference - 2.5 * math.log10(exposure_sec) + 2.5 * math.log10(density)
             )
+            fitted_zero_points[row["profile"]].append(implied)
+            implied_by_sweep[key].append(implied)
 
     sweep_rows = []
     for (profile, sweep), errors in sorted(results.items()):
         quality_key = sweep_keys.get(sweep)
         annotation = quality.get(quality_key, {})
-        sweep_rows.append(
-            {
-                "profile": profile,
-                "sweep": sweep,
-                "frames": len(errors),
-                "median_error": statistics.median(errors),
-                "frame_scatter": statistics.pstdev(errors) if len(errors) > 1 else 0.0,
-                "condition": annotation.get("condition", "unreviewed"),
-                "use_for_factory_fit": annotation.get("use_for_factory_fit", False),
-                "quality_note": annotation.get("note", ""),
-            }
+        ratios = ratio_by_sweep.get((profile, sweep), [])
+        row_out = {
+            "profile": profile,
+            "sweep": sweep,
+            "frames": len(errors),
+            "median_error": statistics.median(errors),
+            "frame_scatter": statistics.pstdev(errors) if len(errors) > 1 else 0.0,
+            "condition": annotation.get("condition", "unreviewed"),
+            "use_for_factory_fit": annotation.get("use_for_factory_fit", False),
+            "quality_note": annotation.get("note", ""),
+        }
+        if ratios:
+            # median_error above is already colour-corrected on these sweeps.
+            row_out["median_red_over_green"] = float(statistics.median(ratios))
+        sweep_rows.append(row_out)
+    # Reduce each sweep to one point, then fit and cross-validate per profile.
+    points_by_profile = defaultdict(list)
+    for (profile, sweep), values in sorted(implied_by_sweep.items()):
+        ratios = ratio_by_sweep.get((profile, sweep), [])
+        points_by_profile[profile].append(
+            SweepPoint(
+                sweep=sweep,
+                night=_night(sweep),
+                implied_zero_point=float(statistics.median(values)),
+                # A sweep counts as coloured only if every accepted frame
+                # reported colour; a partial sweep would mix two populations.
+                red_over_green=(
+                    float(statistics.median(ratios))
+                    if len(ratios) == len(values)
+                    else None
+                ),
+            )
         )
+
+    models = {}
+    for profile, points in sorted(points_by_profile.items()):
+        shipped = get_camera_profile(profile)
+        # Profiles that ship no colour model carry pivot 0.0; let the fit pick
+        # its own pivot there so the exploratory intercept is quoted at a real
+        # sky colour rather than at R/G = 0.
+        evaluation = evaluate_profile(points, shipped.radiometric_colour_pivot or None)
+        evaluation["shipped"] = {
+            "radiometric_zero_point": shipped.radiometric_zero_point,
+            "radiometric_colour_slope": shipped.radiometric_colour_slope,
+            "radiometric_colour_pivot": shipped.radiometric_colour_pivot,
+            "radiometric_colour_range": list(shipped.radiometric_colour_range),
+            "model": "colour" if shipped.radiometric_colour_slope else "constant",
+        }
+        evaluation["agrees_with_shipped"] = (
+            evaluation["verdict"] == evaluation["shipped"]["model"]
+        )
+        models[profile] = evaluation
+
     output = {
         "sweeps": sweep_rows,
+        # Constant-only fit, retained for continuity with earlier runs. It is
+        # the shipped model only where radiometric_colour_slope is 0; compare
+        # radiometric_models before quoting it as a factory value.
         "fitted_radiometric_zero_points": {
             profile: {
                 "frames": len(values),
@@ -125,6 +214,7 @@ def main() -> None:
             }
             for profile, values in fitted_zero_points.items()
         },
+        "radiometric_models": models,
         "missing": missing,
     }
     rendered = json.dumps(output, indent=2, sort_keys=True)

--- a/python/tests/test_radiometer.py
+++ b/python/tests/test_radiometer.py
@@ -149,3 +149,103 @@ def test_recent_conditioned_optics_deficit_corrects_radiometer(monkeypatch):
     assert solver.update_radiometric_sqm(shared, calc, acc, sample, now=100.0)
     published = shared.set_sqm.call_args.args[0]
     assert published.value == pytest.approx(uncorrected - 0.7)
+
+
+@pytest.mark.unit
+def test_colour_term_moves_the_zero_point_with_sky_colour():
+    """A bare sensor's zero point must track sky colour.
+
+    LP sky is green-weighted (low R/G), airglow is grey and NIR-rich (R/G ~1).
+    The sensor sees that difference and a V-band meter does not, so a single
+    constant is wrong at one end. Same sky signal, different colour, must give
+    a different answer.
+    """
+    from PiFinder.sqm import get_camera_profile
+    from PiFinder.sqm.radiometer import radiometric_sqm
+
+    prof = get_camera_profile("imx462")
+    base = dict(
+        sequence=1,
+        captured_at=0.0,
+        exposure_sec=1.0,
+        background_per_pixel=400.0,
+        pixels_per_side=980,
+    )
+    ped = prof.bias_offset
+
+    lp = dict(base, background_red=ped + 0.85 * 100, background_green=ped + 100)
+    dark = dict(base, background_red=ped + 1.00 * 100, background_green=ped + 100)
+
+    v_lp, d_lp = radiometric_sqm(lp, prof, pedestal=ped)
+    v_dark, _ = radiometric_sqm(dark, prof, pedestal=ped)
+
+    assert v_lp is not None and v_dark is not None
+    # 0.15 of R/G at the fitted slope
+    assert (v_dark - v_lp) == pytest.approx(
+        0.15 * prof.radiometric_colour_slope, abs=1e-6
+    )
+    assert d_lp["sky_red_over_green"] == pytest.approx(0.85, abs=1e-6)
+    # The reported constant must stay the profile value, not the applied one,
+    # so archives remain comparable across this change.
+    assert d_lp["radiometric_zero_point"] == pytest.approx(prof.radiometric_zero_point)
+    # At the pivot the correction is exactly zero -- that is what makes the
+    # no-colour fallback land on a sensible value rather than the fit intercept.
+    assert d_lp["radiometric_zero_point_effective"] == pytest.approx(
+        prof.radiometric_zero_point, abs=1e-9
+    )
+
+
+@pytest.mark.unit
+def test_missing_colour_falls_back_to_the_constant():
+    """No colour (mono sensor, or a malformed sample) must not break or drift."""
+    from PiFinder.sqm import get_camera_profile
+    from PiFinder.sqm.radiometer import radiometric_sqm
+
+    prof = get_camera_profile("imx462")
+    sample = dict(
+        sequence=1,
+        captured_at=0.0,
+        exposure_sec=1.0,
+        background_per_pixel=400.0,
+        pixels_per_side=980,
+    )
+    v, d = radiometric_sqm(sample, prof, pedestal=prof.bias_offset)
+    assert v is not None
+    assert d["radiometric_zero_point"] == pytest.approx(prof.radiometric_zero_point)
+    assert d["radiometric_zero_point_effective"] == pytest.approx(
+        prof.radiometric_zero_point
+    )
+    assert "sky_red_over_green" not in d
+
+
+@pytest.mark.unit
+def test_colour_ratio_is_clamped_to_the_calibrated_range():
+    """Never extrapolate off the end of the fit."""
+    from PiFinder.sqm import get_camera_profile
+    from PiFinder.sqm.radiometer import radiometric_sqm
+
+    prof = get_camera_profile("imx462")
+    ped = prof.bias_offset
+    wild = dict(
+        sequence=1,
+        captured_at=0.0,
+        exposure_sec=1.0,
+        background_per_pixel=400.0,
+        pixels_per_side=980,
+        background_red=ped + 500.0,
+        background_green=ped + 100.0,  # R/G = 5
+    )
+    _, d = radiometric_sqm(wild, prof, pedestal=ped)
+    assert d["sky_red_over_green"] == pytest.approx(5.0)
+    assert d["sky_red_over_green_clamped"] == pytest.approx(
+        prof.radiometric_colour_range[1]
+    )
+
+
+@pytest.mark.unit
+def test_ir_cut_sensor_keeps_a_plain_constant():
+    """HQ has a factory IR-cut, so there is no NIR leak to correct."""
+    from PiFinder.sqm import get_camera_profile
+
+    assert get_camera_profile("hq").radiometric_colour_slope == 0.0
+    assert get_camera_profile("imx296").radiometric_colour_slope == 0.0

--- a/python/tests/test_radiometer.py
+++ b/python/tests/test_radiometer.py
@@ -249,3 +249,148 @@ def test_ir_cut_sensor_keeps_a_plain_constant():
 
     assert get_camera_profile("hq").radiometric_colour_slope == 0.0
     assert get_camera_profile("imx296").radiometric_colour_slope == 0.0
+
+
+def _rggb(height, width, red, green, blue):
+    """Synthetic RGGB mosaic with a known, distinct value per CFA site."""
+    a = np.zeros((height, width), dtype=np.uint16)
+    a[0::2, 0::2] = red
+    a[0::2, 1::2] = green
+    a[1::2, 0::2] = green
+    a[1::2, 1::2] = blue
+    return a
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("height,width", [(1080, 1920), (1085, 1925), (215, 215)])
+def test_sky_colour_is_sampled_on_the_right_mosaic_sites(height, width):
+    """Red must come off the red sites, at any frame size.
+
+    Blue is deliberately far from red here: a half-site phase slip reads blue
+    as red and would otherwise pass silently, since the result stays a
+    plausible number. The odd sizes exercise the border-evening -- a 215-px
+    frame gives a 21-px border, and an odd border is exactly what shifts the
+    crop onto the wrong CFA phase.
+    """
+    profile = get_camera_profile("imx462")
+    sample = collect_radiometer_sample(
+        _rggb(height, width, red=850, green=1000, blue=500),
+        profile,
+        1.0,
+        sequence=1,
+        captured_at=0.0,
+    )
+    assert sample["background_red"] == pytest.approx(850.0)
+    assert sample["background_green"] == pytest.approx(1000.0)
+
+
+@pytest.mark.unit
+def test_rotated_or_odd_cropped_profiles_refuse_to_report_colour():
+    """The invariants the sampler assumes are checked, not assumed.
+
+    A 180-degree rotation leaves the green sites alone but swaps red and blue,
+    so the pre-existing green extraction never had to care and this one does.
+    Reporting no colour costs a fallback to the constant zero point; reporting
+    blue as red would shift the published SQM by up to the clamp width.
+    """
+    from dataclasses import replace
+
+    from PiFinder.sqm.radiometer import _mosaic_phase_is_rggb
+
+    profile = get_camera_profile("imx462")
+    assert _mosaic_phase_is_rggb(profile)
+
+    for broken in (
+        replace(profile, rotation_90=2),  # 180 deg: red <-> blue
+        replace(profile, rotation_90=1),  # 90 deg: transposes the CFA
+        replace(profile, crop_x=(471, 471)),  # odd origin: half-site slip
+        replace(profile, crop_y=(51, 51)),
+        replace(profile, format="SBGGR12"),  # Bayer, but not RGGB
+    ):
+        assert not _mosaic_phase_is_rggb(broken)
+        sample = collect_radiometer_sample(
+            _rggb(256, 256, red=850, green=1000, blue=500),
+            broken,
+            1.0,
+            sequence=1,
+            captured_at=0.0,
+        )
+        assert "background_red" not in sample
+
+
+@pytest.mark.unit
+def test_shipped_colour_profiles_hold_the_phase_invariants():
+    """Guard the profiles themselves, not just the sampler.
+
+    These three are RGGB, unrotated and even-cropped today, which is why the
+    colour term is correct as shipped. If a future orientation change breaks
+    that, this fails here rather than quietly biasing everyone's SQM.
+    """
+    from PiFinder.sqm.radiometer import _mosaic_phase_is_rggb
+
+    for name in ("imx462", "imx290", "hq"):
+        profile = get_camera_profile(name)
+        assert _mosaic_phase_is_rggb(profile), name
+        assert profile.rotation_90 == 0
+        assert profile.crop_x[0] % 2 == 0 and profile.crop_y[0] % 2 == 0
+
+
+@pytest.mark.unit
+def test_mono_profile_reports_no_colour():
+    profile = get_camera_profile("imx296")
+    sample = collect_radiometer_sample(
+        np.full((256, 256), 300, dtype=np.uint16),
+        profile,
+        1.0,
+        sequence=1,
+        captured_at=0.0,
+    )
+    assert "background_red" not in sample
+    assert "background_green" not in sample
+
+
+@pytest.mark.unit
+def test_colour_sample_survives_the_round_trip_to_a_corrected_value():
+    """End to end: mosaic in, colour-corrected zero point out.
+
+    The other colour tests hand-build background_red/green; this one is the
+    only path that proves the sampler and the estimator agree on units.
+    """
+    profile = get_camera_profile("imx462")
+    pedestal = profile.bias_offset
+    sample = collect_radiometer_sample(
+        _rggb(512, 512, red=int(pedestal + 100), green=int(pedestal + 100), blue=200),
+        profile,
+        1.0,
+        sequence=1,
+        captured_at=0.0,
+    )
+    _, details = radiometric_sqm(sample, profile, pedestal=pedestal)
+    assert details["sky_red_over_green"] == pytest.approx(1.0)
+    assert details["radiometric_zero_point_effective"] == pytest.approx(
+        profile.radiometric_zero_point
+        + profile.radiometric_colour_slope * (1.0 - profile.radiometric_colour_pivot)
+    )
+
+
+@pytest.mark.unit
+def test_a_phase_slip_really_would_read_blue_as_red():
+    """Pin the failure the guard prevents, so its rationale stays checkable.
+
+    ``crop_and_rotate`` runs before the sampler, so a rotated profile hands it
+    an already-rotated frame. Feed the sampler that frame directly and red
+    comes back as blue -- silently, still a plausible sky level. This is the
+    whole reason _mosaic_phase_is_rggb refuses those profiles.
+    """
+    from PiFinder.sqm.radiometer import _sky_red_green
+
+    profile = get_camera_profile("imx462")
+    frame = _rggb(256, 256, red=850, green=1000, blue=500)
+
+    red, green = _sky_red_green(frame, profile, 0.10, 4)
+    assert (red, green) == (850.0, 1000.0)
+
+    # What the sampler would have seen had the profile been rotated 180.
+    slipped_red, slipped_green = _sky_red_green(np.rot90(frame, 2), profile, 0.10, 4)
+    assert slipped_red == 500.0  # blue, not red
+    assert slipped_green == 1000.0  # green sites are rotation-invariant

--- a/python/tests/test_radiometric_fit.py
+++ b/python/tests/test_radiometric_fit.py
@@ -1,0 +1,202 @@
+"""Tests for the offline radiometric zero-point model fit.
+
+The archive these run against in anger is not in the repo, so the fitting and
+cross-validation maths is pinned here on synthetic sweeps whose answer is known
+by construction. The point is that the decision "does this sensor need a colour
+term" is reproducible, not that any particular archive gives a particular number.
+"""
+
+import pytest
+
+from PiFinder.sqm.radiometric_fit import (
+    SweepPoint,
+    evaluate_profile,
+    fit_colour,
+    fit_constant,
+    leave_one_night_out,
+)
+
+PIVOT = 0.85
+
+
+def _sweeps(spec):
+    """Build sweeps from (night, R/G, zero_point) triples."""
+    return [
+        SweepPoint(
+            sweep=f"sweep_{night}_{i:02d}",
+            night=night,
+            implied_zero_point=zp,
+            red_over_green=rg,
+        )
+        for i, (night, rg, zp) in enumerate(spec)
+    ]
+
+
+def _colour_dependent(slope=5.5, intercept=15.16):
+    """Two LP nights and one dark night, zero point linear in sky colour."""
+    spec = []
+    for night, ratios in (
+        ("20260701", [0.83, 0.85, 0.87]),
+        ("20260705", [0.84, 0.86, 0.89]),
+        ("20260720", [1.00, 1.02, 1.04]),  # the only dark night
+    ):
+        for rg in ratios:
+            spec.append((night, rg, intercept + slope * (rg - PIVOT)))
+    return _sweeps(spec)
+
+
+@pytest.mark.unit
+def test_constant_fit_reports_median_and_scatter():
+    points = _sweeps([("n1", 0.85, 14.0), ("n1", 0.85, 15.0), ("n2", 0.85, 16.0)])
+    fit = fit_constant(points)
+    assert fit["zero_point"] == pytest.approx(15.0)
+    assert fit["sweeps"] == 3
+    assert fit["residual_sd"] > 0
+
+
+@pytest.mark.unit
+def test_colour_fit_recovers_a_known_slope():
+    fit = fit_colour(_colour_dependent(slope=5.5, intercept=15.16), PIVOT)
+    assert fit["colour_slope"] == pytest.approx(5.5, abs=1e-6)
+    assert fit["zero_point_at_pivot"] == pytest.approx(15.16, abs=1e-6)
+    assert fit["residual_sd"] == pytest.approx(0.0, abs=1e-9)
+    assert fit["colour_range"] == pytest.approx([0.83, 1.04])
+
+
+@pytest.mark.unit
+def test_colour_fit_refuses_a_sample_it_cannot_support():
+    """Too few sweeps, or all one colour, must not produce a slope."""
+    too_few = _sweeps([("n1", 0.83, 15.0), ("n2", 1.04, 16.0)])
+    assert fit_colour(too_few, PIVOT) is None
+
+    # Enough sweeps, but no colour lever arm: any slope fits equally.
+    no_spread = _sweeps([("n%d" % i, 0.85, 15.0 + 0.01 * i) for i in range(8)])
+    assert fit_colour(no_spread, PIVOT) is None
+
+    mono = [
+        SweepPoint(sweep=f"s{i}", night=f"n{i}", implied_zero_point=15.0)
+        for i in range(8)
+    ]
+    assert fit_colour(mono, PIVOT) is None
+
+
+@pytest.mark.unit
+def test_cross_validation_prefers_colour_when_the_sky_really_is_coloured():
+    cv = leave_one_night_out(_colour_dependent(), PIVOT)
+    assert cv["colour_mae"] < cv["constant_mae"]
+    assert cv["nights"] == 3
+
+
+@pytest.mark.unit
+def test_holding_out_the_only_dark_night_tests_extrapolation():
+    """The load-bearing case: predict a regime the fit never saw.
+
+    Trained on LP nights alone, the colour model must still land near the dark
+    night. A constant cannot -- it can only return the LP average. This is the
+    difference between extrapolating and interpolating, and it is the whole
+    argument for the colour term being physical rather than a spare parameter.
+    """
+    cv = leave_one_night_out(_colour_dependent(), PIVOT)
+    dark = next(r for r in cv["per_night"] if r["night"] == "20260720")
+
+    # Held out, the dark night's colours sit outside everything the fit saw.
+    assert dark["outside_training_colour_range"]
+
+    # Clamped -- what shipping would have done -- the model is pinned at the
+    # edge of its fitted span and can only recover part of the gap.
+    assert dark["colour_mae"] < dark["constant_mae"]
+
+    # Unclamped, the relation itself extrapolates: on data that is linear by
+    # construction it lands essentially exactly, while a constant cannot.
+    assert dark["colour_mae_unclamped"] == pytest.approx(0.0, abs=1e-9)
+    assert dark["constant_mae"] > 0.5
+
+
+@pytest.mark.unit
+def test_cross_validation_rejects_colour_when_the_sensor_does_not_care():
+    """The negative control -- an IR-cut sensor with no NIR leak to correct.
+
+    Colour varies, the zero point does not. In-sample the colour model still
+    wins (a free parameter always does), so a verdict taken from residual
+    scatter would wrongly ship a slope here. Held-out error is what catches it.
+    """
+    spec = []
+    for night, ratios in (
+        ("20260701", [0.83, 0.86, 0.89]),
+        ("20260705", [0.90, 0.95, 1.00]),
+        ("20260720", [1.00, 1.02, 1.04]),
+    ):
+        for i, rg in enumerate(ratios):
+            # Real scatter, but none of it explained by colour.
+            spec.append((night, rg, 14.97 + (0.05 if i % 2 else -0.05)))
+    points = _sweeps(spec)
+
+    # Least squares cannot do worse in sample than the no-slope fit, so this
+    # comparison can never reject a colour term however useless it is.
+    in_sample_colour = fit_colour(points, PIVOT)["residual_sd"]
+    in_sample_constant = fit_constant(points)["residual_sd"]
+    assert in_sample_colour <= in_sample_constant + 1e-9  # the trap
+
+    result = evaluate_profile(points, PIVOT)
+    assert result["verdict"] == "constant"
+    assert "rejected by CV" in result["verdict_reason"]
+
+
+@pytest.mark.unit
+def test_verdict_is_colour_for_a_genuinely_colour_dependent_sensor():
+    result = evaluate_profile(_colour_dependent(), PIVOT)
+    assert result["verdict"] == "colour"
+    assert result["colour"]["colour_slope"] == pytest.approx(5.5, abs=1e-6)
+    assert result["nights"] == 3
+
+
+@pytest.mark.unit
+def test_a_single_night_cannot_be_cross_validated():
+    """One night is not evidence about another night."""
+    points = _sweeps([("20260701", 0.83 + 0.03 * i, 15.0 + i) for i in range(7)])
+    assert leave_one_night_out(points, PIVOT) is None
+    result = evaluate_profile(points, PIVOT)
+    assert result["verdict"] == "constant"
+    assert "too few nights" in result["verdict_reason"]
+
+
+@pytest.mark.unit
+def test_prediction_clamps_to_the_fitted_colour_range():
+    """Never extrapolate off the end of the fit, matching production."""
+    from PiFinder.sqm.radiometric_fit import _predict_colour
+
+    model = fit_colour(_colour_dependent(), PIVOT)
+    at_top = _predict_colour(model, 1.04)
+    assert _predict_colour(model, 5.0) == pytest.approx(at_top)
+    at_bottom = _predict_colour(model, 0.83)
+    assert _predict_colour(model, 0.1) == pytest.approx(at_bottom)
+    # No colour falls back to the pivot value, not the raw intercept.
+    assert _predict_colour(model, None) == pytest.approx(model["zero_point_at_pivot"])
+
+
+@pytest.mark.unit
+def test_pivot_defaults_to_the_middle_of_the_measured_colours():
+    """Exploring a sensor that ships no colour model must stay interpretable.
+
+    Those profiles carry pivot 0.0, and an intercept quoted at R/G = 0 is an
+    extrapolation far outside any real sky. Defaulting to the sample's median
+    colour keeps the reported zero point comparable to the shipped constant.
+    """
+    points = _colour_dependent(slope=5.5, intercept=15.16)
+    fit = fit_colour(points)  # no pivot given
+
+    assert fit["pivot"] == pytest.approx(0.87)  # median of the sample colours
+    assert fit["colour_slope"] == pytest.approx(5.5, abs=1e-6)
+    # Same line, just re-expressed: the value at the explicit pivot is unchanged.
+    explicit = fit_colour(points, PIVOT)
+    assert fit["zero_point_at_pivot"] == pytest.approx(
+        explicit["zero_point_at_pivot"] + 5.5 * (fit["pivot"] - PIVOT), abs=1e-6
+    )
+
+
+@pytest.mark.unit
+def test_a_zero_pivot_is_not_silently_used_as_a_real_colour():
+    """Guard the wiring the script relies on: `pivot or None` must reach here."""
+    points = _colour_dependent()
+    assert fit_colour(points, 0.0)["pivot"] == 0.0  # explicit 0.0 is honoured
+    assert fit_colour(points, None)["pivot"] != 0.0  # None picks a real colour

--- a/python/tests/test_sqm.py
+++ b/python/tests/test_sqm.py
@@ -1854,5 +1854,5 @@ class TestBandOffset:
     def test_band_offset_values(self):
         assert get_camera_profile("imx462").sqm_band_offset == pytest.approx(0.53)
         assert get_camera_profile("imx290").sqm_band_offset == pytest.approx(0.53)
-        assert get_camera_profile("hq").sqm_band_offset == pytest.approx(0.60)
-        assert get_camera_profile("imx296").sqm_band_offset == pytest.approx(-0.22)
+        assert get_camera_profile("hq").sqm_band_offset == pytest.approx(0.99)
+        assert get_camera_profile("imx296").sqm_band_offset == pytest.approx(-0.02)


### PR DESCRIPTION
Follow-up to #544, which merged the pipeline change but deferred the recalibration it needs — spotted while prepping the 2.6.1 notes. Re-deriving from the sweep archive found the deferred refit was the *smaller* half of the problem.

## The main finding: one constant can't fit both sky regimes

Over **23 referenced imx462 sweeps spanning 17.5–20.9 mag**, the shipped `radiometric_zero_point=15.25` reads **~0.10 mag dark** at the LP site and **~0.85 mag bright** at a dark one. Every attempt to fit a single constant kept disagreeing with itself, because it was averaging two regimes.

The cause is physical. The radiometer measures sky in the **sensor's** passband; the reference meter measures **V**. Converting between them depends on the sky's spectrum — light pollution is sodium/LED and green-weighted, airglow is grey and NIR-rich, which a bare Bayer sensor sees and a V-band meter does not. Sky brightness is only a proxy for that. **Sky colour measures it directly**, and it's already in the frame: measured R/G runs **0.83–0.89** at the LP site and **1.00–1.04** at the dark site.

| model | residual sd |
|---|---|
| constant (shipped) | 0.337 |
| vs sky brightness | 0.185 |
| **vs measured sky colour (R/G)** | **0.079** |

## Why I believe it isn't just a spare parameter

**Leave-one-night-out CV: MAE 0.247 → 0.108.** The load-bearing row is holding out `20260720`, the only dark night — trained on nothing but LP data, the model predicts an unseen regime at **0.312** against the constant's **0.944**. It extrapolates, rather than interpolating between fitted points.

**The same fit on the HQ is rejected by CV** (0.234 with colour vs 0.182 constant), and its colour slope measures **20× smaller** (+0.272 vs +5.544). That is exactly what a NIR-leak term must do on a sensor with a factory IR-cut filter. A model that wins everywhere would be suspicious; one that wins only where the physics says it should is evidence.

## Result against the archive

| | before | after |
|---|---|---|
| imx462 median residual | −0.045 | **+0.005** |
| imx462 spread | −0.23 … **+1.08** | −0.18 … **+0.16** |
| the three dark-site sweeps | +0.76, +0.77, +1.08 | +0.16, −0.02, +0.005 |
| hq median residual | +0.181 | **+0.000** |

The ~1 mag dark-site error is gone and the LP regime got *tighter*, not traded away.

## Shape of the change

- `collect_radiometer_sample` now records `background_red` / `background_green` off the mosaic (colour sensors only).
- `CameraProfile` gains `radiometric_colour_slope` / `_pivot` / `_range`. **Slope 0 is a plain constant**, so mono and IR-cut sensors are unchanged in behaviour.
- imx462/imx290: `15.25` → `15.159 + 5.544·(R/G − 0.85)`, R/G clamped to the calibrated 0.83–1.04 rather than extrapolated.
- hq: constant, `14.79` → `14.971`.
- A frame with no colour falls back to the constant, pinned at the LP-regime value.

## Also: the band offsets #544 promised (diagnostic only)

`sqm_band_offset` is read **only** by `sqm.py`, the stellar path — the published SQM comes from the radiometer, so these affect a diagnostic, not what users see.

#544's text quoted imx296 −0.22 → **+0.21** and hq 0.60 → **0.43**. Neither reproduces:

| profile | shipped | #544 text | re-derived | evidence |
|---|---|---|---|---|
| imx296 | −0.22 | +0.21 | **−0.02** | 4 sweeps, residuals +0.13…+0.22 — tight |
| hq | 0.60 | 0.43 | **0.99** | 9 sweeps, 0.67 mag scatter → 0.99 ± 0.2 |
| imx462 | 0.53 | — | 0.514 | **control** — validates the method |

The HQ band offset argues with the physics: it's nominally a passband term and the IR-cut implies ≈0, yet 0 puts the stellar SQM a full magnitude bright. So roughly a magnitude of the HQ *stellar* chain is unaccounted for and this constant is absorbing it. The comment says so, so whoever finds the real error refits rather than assuming the number transfers.

## Caveats, kept visible

- **imx296** rests on 4 sweeps from one night and one observer, and being **mono it cannot use the colour model at all** — its radiometric zero point is deliberately left untouched. A dark-site sweep from that camera would be the single most useful thing to add.
- The imx462 dark-site anchor is **one night** (3 sweeps). The CV result is what makes it credible, not the sample size.
- Sky colour is a proxy for spectrum, not a measurement of it; two different spectra with the same R/G would be conflated.