### PR TITLE
docs: convert the catalogs page to the house style

### DIFF
--- a/docs/source/catalogs.rst
+++ b/docs/source/catalogs.rst
@@ -2,14 +2,14 @@
 PiFinder™ Catalogs
 ===================
 
-The PiFinder ships with several astronomical catalogs you can search and filter.
-Each carries a short catalog code shown on the UI. Choose which catalogs are
-active in the :ref:`Filters<user_guide:filters>` menu.
+The PiFinder includes several astronomical catalogs that you can search and
+filter. Each has a short catalog code that appears on the screen. Select which
+catalogs are active in the :ref:`Filters<user_guide:filters>` menu.
 
-A few catalogs — the Washington Double Star catalog especially — hold far too many
+A few catalogs, especially the Washington Double Star catalog, hold far too many
 entries to scroll. For those, use **Name Search** to jump to an object by its
-designation, or sort by **Nearest** to surface the objects closest to where your
-scope is pointed.
+designation, or sort by **Nearest** to show the objects closest to where your
+telescope points.
 
 Abl
 ----
@@ -17,7 +17,7 @@ The Abell Catalog of Planetary Nebulae (George O. Abell, 1966): 79 confirmed pla
 
 Arp
 ----
-Atlas of Peculiar Galaxies (Arp 1966). Galaxies with unusual morphology. See `Wikipedia - Atlas of Peculiar Galaxies <https://en.wikipedia.org/wiki/Atlas_of_Peculiar_Galaxies>`_
+Atlas of Peculiar Galaxies (Arp 1966). Galaxies with unusual shapes. See `Wikipedia - Atlas of Peculiar Galaxies <https://en.wikipedia.org/wiki/Atlas_of_Peculiar_Galaxies>`_.
 
 B
 ----
@@ -33,7 +33,7 @@ Col
 
 EGC
 ----
-Catalog of Extra-Galactic Globular Clusters: globulars associated with nearby galaxies, mostly in Andromeda, visible through modest amateur telescopes.
+Catalog of Extra-Galactic Globular Clusters: globular clusters associated with nearby galaxies, mostly in Andromeda, visible through modest amateur telescopes.
 
 H
 ----------
@@ -49,7 +49,7 @@ IC catalog
 
 Lyn
 ----
-Open Cluster Data, 5th Edition (Lyngå 1987) — 1,151 open clusters.
+Open Cluster Data, 5th Edition (Lyngå 1987): 1,151 open clusters.
 
 M
 ----------
@@ -61,7 +61,7 @@ NGC 2000.0, The Complete New General Catalogue and Index Catalogue of Nebulae an
 
 RDS
 ----
-The RASC Double Stars Observing Program: 110 double-star targets visible from the northern hemisphere across many constellations.
+The RASC Double Stars Observing Program: 110 double stars visible from the northern hemisphere across many constellations.
 
 SaA
 ----------
@@ -81,7 +81,7 @@ Sh2
 
 Str
 ----
-Named bright stars. Especially useful for aligning GoTo scopes.
+Named bright stars. Especially useful for aligning GoTo telescopes.
 
 Ta2
 ----------
@@ -94,7 +94,7 @@ TLK's hand-picked list of interesting variable stars visible from the northern h
 WDS
 ----
 The PiFinder includes over 130,000 double and multiple star pairs from the
-Washington Double Star Catalog. The full list is far too long to scroll, so find
-a pair with **Name Search** (type its WDS designation) or sort by **Nearest** to
-bring up the doubles closest to where your scope is pointing.
-For more on WDS, see `https://www.astro.gsu.edu/wds/ <https://www.astro.gsu.edu/wds/>`_
+Washington Double Star Catalog. The full list is far too long to scroll. Find a
+pair with **Name Search** by typing its WDS designation, or sort by **Nearest**
+to show the doubles closest to where your telescope points.
+For more on WDS, see `https://www.astro.gsu.edu/wds/ <https://www.astro.gsu.edu/wds/>`_.


### PR DESCRIPTION
Full simplified technical English pass over `docs/source/catalogs.rst`, using the `docs` skill's seven rules and approved-term table. Part of the manual-wide conversion, one PR per file.

## Measured change

```
  PASS  docs/source/catalogs.rst
     em-dash 3->0 | semicolon 0->0 | banned 3->1 | words 422->418 (-1%)
     terms: choose 1->0, target 1->0
OVERALL: PASS
```

## What the converting agent reported

```
EM_DASHES: 3 occurrences -> 0
SEMICOLONS: 0 -> 0
TERMS: scope->telescope x3; "double-star targets"->"double stars"; Choose->Select;
  "shown on the UI"->"appears on the screen"; globulars->globular clusters;
  "unusual morphology"->"unusual shapes"; surface/bring up -> show (one verb)
STRUCTURAL: intro em-dash aside -> commas; Lyn em-dash -> colon, matching the
  count-after-colon form already used by Abl/EGC/RDS/SaM/Ta2 on this page;
  WDS comma-splice split, second sentence now starts with "Find"
LEFT_ALONE: all headings and underline run-lengths; every catalog name, version,
  count, date and attribution; U+2212 minus signs in declinations (not dashes);
  passives with a named or irrelevant actor ("compiled by Per Collinder")
FACT_CONCERNS: "Str" is described as "Named bright stars" but is the only entry
  in the list with no published source named
```

## Safety

Style only. No facts, numbers, procedures or step order were changed.

Verified mechanically against `origin/main` that every heading (text *and* underline character), every `:ref:`, `:doc:`, image path, substitution, `include::` and external URL is unchanged. Headings matter because `autosectionlabel` turns each one into a cross-reference target that other pages depend on, and a rename would break them silently.

Sphinx builds clean under `-n` (nitpicky).

Any `FACT_CONCERNS` above were deliberately **not** fixed. They are reported for a maintainer decision, since changing them would be a content edit rather than a style one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqTCarGCgTRWBQ1ysG8XFD
