### PR TITLE
docs: convert the equipment page to the house style

### DIFF
--- a/docs/source/equipment.rst
+++ b/docs/source/equipment.rst
@@ -2,72 +2,74 @@ Equipment
 =========
 
 The PiFinder can track the telescopes and eyepieces you observe with. Telling
-it about your gear is optional, but it unlocks several conveniences: it works
-out the magnification and true field of view for any telescope-and-eyepiece
-pairing, sizes and orients the survey images on the
-:ref:`user_guide:object details` screen to match the eyepiece view, and lets
-the push-to arrows follow the way your setup moves.
+it about your gear is optional, but it adds several conveniences. The PiFinder
+works out the magnification and true field of view for any
+telescope-and-eyepiece pairing. It sizes and orients the survey images on the
+:ref:`user_guide:object details` screen to match the eyepiece view. It also
+lets the push-to arrows follow the way your setup moves.
 
-You manage equipment from two places: the :ref:`connectivity:web interface` is
-where you add and edit telescopes and eyepieces, and the Equipment screen on the
-PiFinder is where you pick which ones are active for tonight's session.
+You manage equipment from two places. Use the :ref:`connectivity:web interface`
+to add and edit telescopes and eyepieces. Use the Equipment screen on the
+PiFinder to select which ones are active for tonight's session.
 
 Telescopes and eyepieces
 ------------------------
 
-A **telescope** records the optical details of one instrument: make and name,
-aperture, focal length, central obstruction, and mount type, plus a few display
-options covered below. Aperture and focal length drive the magnification and
-field-of-view calculations.
+A **telescope** records the optical details of one instrument. It stores the
+make and name, aperture, focal length, central obstruction, and mount type,
+plus a few display options covered below. The PiFinder uses the aperture and
+focal length for the magnification and field-of-view calculations.
 
-An **eyepiece** records its focal length and apparent field of view, plus the
-field stop if you know it, which gives a more precise field-of-view figure.
-Store as many of each as you like and switch between them as the night goes on.
+An **eyepiece** records its focal length and apparent field of view. Add the
+field stop as well if you know it, because it gives a more precise
+field-of-view figure. Store as many of each as you like and switch between them
+as the night goes on.
 
 Adding and editing your gear
 ----------------------------
 
 Add telescopes and eyepieces through the :ref:`connectivity:web interface`.
 Connect to the PiFinder as described there, then open the Equipment page from
-the navigation menu. You'll find a list of telescopes and a list of eyepieces,
-each with buttons to add, edit, or remove an item.
+the navigation menu. The page shows a list of telescopes and a list of
+eyepieces. Each list has buttons to add, edit, or remove an item.
 
 A new PiFinder starts with a generic 200mm Dobsonian and a small set of Plössl
-eyepieces so the calculations work out of the box. Edit or replace these with
-your own gear whenever you're ready.
+eyepieces, so the calculations work from the start. Edit or replace these with
+your own gear when you are ready.
 
 .. note::
-   The on-device Equipment menu builds its list of telescopes and eyepieces
-   when the PiFinder starts up. If you add new gear in the web interface while
-   the PiFinder is running, restart the PiFinder so the new items appear in the
-   on-device selection lists.
+   The Equipment menu on the PiFinder builds its list of telescopes and
+   eyepieces when you turn the PiFinder on. If you add new gear in the web
+   interface while the PiFinder is running, restart the PiFinder so the new
+   items appear in its selection lists.
 
 Choosing your active telescope and eyepiece
 -------------------------------------------
 
 The PiFinder uses one **active** telescope and one **active** eyepiece at a time
-for its calculations and displays. Set these from either place:
+for its calculations and for what it shows on the screen. Set them from either
+place:
 
 * **On the PiFinder**, open the :ref:`user_guide:tools` menu and select
-  Equipment. The Equipment screen shows the active telescope and eyepiece and,
-  when both are set, the resulting magnification and true field of view. Choose
-  "Telescope..." or "Eyepiece..." to pick from your stored gear.
-* **In the web interface**, use the Equipment page to mark a telescope or
+  Equipment. The Equipment screen shows the active telescope and eyepiece. When
+  both are set, it also shows the resulting magnification and true field of
+  view. Select "Telescope..." or "Eyepiece..." to change either one.
+* **In the web interface**, open the Equipment page and mark a telescope or
   eyepiece active.
 
 .. image:: images/equipment/equipment_screen_docs.png
 
-Choosing "Telescope..." or "Eyepiece..." opens a list of your stored gear, a
-check mark beside the active one. Use the **UP/DOWN** arrows to highlight an
-item and **RIGHT** to make it active.
+Select "Telescope..." or "Eyepiece..." to open a list of your stored gear. A
+check mark sits beside the active item. Press the **UP** and **DOWN** arrows to
+highlight an item, then press **RIGHT** to make it active.
 
 .. image:: images/equipment/select_telescope_docs.png
    :width: 45%
 .. image:: images/equipment/select_eyepiece_docs.png
    :width: 45%
 
-If nothing is selected, the PiFinder skips the magnification and field-of-view
-figures and shows the object image in its default orientation.
+With no active telescope or eyepiece, the PiFinder skips the magnification and
+field-of-view figures. It shows the object image in its default orientation.
 
 Magnification and true field of view
 -------------------------------------
@@ -78,39 +80,39 @@ Equipment screen:
 * **Magnification** is the telescope's focal length divided by the eyepiece's.
   A 1000mm telescope with a 25mm eyepiece gives 40×.
 * **True field of view** (TFOV) is how much sky you see through that
-  combination, in degrees. Compare it against the push-to distance: when the
-  object is within half your true field of view of the centre, it's in the
+  combination, in degrees. Compare it against the push-to distance. When the
+  object is within half your true field of view of the centre, it is in the
   eyepiece.
 
 The true field of view also sets the starting zoom of the survey image on the
 :ref:`user_guide:object details` screen, so the image frames roughly the same
-patch of sky your eyepiece shows. Zoom in and out from there with the **+** and
-**-** keys.
+patch of sky your eyepiece shows. Press **+** and **-** to zoom in and out from
+there.
 
-Both figures appear on the object image too — field of view in the top-left
-corner, magnification in the top-right — so you always know the scale of what
-you're looking at.
+Both figures also appear on the object image. The field of view sits in the
+top-left corner and the magnification in the top-right, so you always know the
+scale of what you are looking at.
 
 .. image:: images/equipment/object_image_fov_mag_docs.png
 
 Matching the object image to your eyepiece: flip and flop
 ---------------------------------------------------------
 
-The survey images on the object details screen are oriented to match your
-eyepiece view, so you can compare them directly. Different telescopes flip the
-view in different ways, so two per-telescope options let you correct the
+The PiFinder orients the survey images on the object details screen to match
+your eyepiece view, so you can compare them directly. Different telescopes flip
+the view in different ways. Two per-telescope options let you correct the
 orientation:
 
 * **Flip image (upside down)** mirrors the image top to bottom.
 * **Flop image (left right)** mirrors the image left to right.
 
-You don't need to reason about your optics. Point at a bright, recognisable
-object, compare the object image to your eyepiece view, and toggle the two
-options until they match:
+You do not need to reason about your optics. Point the telescope at a bright,
+recognisable object. Compare the object image to your eyepiece view, then set
+the two options until they match:
 
 * If the image is **upside down** compared to the eyepiece, turn on **Flip**.
 * If the image is **mirrored** left-to-right, turn on **Flop**.
-* If it's both, turn on both.
+* If it is both, turn on both.
 
 As a starting point for common setups:
 
@@ -128,16 +130,16 @@ As a starting point for common setups:
      - off
      - off
    * - Refractor or SCT with a star diagonal
-     - one of the two — try Flop first
+     - Turn on one of the two. Try Flop first
      -
    * - Refractor with a correct-image (erecting) diagonal
      - on
      - on
 
 A plain Newtonian or Dobsonian needs neither option, which is why both are off
-by default. A star diagonal produces a mirror image, so you'll need exactly one
-of Flip or Flop; which one depends on how the diagonal sits in the focuser, so
-pick whichever makes the image match.
+by default. A star diagonal produces a mirror image, so you need exactly one of
+Flip or Flop. Which one depends on how the diagonal sits in the focuser, so
+turn on whichever makes the image match.
 
 .. note::
    Early PiFinder software shipped the default Dobsonian with Flop turned on by
@@ -147,9 +149,9 @@ pick whichever makes the image match.
 Reversing the push-to arrows
 ----------------------------
 
-The same telescope settings include **Reverse Arrow A** and **Reverse Arrow B**,
-which flip the push-to arrows so they point the way your telescope actually
-moves. If nudging the scope in the direction an arrow points sends the target
-further away instead of closer, turn on the matching reverse option. The two
-arrows cover the two directions of movement, so enable A, B, or both until the
-arrows guide you the right way.
+The same telescope settings include **Reverse Arrow A** and **Reverse Arrow B**.
+These flip the push-to arrows so they point the way your telescope actually
+moves. If you nudge the telescope in the direction an arrow points and the
+object moves further away instead of closer, turn on the matching reverse
+option. The two arrows cover the two directions of movement, so turn on A, B,
+or both until the arrows guide you the right way.

--- a/docs/source/equipment.rst
+++ b/docs/source/equipment.rst
@@ -17,8 +17,9 @@ Telescopes and eyepieces
 
 A **telescope** records the optical details of one instrument. It stores the
 make and name, aperture, focal length, central obstruction, and mount type,
-plus a few display options covered below. The PiFinder uses the aperture and
-focal length for the magnification and field-of-view calculations.
+plus a few display options covered below. The PiFinder uses the focal length for
+the magnification and field-of-view calculations, and the aperture for the
+:ref:`contrast reserve <user_guide:contrast reserve>`.
 
 An **eyepiece** records its focal length and apparent field of view. Add the
 field stop as well if you know it, because it gives a more precise


### PR DESCRIPTION
Full simplified technical English pass over `docs/source/equipment.rst`, using the `docs` skill's seven rules and approved-term table. Part of the manual-wide conversion, one PR per file.

## Measured change

```
  PASS  docs/source/equipment.rst
     em-dash 3->0 | semicolon 1->0 | banned 8->2 | words 1003->1042 (+4%)
     terms: choose 3->1, pick 3->0, target 1->0
OVERALL: PASS
```

## What the converting agent reported

```
EM_DASHES: 3 -> 0   (paired aside -> two sentences; table cell -> two sentences)
SEMICOLONS: 1 -> 0
TERMS: scope->telescope; target->object; pick/choose->select x3; "displays"(noun)
  -> "what it shows on the screen"; "starts up"->"turn the PiFinder on";
  arrow-key phrasing -> approved gesture form; enable->turn on; toggle->set
STRUCTURAL: 9 sentence splits, no reordering, no sections added or removed.
  Intro colon-plus-three-clauses -> four sentences. Passive "images are oriented"
  -> "The PiFinder orients the survey images".
LEFT_ALONE: all 6 headings byte-identical, including "Choosing your active
  telescope and eyepiece" (kept despite "Choosing", because it is an
  autosectionlabel target). All formulas and worked examples (1000mm/25mm = 40x),
  the full flip/flop table, all 4 image paths, all 5 :ref: targets, British
  spellings, and every on-screen label. "display options" kept: it means the
  per-telescope Flip/Flop options, not the screen.
FACT_CONCERNS: the page says aperture drives the magnification and
  field-of-view calculations. Magnification is telescope focal length / eyepiece
  focal length, and TFOV follows from those plus apparent field of view, as this
  same page states two sections later. Aperture appears to feed neither.
  Preserved verbatim in meaning; needs a maintainer decision, not a style fix.
```

## Content changes (added after review)

The `FACT_CONCERNS` note above is now fixed, on the maintainer's decision.

The page credited aperture for the magnification and field-of-view
calculations. It feeds neither. In `python/PiFinder/equipment.py`,
`calc_magnification` is telescope focal length / eyepiece focal length, and
`calc_tfov` is apparent field / magnification (or field stop / telescope focal
length). Aperture is read only in `python/PiFinder/ui/object_details.py`, where
it feeds contrast reserve.

The sentence now names focal length for those two calculations, and points
aperture at the contrast reserve section so the setting still has a documented
purpose. This adds one `:ref:` to `user_guide:contrast reserve` -- an existing
target already linked from `user_guide.rst` -- so `verify_ste.py` reports
`ref added (check)` for this PR by design.

## Safety

Every other change in this PR is style only. No numbers, procedures or step order were changed.

Verified mechanically against `origin/main` that every heading (text *and* underline character), every `:ref:`, `:doc:`, image path, substitution, `include::` and external URL is unchanged. Headings matter because `autosectionlabel` turns each one into a cross-reference target that other pages depend on, and a rename would break them silently.

Sphinx builds clean under `-n` (nitpicky).

Any `FACT_CONCERNS` above that are not listed under **Content changes** were deliberately **not** fixed. They are reported for a maintainer decision, since changing them would be a content edit rather than a style one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqTCarGCgTRWBQ1ysG8XFD

