### PR TITLE
docs: add the two missing rev4 cross-links

### DIFF
--- a/docs/source/sd_card.rst
+++ b/docs/source/sd_card.rst
@@ -2,7 +2,9 @@ Swapping the SD Card
 ====================
 
 .. note::
-   This page covers rev4, v3 and v2.5 PiFinders.  The microSD card holds everything the
+   This page covers rev4, v3 and v2.5 PiFinders, and the procedure differs on each.  If
+   you're not sure which one you have, the :ref:`quick_start:which pifinder do i have?`
+   section of the Quick Start tells them apart.  The microSD card holds everything the
    PiFinder runs — the operating system, the PiFinder software, your settings,
    and the deep sky catalog images — so swapping it is how you recover from a
    corrupt card or move to a fresh or larger one.

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -60,10 +60,10 @@ If the screen is still blank, the keypad backlight tells you where the problem i
 
 - **No keypad light and no screen** (a faint red LED inside the case means the Pi has
   power but isn't booting): this is almost always **SD card corruption**, the most common
-  hardware issue.  Re-image the card with the latest release, or request a fresh one.  SD
-  card faults are all-or-nothing — they stop the PiFinder booting rather than causing
-  subtle misbehaviour, so don't re-image to explain slow solves or the occasional position
-  jump.
+  hardware issue.  Re-image the card with the latest release, or request a fresh one
+  (:doc:`sd_card` covers getting at the card on each revision).  SD card faults are
+  all-or-nothing — they stop the PiFinder booting rather than causing subtle misbehaviour,
+  so don't re-image to explain slow solves or the occasional position jump.
 - **Keypad lights up, but the screen is blank or garbled**: that points to the screen's
   connection, not the software.  Confirm it through the
   :ref:`web interface <connectivity:web interface>` — if the remote screen looks correct


### PR DESCRIPTION
Follow-up to the rev4 documentation pass (#574–#578). Two cross-links whose
targets did not exist when the pass ran — each was spotted by an agent that
correctly declined to reach outside its assigned files.

### The links

**`troubleshooting.rst`** — the *"No keypad light and no screen"* bullet tells the
reader their problem is almost always **SD card corruption**, then leaves them
with nowhere to go. It now links to :doc:`sd_card`, so a reader who has just been
told their card is corrupt can reach the swap procedure.

**`sd_card.rst`** — the page now covers three revisions with materially different
procedures (rev4 side slot, v3 three side screws, v2.5 door-or-faceplate), so an
owner has to know which unit they have *before* picking one. The scope note now
points at *Which PiFinder do I have?* in the Quick Start.

### Scope

Deliberately tight: two links, no prose rewrites. The only added wording is the
clause that motivates each link ("the procedure differs on each", "covers getting
at the card on each revision").

### Verification

Full Sphinx build into an empty dir, nitpicky mode, **zero warnings**:

```
sphinx-build -b html -n -E -q docs/source <empty-outdir>
```

Both references were checked in the generated HTML rather than assumed:
`troubleshooting.html` → `sd_card.html`, and `sd_card.html` →
`quick_start.html#which-pifinder-do-i-have`, an anchor that exists.

Photo work from the same handoff (six `TODO(rich)` markers) is **not** in this PR
— it is gated on Rich supplying the photographs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)