### PR TITLE
docs: convert the v2.5 upgrade guide to the house style

### DIFF
--- a/docs/source/v25_upgrade.rst
+++ b/docs/source/v25_upgrade.rst
@@ -5,32 +5,32 @@ Thanks for ordering a PiFinder v2.5 upgrade kit! It contains everything you need
 PiFinder's camera up to v3 capabilities and swap the button faceplate for one labelled to match
 the new software.
 
-These photos show a Right-handed PiFinder, but the steps are the same for Left and Flat units.
+These photos show a Right-handed PiFinder, but the steps are the same for Left and Flat PiFinders.
 
 Get Started
 ------------
 
-Unpack your PiFinder v2 and all the kit parts. Put them on a messy workbench and take an
-out-of-focus picture....
+Unpack your PiFinder v2 and all the kit parts. The photo below shows mine, on a messy workbench
+and out of focus.
 
-You'll also need a small Phillips screwdriver and a pair of side cutters. The whole process takes
-about 10 minutes and isn't tricky, but read through this guide once before diving in.
+You also need a small Phillips screwdriver and a pair of side cutters. The whole process takes
+about 10 minutes and isn't difficult. Read through this guide once before you start.
 
 .. image:: images/v25_upgrade/v25_upgrade_10.jpeg
 
 Camera Prep
 ----------------
 
-The new v3 camera ships with one of two lens holders installed. Either way, you'll remove it and
-fit the one from the kit.
+The new v3 camera ships with one of two lens holders installed. In both cases, remove it and fit
+the lens holder from the kit.
 
 .. include:: includes/camera_prep.rst
 
 Installing the Camera
 ----------------------
 
-Grab your PiFinder and remove the four screws holding the camera. If the internal battery is
-installed, it's easier to remove the lens first.
+On your PiFinder, remove the four screws that hold the camera. If the internal battery is
+installed, remove the lens first to make this easier.
 
 
 .. image:: images/v25_upgrade/v25_upgrade_18.jpeg
@@ -40,19 +40,20 @@ installed, it's easier to remove the lens first.
 Open the camera's cable connector by gently sliding the dark-grey part toward the cable. The cable
 then comes loose easily.
 
-Unplug the cable and set the camera aside, saving the four m2.5 8mm screws.
+Unplug the cable and set the camera aside. Keep the four m2.5 8mm screws.
 
 .. image:: images/v25_upgrade/v25_upgrade_20.jpeg
 
 .. image:: images/v25_upgrade/v25_upgrade_21.jpeg
 
 
-Remove the four brass stand-offs that held the camera; these are no longer needed.
+Remove the four brass stand-offs that held the camera. You no longer need them.
 
 .. image:: images/v25_upgrade/v25_upgrade_22.jpeg
 
-Use the four screws to secure the adaptor to the PiFinder back plate as shown. The adapter has an
-opening on one side for the cable to exit; align it with the direction the cable comes from.
+Secure the adapter to the PiFinder back plate with the four screws, as shown. The adapter has an
+opening on one side for the cable to exit. Align that opening with the direction the cable comes
+from.
 
 .. image:: images/v25_upgrade/v25_upgrade_23.jpeg
 
@@ -65,7 +66,7 @@ Next, connect the cable to the new camera module.
 Swapping the Faceplate
 -----------------------
 
-Not much to say here, except to ignore the well-used state of my development PiFinder.
+This part is simple. Ignore the well-used state of my development PiFinder.
 
 Remove the three screws, swap the plate, and screw it back on.
 
@@ -84,29 +85,29 @@ To use the new camera, update to the latest PiFinder software. See the
 `Version 1.x software update guide <https://pifinder.readthedocs.io/en/v1.11.2/user_guide.html#update-software>`_
 for the different ways to update. If your PiFinder is very old, you may need to write a new SD card.
 
-With the new software running, switch the camera type to one of the v3 sensors. Upgrade kits
-currently ship with the Sony imx462 or imx296 sensor; the box your camera module came in indicates
-which. From the main PiFinder menu:
+With the new software running, set Camera Type to one of the v3 sensors. Upgrade kits currently
+ship with the Sony imx462 or imx296 sensor. The box your camera module came in shows which one
+you have. From the main PiFinder menu:
 
-* Scroll down and choose Settings
+* Scroll down and select Settings
 
 .. image:: images/v25_upgrade/v25_upgrade_41.png
 
-* Scroll down to Advanced, then choose Camera Type
+* Scroll down to Advanced, then select Camera Type
 
 .. image:: images/v25_upgrade/v25_upgrade_42.png
 
-* Choose either v3 - imx462 or v3 - imx296
+* Select either v3 - imx462 or v3 - imx296
 
 .. image:: images/v25_upgrade/v25_upgrade_44.png
 
-Choosing the new sensor restarts the software, but that restart alone won't initialize the
-camera.  **Fully power the PiFinder off and back on** — otherwise the camera view stays blank
-and it looks as though the switch didn't take.  After the power cycle the camera preview shows
-a bright image or static, depending on lighting. Set your exposure to 0.4 or 0.2 at most with
-the new camera, and try lower once you're out under the stars.
+Selecting the new sensor restarts the software, but that restart alone does not initialize the
+camera. **Fully power the PiFinder off and back on.** Otherwise the camera view stays blank and
+it looks as though the change didn't take. After the power cycle, the camera preview shows a
+bright image or static, depending on the lighting. With the new camera, set your exposure to 0.4
+or 0.2 at most. Try a lower value once you're out under the stars.
 
-That's it; congratulations on your new PiFinder v2.5.
+That's it. Congratulations on your new PiFinder v2.5.
 
-Check out the :doc:`quick_start` for details on focusing and a primer on the new software
+See the :doc:`quick_start` for details on focusing and an introduction to the new software
 interface.


### PR DESCRIPTION
Full simplified technical English pass over `docs/source/v25_upgrade.rst`, using the `docs` skill's seven rules and approved-term table. Part of the manual-wide conversion, one PR per file.

## Measured change

```
  PASS  docs/source/v25_upgrade.rst
     em-dash 1->0 | semicolon 4->0 | banned 4->0 | words 556->559 (+1%)
     terms: choose 4->0
OVERALL: PASS
```

## What the converting agent reported

```
EM_DASHES: 1 -> 0
SEMICOLONS: 4 -> 0
TERMS: choose->select x4; the Advanced bullet now matches troubleshooting.rst
  word for word; "units"->"PiFinders"; adaptor->adapter (the file had both
  spellings one sentence apart; the manual uses "adapter" 15x, including the
  shared camera_cable_connect.rst include); "switch the camera type"->"set
  Camera Type"; "the switch didn't take"->"the change didn't take", avoiding
  collision with the v3 power slide switch
STRUCTURAL: 4 sentence splits (rule 1) plus five rule-3 rewrites putting the
  command verb first. The closing out-of-focus gag was a false imperative in a
  procedure, which a second-language reader can read as a real step; made
  declarative while keeping the joke.
LEFT_ALONE: all five headings verbatim. The three-step menu procedure stays a
  bullet list rather than numbered: interleaved .. image:: directives terminate
  each list, so numbered items would render as three separate lists and emit
  start-value warnings. The opening exclamation kept as a genuine warm moment.
  The bold power-cycle caution preserved intact. Both .. include:: files
  untouched.
FACT_CONCERNS: "set your exposure to 0.4 or 0.2 at most" is ambiguous in the
  source (two values for a stated maximum, no unit). Preserved verbatim.
```

## Safety

Style only. No facts, numbers, procedures or step order were changed.

Verified mechanically against `origin/main` that every heading (text *and* underline character), every `:ref:`, `:doc:`, image path, substitution, `include::` and external URL is unchanged. Headings matter because `autosectionlabel` turns each one into a cross-reference target that other pages depend on, and a rename would break them silently.

Sphinx builds clean under `-n` (nitpicky).

Any `FACT_CONCERNS` above were deliberately **not** fixed. They are reported for a maintainer decision, since changing them would be a content edit rather than a style one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqTCarGCgTRWBQ1ysG8XFD
