### PR TITLE
Settle the exposure sweep on the exposure the sensor actually delivers

### DIFF
--- a/python/PiFinder/camera_interface.py
+++ b/python/PiFinder/camera_interface.py
@@ -185,6 +185,37 @@ class CameraInterface:
     def capture_raw_file(self, filename) -> None:
         pass
 
+    def _settle_exposure(self, requested_us, max_frames=8, tolerance=0.02):
+        """Discard frames until the sensor actually delivers `requested_us`.
+
+        A fixed flush count cannot be right for every sensor: the IMX290/462
+        serves exactly three frames at the old exposure after a change, while
+        the IMX477 emits half-exposure transitional frames instead. Flushing
+        two frames -- as this did -- left the next capture still on the old
+        exposure, so a sweep's processed PNG was one step behind the raw TIFF
+        beside it, and the radiometer sample attached to the record described
+        the PNG. Watch the driver's reported ExposureTime instead.
+
+        Returns the number of frames discarded.
+        """
+        for n in range(max_frames):
+            self.capture()
+            meta = getattr(self, "last_frame_metadata", None) or {}
+            actual = meta.get("ExposureTime")
+            if actual is None:
+                # Backend reports no exposure metadata (debug/none cameras);
+                # nothing to settle against, so don't burn frames on it.
+                return n + 1
+            if abs(float(actual) - requested_us) <= tolerance * requested_us:
+                return n + 1
+        logger.warning(
+            "Exposure did not settle at %sµs after %d frames; "
+            "the frame may not match its label",
+            requested_us,
+            max_frames,
+        )
+        return max_frames
+
     def _blank_capture(self):
         """
         Returns a properly formated black frame
@@ -748,11 +779,8 @@ class CameraInterface:
                                 # Flush camera buffer - discard pre-buffered frames with old exposure
                                 # Picamera2 maintains a frame queue, need to flush frames captured
                                 # before the new exposure setting was applied
-                                logger.debug(
-                                    f"Flushing camera buffer for {exp_us}µs exposure"
-                                )
-                                _ = self.capture()  # Discard buffered frame 1
-                                _ = self.capture()  # Discard buffered frame 2
+                                logger.debug(f"Settling camera at {exp_us}µs exposure")
+                                settled = self._settle_exposure(exp_us)
 
                                 # Now capture both processed and RAW images with correct exposure
                                 exp_ms = exp_us / 1000
@@ -806,12 +834,21 @@ class CameraInterface:
                                 # sample below does NOT: it is recomputed on
                                 # every capture and gives live per-frame
                                 # background/MAD/gradient through the sweep.
+                                frame_record["settle_frames"] = settled
                                 try:
                                     frame_record["sqm_details"] = _json_safe(
                                         shared_state.sqm_details()
                                     )
+                                    # The freeze is expected, but only the
+                                    # source said so -- an analyst reading the
+                                    # archive saw one value repeated across
+                                    # every frame with nothing marking it as a
+                                    # single pre-sweep snapshot. Say so in the
+                                    # data.
+                                    frame_record["sqm_details_frozen"] = True
                                 except Exception:
                                     frame_record["sqm_details"] = None
+                                    frame_record["sqm_details_frozen"] = None
                                 try:
                                     frame_record["radiometer_sample"] = _json_safe(
                                         shared_state.sqm_radiometer_sample()

--- a/python/tests/test_sweep_frame_record.py
+++ b/python/tests/test_sweep_frame_record.py
@@ -120,3 +120,80 @@ def test_tracker_window_dumps_are_json_serializable():
     assert dump["n_samples"] == 1
     assert dump["last_sequence"] == 7
     json.dumps(dump)
+
+
+@pytest.mark.unit
+class TestExposureSettling:
+    """The sweep must not label a frame with an exposure the sensor wasn't at.
+
+    The IMX290/462 serves exactly three frames at the old exposure after a
+    change. Flushing a fixed two left the next capture stale, so the sweep's
+    processed PNG was one step behind the raw TIFF beside it and the radiometer
+    sample described the PNG rather than the labelled exposure.
+    """
+
+    class _FakeCamera:
+        """Applies a new exposure only after `lag` frames, like the real sensor."""
+
+        def __init__(self, lag=3):
+            self.lag = lag
+            self.requested = None
+            self.applied = None
+            self._since_change = 0
+            self.captures = 0
+            self.last_frame_metadata = {}
+
+        def set_exposure(self, us):
+            self.requested = us
+            self._since_change = 0
+
+        def capture(self):
+            self.captures += 1
+            self._since_change += 1
+            if self._since_change > self.lag:
+                self.applied = self.requested
+            self.last_frame_metadata = {"ExposureTime": self.applied}
+            return None
+
+    def _settler(self, cam):
+        from PiFinder.camera_interface import CameraInterface
+
+        cam._settle_exposure = CameraInterface._settle_exposure.__get__(cam)
+        return cam
+
+    def test_settles_on_the_actual_exposure(self):
+        cam = self._settler(self._FakeCamera(lag=3))
+        cam.applied = 25_000
+        cam.set_exposure(400_000)
+
+        cam._settle_exposure(400_000)
+
+        assert cam.last_frame_metadata["ExposureTime"] == 400_000
+
+    def test_two_flushes_would_have_been_stale(self):
+        """Pin the original bug: the old fixed count leaves the wrong exposure."""
+        cam = self._FakeCamera(lag=3)
+        cam.applied = 25_000
+        cam.set_exposure(400_000)
+        cam.capture()
+        cam.capture()  # the old code stopped here
+
+        assert cam.last_frame_metadata["ExposureTime"] == 25_000
+
+    def test_gives_up_rather_than_spinning(self):
+        cam = self._settler(self._FakeCamera(lag=99))
+        cam.applied = 25_000
+        cam.set_exposure(400_000)
+
+        n = cam._settle_exposure(400_000, max_frames=4)
+
+        assert n == 4
+
+    def test_backend_without_exposure_metadata_does_not_burn_frames(self):
+        cam = self._settler(self._FakeCamera(lag=0))
+        cam.applied = None
+        cam.set_exposure(400_000)
+
+        n = cam._settle_exposure(400_000, max_frames=8)
+
+        assert n == 1


### PR DESCRIPTION
The exposure sweep flushes a fixed **two** frames after each exposure change. The IMX290/462 serves exactly **three** at the old exposure, so the next capture is still stale.

Consequence, in every sweep pair:

- the raw **TIFF** is at the labelled exposure — correct
- the processed **PNG** is one sweep step behind — mislabelled
- `radiometer_sample` is taken from that capture, so it describes the PNG, not the filename

Measured on a fresh sweep:

| frame label | radiometer exposure | raw_stats median | SensorBlackLevels |
|---|---|---|---|
| 823.53 ms | **472 ms** | 997 ✓ | 3891 ✓ |
| 54.35 ms | **823 ms** | 284 ✓ | 3809 ✓ |
| 558.52 ms | **54 ms** | 748 ✓ | 3864 ✓ |
| 311.95 ms | **558 ms** | 519 ✓ | 3831 ✓ |

Each sample belongs to the *previous* step. `raw_stats` and `SensorBlackLevels` track the label correctly, so the TIFFs are fine and only the PNG side is wrong.

## Fix

A fixed count can't be right for every sensor anyway — the IMX477 emits *half-exposure* transitional frames rather than whole stale ones. So watch the driver's reported `ExposureTime` and discard until it matches, with a cap and a warning if it never settles. Backends reporting no exposure metadata (debug, none) return immediately instead of burning eight frames.

Tests cover the settle, the give-up path, the no-metadata path, and **pin the original bug** by asserting that two flushes leave the old exposure in place.

## Also: the frozen `sqm_details`

The solver starves during a sweep so that snapshot can't update — which the source already noted, but the *archive* didn't. An analyst opening `frame_metadata.json` saw one value repeated across twenty frames with `nstars: 0` and nothing marking it as a single pre-sweep sample. Each record now carries `sqm_details_frozen`, plus `settle_frames` recording how many frames the change actually took.

## Existing archives

Nothing is lost and they don't need rewriting — every artifact's true exposure is already recorded (`camera_metadata.ExposureTime` for the TIFF, `radiometer_sample.exposure_sec` for the PNG). `support/dumps/tools/relabel_sweep_exposures.py` annotates them so the pairing is explicit. Auditing 24 sweeps: **8 mismatched, 16 unverifiable** (they predate `radiometer_sample`, so there's no second exposure to check against — reported as unverifiable rather than clean, since the mismatch is likely present there too).

Worth noting for anyone re-deriving calibration from the archive: this does **not** materially affect it. Forcing solve images from the raw TIFF instead of the PNG moved a re-derived band offset by 0.004 mag, because sky background comes from the TIFF and `mzero` is a robust band-median.