### PR TITLE
docs: rev4 external SD-card access (sd_card.rst)

### DIFF
--- a/docs/source/sd_card.rst
+++ b/docs/source/sd_card.rst
@@ -2,7 +2,7 @@ Swapping the SD Card
 ====================
 
 .. note::
-   This page covers rev4 and v3 PiFinders.  The microSD card holds everything the
+   This page covers rev4, v3 and v2.5 PiFinders.  The microSD card holds everything the
    PiFinder runs — the operating system, the PiFinder software, your settings,
    and the deep sky catalog images — so swapping it is how you recover from a
    corrupt card or move to a fresh or larger one.
@@ -13,9 +13,9 @@ nothing has to come apart.  This page covers getting at the card and swapping it
 To put software on the new card first, see :doc:`Software Setup <software>`.
 
 .. note::
-   On v3 PiFinders the card is inside the case, in the slot between the Raspberry
-   Pi and the power board, and the case has to come apart to reach it.  See
-   :ref:`sd_card:reaching the card on a v3 unit` below.
+   On v3 and v2.5 PiFinders the card is inside the case, in the slot between the
+   Raspberry Pi and the power board, and you have to open the case to reach it.
+   See :ref:`sd_card:reaching the card on v3 and v2.5 units` below.
 
 When you'd swap the card
 ------------------------
@@ -36,8 +36,8 @@ go dark before you touch the card — see :ref:`user_guide:shutdown`.  Pulling a
 card from a running unit can corrupt it.
 
 .. note::
-   On v3 PiFinders, switch the power off at the slide switch once the screen and
-   keypad have gone dark, before you open the case.
+   On v3 and v2.5 PiFinders, switch the power off at the slide switch once the
+   screen and keypad have gone dark, before you open the case.
 
 Swapping the card
 -----------------
@@ -51,19 +51,18 @@ don't flex it against the case.
 
 .. TODO(rich): add a rev4 photo of the side SD slot with the card part-ejected.
 
-Reaching the card on a v3 unit
-------------------------------
+Reaching the card on v3 and v2.5 units
+--------------------------------------
 
-On a v3 PiFinder the card sits inside the case, so the case has to come apart to
-reach it.  You'll need a small Phillips screwdriver.  The card sits in a friction
-slot — there's no spring to push it in or out, so you pull it straight out and
-push the new one straight in.
+On these units the card sits inside the case, so you'll need to open it up first.
+The card sits in a friction slot — there's no spring to push it in or out, so you
+pull it straight out and push the new one straight in.
 
-Opening the case
-~~~~~~~~~~~~~~~~
+Opening a v3 case
+~~~~~~~~~~~~~~~~~
 
-On every v3 unit, start by removing the three screws on the right-hand side as
-you face the screen.
+You'll need a small Phillips screwdriver.  On every v3 unit, start by removing
+the three screws on the right-hand side as you face the screen.
 
 .. image:: images/sd_card/sd_card_remove_screws.jpeg
    :width: 70%
@@ -95,12 +94,20 @@ the camera to access the sd card.
 .. image:: images/sd_card/flat_open.jpeg
    :width: 70%
 
+Opening a v2.5 case
+~~~~~~~~~~~~~~~~~~~
+
+A v2.5 unit has an access door that snaps out to expose the card — no tools
+needed.  The alternative is to undo the three faceplate screws with a small
+Phillips screwdriver and slide the whole shroud off.  Those are the faceplate
+screws, not the side screws a v3 uses.
+
 Removing and replacing the card
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The card sits in the slot between the green Raspberry Pi board and the black
-power board.  The white camera ribbon cable runs nearby — move it gently aside
-if it's in the way, taking care not to crease or unseat it.
+The card sits in the slot between the Raspberry Pi board and the power board.
+The white camera ribbon cable runs nearby — move it gently aside if it's in the
+way, taking care not to crease or unseat it.
 
 .. image:: images/sd_card/sd_card_closup.jpg
    :width: 47%
@@ -114,9 +121,9 @@ support it as you work and don't flex it against the case.
 Reassembling
 ~~~~~~~~~~~~
 
-Reverse the steps: refit the cover or holder for your configuration, check that
-the camera ribbon is sitting flat and isn't pinched, and replace the three side
-screws — snug, not forced.
+Reverse the steps you took to get in: refit the cover, holder or shroud, check
+that the camera ribbon is sitting flat and isn't pinched, and replace the three
+screws — snug, not forced.  An access door presses back into place on its own.
 
 First boot
 ----------

--- a/docs/source/sd_card.rst
+++ b/docs/source/sd_card.rst
@@ -2,15 +2,20 @@ Swapping the SD Card
 ====================
 
 .. note::
-   This procedure is for v3 PiFinders.  The microSD card holds everything the
+   This page covers rev4 and v3 PiFinders.  The microSD card holds everything the
    PiFinder runs — the operating system, the PiFinder software, your settings,
    and the deep sky catalog images — so swapping it is how you recover from a
    corrupt card or move to a fresh or larger one.
 
-The PiFinder boots from a microSD card tucked inside the case, in the slot
-between the Raspberry Pi and the power board.  This page covers getting at that
-card and swapping it.  To put software on the new card first, see
-:doc:`Software Setup <software>`.
+The PiFinder boots from a microSD card.  On rev4 that card sits in a slot on the
+side of the case, reachable from outside, so swapping it takes no tools and
+nothing has to come apart.  This page covers getting at the card and swapping it.
+To put software on the new card first, see :doc:`Software Setup <software>`.
+
+.. note::
+   On v3 PiFinders the card is inside the case, in the slot between the Raspberry
+   Pi and the power board, and the case has to come apart to reach it.  See
+   :ref:`sd_card:reaching the card on a v3 unit` below.
 
 When you'd swap the card
 ------------------------
@@ -19,23 +24,43 @@ When you'd swap the card
   :doc:`troubleshooting`).
 * You'd rather re-image onto a spare card and keep your original as a backup.
 
-Image the new card before you open the case — the
+Image the new card before you start — the
 :ref:`software:prebuilt release image` is the quickest way, and it already
 includes the catalog images.
 
 Before you start
 ----------------
 
-If the PiFinder is on, shut the PiFinder down cleanly first (Tools → Shutdown), wait for the screen and
-keypad to go dark, then switch off the power.  Pulling a card from a running unit
-can corrupt it.
+If the PiFinder is on, shut it down cleanly and wait for the screen and keypad to
+go dark before you touch the card — see :ref:`user_guide:shutdown`.  Pulling a
+card from a running unit can corrupt it.
 
-You'll need a small Phillips screwdriver.  The card sits in a friction slot —
-there's no spring to push it in or out, so you pull it straight out and push the
-new one straight in.
+.. note::
+   On v3 PiFinders, switch the power off at the slide switch once the screen and
+   keypad have gone dark, before you open the case.
+
+Swapping the card
+-----------------
+
+The card slot is on the side of the case, and it's spring-loaded.  Press the card
+in and let go — the spring pushes it part-way out — then slide it clear.  Push
+the replacement in until it clicks and stays put.
+
+The card is easy to crack once it's part-way out, so support it as you work and
+don't flex it against the case.
+
+.. TODO(rich): add a rev4 photo of the side SD slot with the card part-ejected.
+
+Reaching the card on a v3 unit
+------------------------------
+
+On a v3 PiFinder the card sits inside the case, so the case has to come apart to
+reach it.  You'll need a small Phillips screwdriver.  The card sits in a friction
+slot — there's no spring to push it in or out, so you pull it straight out and
+push the new one straight in.
 
 Opening the case
-----------------
+~~~~~~~~~~~~~~~~
 
 On every v3 unit, start by removing the three screws on the right-hand side as
 you face the screen.
@@ -48,30 +73,30 @@ sure which one you have, the :ref:`build_guide:configurations overview` has
 photos of each.
 
 Right configuration
-~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^
 
 Simply lift off the separate cover held on by the three screws to expose the card.
 
 Left configuration
-~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^
 
-For the left configuration, the three screws hold the camera assembly in place.  
-Gently tilt the camera assembly out of the way to reach the card. Be mindful of 
+For the left configuration, the three screws hold the camera assembly in place.
+Gently tilt the camera assembly out of the way to reach the card. Be mindful of
 the cable, but there should be plenty of slack.
 
 Flat configuration
-~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^
 
-The three screws hold one side of the flat cradle. Removing them allows enough flex to 
-gently pull the flat holder down to expose the card.  The image below shows this, but 
+The three screws hold one side of the flat cradle. Removing them allows enough flex to
+gently pull the flat holder down to expose the card.  The image below shows this, but
 was taken during assembly before the camera is installed.  There is no need to remove
 the camera to access the sd card.
 
 .. image:: images/sd_card/flat_open.jpeg
    :width: 70%
 
-Swapping the card
------------------
+Removing and replacing the card
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The card sits in the slot between the green Raspberry Pi board and the black
 power board.  The white camera ribbon cable runs nearby — move it gently aside
@@ -86,12 +111,15 @@ Grip the card and pull it straight out, then push the replacement straight in
 until it's fully seated.  The card is easy to crack once it's part-way out, so
 support it as you work and don't flex it against the case.
 
-Reassemble and boot
--------------------
+Reassembling
+~~~~~~~~~~~~
 
 Reverse the steps: refit the cover or holder for your configuration, check that
 the camera ribbon is sitting flat and isn't pinched, and replace the three side
 screws — snug, not forced.
+
+First boot
+----------
 
 Power the PiFinder on.  The first boot from a freshly imaged card takes longer
 than usual while it expands the filesystem to fill the card, so give it a couple


### PR DESCRIPTION
## What & why

`docs/source/sd_card.rst` was entirely a v3 procedure — three screws on the right-hand side, a Right/Left/Flat split for getting in, and a card wedged between the Raspberry Pi and the power board with the camera ribbon in the way.

On **rev4** the microSD card is externally accessible in a spring-loaded slot on the side of the case (confirmed by Rich, 2026-08-06). There is no disassembly at all: press the card in to release it, slide it out, push the replacement in until it clicks.

**This page was not one of the plan's WP1–WP4.** It came into scope when Rich answered `rev4-docs-update-plan.md` §8 open question #6 ("does the rev4 case differ enough to need new SD-card coverage?") with **yes**.

## How the page was restructured

Per **D1** (rev4 is the default voice):

- **Top note** now scopes the page to "rev4, v3 and v2.5 PiFinders" instead of "for v3 PiFinders", keeping the existing explanation of what lives on the card.
- **Intro** leads with rev4: the card is in a slot on the side of the case, reachable from outside, no tools and nothing to come apart. A short `.. note::` points v3 and v2.5 owners at their section.
- **"Swapping the card"** is now the rev4 procedure — press in, spring pushes it part-way out, slide clear, push the replacement in until it clicks. The "easy to crack once part-way out" caution is kept.
- **"Reaching the card on v3 and v2.5 units"** is a new scoped section carrying *all* the previous v3 material, unchanged in substance: the Phillips screwdriver, the friction slot (no spring), the three side screws + photo, the Right / Left / Flat sub-sections, the between-the-boards close-ups, the camera-ribbon caution, and the reassembly step ("snug, not forced"). A v3 owner loses nothing.
- **"First boot"** is split out of the old "Reassemble and boot" so the universal part (longer first boot, filesystem expansion) is not buried inside older-hardware material. The `.. important::` Camera Type block is unchanged.
- Fixed blanket claims flagged in the brief: "tucked inside the case" (intro), "You'll need a small Phillips screwdriver" / "The card sits in a friction slot" (tooling), "replace the three side screws" (reassembly) — all now scoped.
- The existing `:ref:` to `build_guide:configurations overview` is preserved. `build_guide.rst` itself is untouched (**D4**).

A scoped *section* was used rather than a `.. note::` because the older-hardware material runs to ~70 lines with several sub-sections — the `.. note::` shape in D1 is for short divergences. The rev4 path still comes first and is not buried.

The old "shut down cleanly (Tools → Shutdown) … then switch off the power" line was a blanket claim that no longer holds on rev4. It now defers to `:ref:`user_guide:shutdown`` for the gesture, with the "switch the power off at the slide switch" step kept in a note scoped to v3/v2.5 — so this page won't collide with WP1's rewrite of the power/shutdown story.

## v2.5 (added after Rich's follow-up)

Rich confirmed the v2.5 route, which is **not** the v3 one: an **access door that snaps out** to expose the card (no tools), or undo the **three faceplate screws** and slide the whole shroud off. It gets its own short `Opening a v2.5 case` subsection alongside `Opening a v3 case`, sharing the "Removing and replacing the card" and "Reassembling" steps.

Two things the wording is careful about:

- The v3 **Right/Left/Flat split does not apply to v2.5**. Those three sub-sections are nested *inside* `Opening a v3 case`, and nothing in the v2.5 subsection implies a configuration-dependent route.
- The **faceplate screws are not the v3 side screws**, and the text says so explicitly so nobody conflates the two sets.

## Written around, not invented

Rich's statements were two sentences, so the prose deliberately avoids: which side of the case the rev4 slot is on relative to the screen, whether it has a cover or flap, whether it is labelled, card orientation (contacts up/down), and **which side the v2.5 access door is on**. None of that is stated or implied. The shared "Removing and replacing the card" text also dropped the v3-specific board colours ("the green Raspberry Pi board and the black power board") now that it covers v2.5 as well — the photos still show them.

## TODO left in the file

```rst
.. TODO(rich): add a rev4 photo of the side SD slot with the card part-ejected.
```

That is the only `TODO(rich)` in the change. The rev4 section is written to be useful without a photo.

## Photo needed

Plan §6 item **#13** — *rev4 case SD-card access* — is now confirmed as needed and only Rich can shoot it: the side slot with the card part-ejected. No placeholder image path is referenced (Sphinx warns on unreadable images and the build must stay clean).

There is an **untracked** `docs/source/images/sd_card/sd_card_side.jpeg` in Rich's working copy. It is not committed, so it isn't in this branch and isn't referenced — but it may well be the shot this page needs. If it is, dropping it in and adding an `.. image::` where the TODO sits finishes the section.

A v2.5 photo (the access door, and/or the faceplate screws) would help too, but the subsection reads fine without one and no placeholder is referenced.

## Suggested elsewhere, not made here (other agents own those files)

- **"Which PiFinder do I have?"** — once WP3 lands that section in `quick_start.rst`, this page's scope note is a natural place to `:ref:` it. Not linked here because the target doesn't exist yet and would break the nitpicky build.
- `troubleshooting.rst:52` names SD-card corruption as the most common boot failure but doesn't link here; a `:doc:`sd_card`` would help. Left to the troubleshooting agent.

## Build

```
cd docs && sphinx-build -b html -n source /tmp/pifinder_docs_build_sdcard2
```

Full rebuild into an empty directory with the prebuilt docs venv (Sphinx 7.2.6 + mermaid): **build succeeded, zero warnings in nitpicky mode.** The `.. TODO(rich):` comment renders as a comment and does not leak into the HTML; the heading ladder renders h1 → h2 → h3 → h4 as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
