### PR TITLE
perf(catalog): index catalog_objects; fixes ~1.4s stall opening object details

### DIFF
--- a/python/PiFinder/db/objects_db.py
+++ b/python/PiFinder/db/objects_db.py
@@ -26,6 +26,51 @@ class ObjectsDatabase(Database):
         self.conn.commit()
         self.bulk_mode = False  # Flag to disable commits during bulk operations
 
+        self._ensure_catalog_object_indexes()
+
+    def _ensure_catalog_object_indexes(self) -> None:
+        """
+        Backfills the catalog_objects indexes on an already-built database.
+
+        create_tables() only runs during catalog import, so the objects.db
+        shipped with an install (and every one built before those indexes
+        existed) has none. Building them takes ~100ms once; thereafter the
+        sqlite_master check below costs a fraction of a millisecond, so this is
+        safe to run on every open.
+
+        Failure is not fatal: several processes open this DB and may race for
+        the write lock, and the DB may sit on read-only media. Either way the
+        queries still return correct results -- just slowly, exactly as before
+        -- so we log and carry on rather than taking startup down with us.
+        """
+        try:
+            present = self.cursor.execute(
+                """
+                select count(*) as n from sqlite_master
+                where type = 'index' and name in (
+                    'idx_catalog_objects_object_id',
+                    'idx_catalog_objects_code_sequence'
+                )
+                """
+            ).fetchone()["n"]
+            if present == 2:
+                return
+
+            logging.info("Building catalog_objects indexes (one time)...")
+            start = time.time()
+            # Another process may be building them right now; wait rather than
+            # failing outright.
+            self.cursor.execute("PRAGMA busy_timeout = 30000;")
+            self.create_catalog_object_indexes()
+            self.conn.commit()
+            logging.info("Built catalog_objects indexes in %.1fs", time.time() - start)
+        except Exception:
+            logging.warning(
+                "Could not build catalog_objects indexes; "
+                "catalog lookups will be slower",
+                exc_info=True,
+            )
+
     def create_tables(self):
         # Create objects table
         self.cursor.execute(
@@ -96,6 +141,8 @@ class ObjectsDatabase(Database):
         """
         )
 
+        self.create_catalog_object_indexes()
+
         # Create images_objects table
         self.cursor.execute(
             """
@@ -110,6 +157,31 @@ class ObjectsDatabase(Database):
 
         # Commit changes to the database
         self.conn.commit()
+
+    def create_catalog_object_indexes(self) -> None:
+        """
+        Creates the catalog_objects lookup indexes.
+
+        Both directions of the sky-object <-> catalog-listing mapping are hot
+        paths: get_catalog_objects_by_object_id() (an object's sibling
+        listings, e.g. M 31 / NGC 224) and get_catalog_object_by_sequence()
+        (resolving a listing back to its sky object, as the observed-objects
+        cache does for every logged listing). Unindexed, each is a full scan of
+        ~151k rows -- ~6ms on a laptop and far worse on a Pi's SD card, paid
+        per call.
+        """
+        self.cursor.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_catalog_objects_object_id
+            ON catalog_objects(object_id);
+            """
+        )
+        self.cursor.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_catalog_objects_code_sequence
+            ON catalog_objects(catalog_code, sequence);
+            """
+        )
 
     def get_pifinder_database(self) -> Tuple[Connection, Cursor]:
         return self.get_database(utils.pifinder_db)

--- a/python/PiFinder/db/objects_db.py
+++ b/python/PiFinder/db/objects_db.py
@@ -32,11 +32,16 @@ class ObjectsDatabase(Database):
         """
         Backfills the catalog_objects indexes on an already-built database.
 
-        create_tables() only runs during catalog import, so the objects.db
-        shipped with an install (and every one built before those indexes
-        existed) has none. Building them takes ~100ms once; thereafter the
-        sqlite_master check below costs a fraction of a millisecond, so this is
-        safe to run on every open.
+        The shipped objects.db carries these indexes, so this is normally a
+        no-op. It exists for the databases that don't come from the shipped
+        file: ones built by a catalog import predating the indexes, or carried
+        across an update that replaces code without replacing the DB.
+        create_tables() only runs at import time, so nothing else would ever
+        add them.
+
+        Building them takes ~100ms once; thereafter the sqlite_master check
+        below costs a fraction of a millisecond, so this is safe to run on
+        every open.
 
         Failure is not fatal: several processes open this DB and may race for
         the write lock, and the DB may sit on read-only media. Either way the

--- a/python/tests/test_catalog_object_indexes.py
+++ b/python/tests/test_catalog_object_indexes.py
@@ -1,0 +1,135 @@
+"""Tests for the catalog_objects lookup indexes.
+
+Both directions of the sky-object <-> catalog-listing mapping are hot paths:
+an object's sibling listings (get_catalog_objects_by_object_id) and a listing
+resolved back to its sky object (get_catalog_object_by_sequence, which the
+observed-objects cache runs for every logged listing). Unindexed, each is a
+full scan of ~151k rows, paid per call.
+
+create_tables() only runs during catalog import, so a shipped objects.db has
+whatever indexes existed when it was built. _ensure_catalog_object_indexes()
+backfills them on open, and must stay quiet and non-fatal when it can't.
+"""
+
+import sqlite3
+
+import pytest
+
+from PiFinder.db.objects_db import ObjectsDatabase
+
+INDEX_NAMES = {
+    "idx_catalog_objects_object_id",
+    "idx_catalog_objects_code_sequence",
+}
+
+
+def _make_db(tmp_path, with_indexes: bool):
+    """An objects.db with the catalog_objects table, indexed or not —
+    standing in for a freshly built DB vs. one shipped before the indexes
+    existed."""
+    path = tmp_path / "objects.db"
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE catalog_objects (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            object_id INTEGER,
+            catalog_code TEXT,
+            sequence INTEGER,
+            description TEXT
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO catalog_objects (object_id, catalog_code, sequence, description)"
+        " VALUES (?, ?, ?, ?)",
+        [(42, "M", 31, "Andromeda"), (42, "NGC", 224, ""), (77, "NGC", 7000, "")],
+    )
+    if with_indexes:
+        conn.execute(
+            "CREATE INDEX idx_catalog_objects_object_id ON catalog_objects(object_id)"
+        )
+        conn.execute(
+            "CREATE INDEX idx_catalog_objects_code_sequence"
+            " ON catalog_objects(catalog_code, sequence)"
+        )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _indexes(path) -> set:
+    conn = sqlite3.connect(path)
+    try:
+        return {
+            row[0]
+            for row in conn.execute(
+                "select name from sqlite_master"
+                " where type = 'index' and tbl_name = 'catalog_objects'"
+            )
+        }
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_indexes_backfilled_on_open(tmp_path):
+    """A DB built before the indexes existed gets them on first open."""
+    path = _make_db(tmp_path, with_indexes=False)
+    assert _indexes(path) == set()
+
+    ObjectsDatabase(db_path=path)
+
+    assert INDEX_NAMES <= _indexes(path)
+
+
+@pytest.mark.unit
+def test_open_is_idempotent(tmp_path):
+    """Opening an already-indexed DB leaves it alone and doesn't raise."""
+    path = _make_db(tmp_path, with_indexes=True)
+
+    ObjectsDatabase(db_path=path)
+    ObjectsDatabase(db_path=path)
+
+    assert INDEX_NAMES <= _indexes(path)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "query, expected_index",
+    [
+        (
+            "select * from catalog_objects where object_id = 42",
+            "idx_catalog_objects_object_id",
+        ),
+        (
+            "select * from catalog_objects"
+            " where catalog_code = 'NGC' and sequence = 224",
+            "idx_catalog_objects_code_sequence",
+        ),
+    ],
+)
+def test_lookups_use_an_index(tmp_path, query, expected_index):
+    """Both hot-path lookups plan as an index search, not a table scan."""
+    path = _make_db(tmp_path, with_indexes=False)
+    db = ObjectsDatabase(db_path=path)
+
+    plan = " ".join(
+        row["detail"] for row in db.cursor.execute(f"explain query plan {query}")
+    )
+
+    assert expected_index in plan
+    assert "SCAN" not in plan
+
+
+@pytest.mark.unit
+def test_unbuildable_indexes_are_not_fatal(tmp_path, caplog):
+    """A DB we can't index still opens — lookups are slow, not broken."""
+    path = tmp_path / "objects.db"
+    sqlite3.connect(path).close()  # no catalog_objects table to index
+
+    db = ObjectsDatabase(db_path=path)
+
+    assert db.conn is not None
+    assert _indexes(path) == set()
+    assert "catalog lookups will be slower" in caplog.text


### PR DESCRIPTION
## The regression

Opening an object's details from the object list stalls the UI for **~1.4s** on a machine far faster than a Pi. Found while testing the 2.6.1 staging on `main`.

Instrumented in the running app against a real 202-log database:

```
PROBE ObservationsDatabase() ctor: 1398 ms (202 logged listings)
PROBE update_object_info():          12 ms
… 1220 / 1224 / 1255 ms on repeat opens
```

All the text layout, contrast reserve and image loading together account for ~11ms. The entire cost is the `ObservationsDatabase` constructor.

## Root cause

Two things combine, neither a bug alone.

**1. `catalog_objects` has never been indexed.** `create_tables()` adds indexes for `names` but not for `catalog_objects`, so both directions of the sky-object ↔ catalog-listing mapping full-scan ~151k rows:

```
… where object_id = ?                      -> SCAN catalog_objects   (6.5 ms/call)
… where catalog_code = ? and sequence = ?  -> SCAN catalog_objects   (6.3 ms/call)
```

**2. #528 moved one of those scans into a per-logged-listing loop.** `load_observed_objects_cache()` used to be a single query against the small `obs_objects` table. It now resolves every logged listing to its object id:

```python
for catalog, sequence in self.observed_objects_cache:
    object_id = self._resolve_object_id(catalog, sequence)   # full table scan, each time
```

`UIObjectDetails.__init__` constructs a fresh `ObservationsDatabase()` on every open (it always has; `show_object_details` doesn't mark the module `stateful`), and that constructor calls `load_observed_objects_cache()` unconditionally. So opening object details costs **one full scan of a 151k-row table per logged observation**.

Exactly linear at ~7.7ms per logged object:

| logged listings | stall |
|---|---|
| 0 | 0 ms |
| 10 | 77 ms |
| 50 | 378 ms |
| 100 | 763 ms |
| 202 | 1565 ms |

An empty log shows no regression at all, which is why this surfaced only now — it gets steadily worse the more the user observes. The equivalent cache load in v2.6.0 measures **1.2ms**.

## The fix

Add both indexes.

- `create_tables()` covers databases built by the catalog import pipeline.
- That only runs at import time, so `_ensure_catalog_object_indexes()` backfills already-shipped databases on open. ~100ms once; thereafter the `sqlite_master` check is sub-millisecond. Deliberately non-fatal — several processes open this DB and can race for the write lock, and it may sit on read-only media — since failure just means today's slow-but-correct plans.

- `astro_data/pifinder_objects.db` is rebuilt with both indexes and committed, so users get the fix on update without paying the one-time build and a fresh flash is fast from first launch. The file grows 60.2MB -> 61.0MB (+1.4%), ~25MB compressed into a `.git` that is already 16GB. No `VACUUM` — it would rewrite every page for no functional gain. Verified after the build: `PRAGMA integrity_check` ok, `foreign_key_check` ok, row counts unchanged (151170 `catalog_objects`, 149329 `objects`).

With the DB shipped indexed, `_ensure_catalog_object_indexes()` is a no-op on a normal install (confirmed — no build logged, open costs ~3ms). It stays for the databases that don't come from the shipped file: ones built by a catalog import predating the indexes, or carried across an update that replaces code without replacing the DB.

## Verification

Re-instrumented the app, launched from an unindexed DB exactly as a user would have:

```
PROBE ObservationsDatabase() ctor: 3 ms (202 logged listings)
PROBE ObservationsDatabase() ctor: 2 ms (202 logged listings)
PROBE ObservationsDatabase() ctor: 3 ms (202 logged listings)
PROBE ObservationsDatabase() ctor: 2 ms (202 logged listings)
```

**1398 ms → 2-3 ms.** Resolved object ids unchanged (177 of 202), so #528's sky-object semantics are untouched. Query plans now `SEARCH … USING INDEX` in both directions.

The same stall was also paid on **every startup** (`catalogs.py:929`, which loads the cache twice) and on entering the **LOG screen** (`ui/log.py:43`); both are fixed by the same indexes.

## Checks

- `nox -s lint format type_hints` — clean (mypy: 147 files, no issues)
- `pytest -m unit` — 1137 passed
- `nox -s smoke_tests` — 5 passed
- New `tests/test_catalog_object_indexes.py` — 5 passed; covers backfill on open, idempotence, both lookups planning as an index search rather than a `SCAN`, and the non-fatal path

## Follow-ups

Tracked in #565 — deliberately **not** closed by this PR, and it should stay open after merge.

The indexes remove the pain, not the shape that caused it: `UIObjectDetails` still rebuilds the whole observed-objects cache on every drill-in, and `_resolve_object_id` still runs one query per logged listing. Those two multiplying is what turned a single missing index into a 1.4s freeze, and the amplifier survives this fix. Measured after this PR the residual is ~1ms, so #565 is a robustness argument rather than a performance one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

