### PR TITLE
docs: convert the connectivity page to the house style

### DIFF
--- a/docs/source/connectivity.rst
+++ b/docs/source/connectivity.rst
@@ -78,7 +78,7 @@ is the same as the ``pifinder`` user's password.  If you change one, you change 
 The default for new images and PiFinders is ``solveit``.  You can change it from the Tools
 page of the web interface.
 
-The web interface is available in English, German, French, and Spanish.  It follows your
+The web interface is available in English, German, French, Spanish, and Chinese.  It follows your
 browser's preferred language.  Set the language on your phone or computer, and the web
 interface matches it.
 

--- a/docs/source/connectivity.rst
+++ b/docs/source/connectivity.rst
@@ -92,7 +92,7 @@ Internet access, follow these steps:
 1) Make sure the PiFinder is in Access Point mode
 2) Connect your phone, tablet, or computer to the PiFinder's WiFi network called PiFinderAP
 3) Open http://pifinder.local in your web browser
-4) Click the 'Network' link in the top bar.  On a smaller screen, click the three stacked horizontal lines in the upper-right corner and select 'Network'.
+4) Click the 'Network' link in the top bar.  On a smaller screen, click the three stacked horizontal lines in the upper-left corner and select 'Network'.
     .. image:: images/user_guide/pf_web_net0.png
 5) When prompted, enter the password for your PiFinder.  The default is ``solveit``.
 6) Scroll down to the 'Wifi Networks' section and click the + button to add a network

--- a/docs/source/connectivity.rst
+++ b/docs/source/connectivity.rst
@@ -2,10 +2,10 @@
 Connecting to Your PiFinder
 ===========================
 
-The PiFinder doesn't need another device to do its job, but connecting your phone, tablet,
-or computer opens up a lot: a web interface for remote control and configuration,
-planetarium apps that follow your telescope, and direct access to your logged observations
-and images.  This page covers how the PiFinder's WiFi works and each way to connect.
+The PiFinder works on its own.  Connect a phone, tablet, or computer and you get more: a web
+interface for remote control and configuration, planetarium apps that follow your telescope,
+and direct access to your logged observations and images.  This page covers how the
+PiFinder's WiFi works and each way to connect.
 
 WiFi
 ==========================
@@ -13,16 +13,16 @@ WiFi
 Access Point and Client Mode
 ----------------------------------
 
-The PiFinder can connect to an existing network in Client mode, or serve as a wireless
-access point for other devices in Access Point (AP) mode.  Use the
-:ref:`connectivity:web interface` or the :ref:`user_guide:status screen` to switch between
-the two modes and see which is active.
+The PiFinder has two WiFi modes.  In Client mode it connects to an existing network.  In
+Access Point (AP) mode it creates its own wireless network for your phone, tablet, or
+computer.  Use the :ref:`connectivity:web interface` or the :ref:`user_guide:status screen`
+to switch modes and to see which mode is active.
 
-In Access Point mode the PiFinder creates a network called PiFinderAP with no password, for
-easy connection of phones, tablets, and other devices in the field.
+The access point is called PiFinderAP and has no password, so you can connect quickly in the
+field.
 
-To use Client mode, add the WiFi network you'd like the PiFinder to connect to using the
-Web Interface, as described in :ref:`connectivity:connecting to a new wifi network`
+To use Client mode, add the WiFi network you want the PiFinder to join.  Add it from the web
+interface, as described in :ref:`connectivity:connecting to a new wifi network`.
 
 PiFinder address
 -----------------
@@ -32,7 +32,7 @@ those without zeroconf networking, use the IP address shown on the
 :ref:`Status<user_guide:status screen>` screen.  You can connect via:
 
 
-* A web browser, for the :ref:`connectivity:web interface` — remote control, WiFi setup, and configuration changes
+* A web browser, for the :ref:`connectivity:web interface` (remote control, WiFi setup, and configuration changes)
 * SSH, for shell access (advanced users)
 * SMB (Samba), to access saved images, logs, and observing lists
 * LX200 protocol, to update a planetarium app such as :doc:`skysafari` with the telescope's position
@@ -42,22 +42,25 @@ Web Interface
 
 The PiFinder's web interface lets you:
 
-* See the current PiFinder status
-* Remote control the PiFinder via a virtual screen and keypad
+* See the PiFinder's current status
+* Control the PiFinder remotely with a virtual screen and keypad
 * Change network settings and connect to new WiFi networks
 * Add and edit your telescopes and eyepieces (see :doc:`equipment`)
 * Back up and restore your observing logs, settings, and other data
 * View and download your logged observations
-* Choose or upload a logging configuration to capture detailed logs for a bug report
+* Select or upload a logging configuration to capture detailed logs for a bug report
 
-To reach the web interface for the first time, make sure the PiFinder is in Access Point mode (see :ref:`user_guide:settings menu`) — the default for new PiFinders, to ease first-time setup.  From a phone, tablet, or computer, connect to the PiFinder's open wireless network, PiFinderAP (no password), then open your browser and visit:
+To reach the web interface for the first time, make sure the PiFinder is in Access Point
+mode (see :ref:`user_guide:settings menu`).  New PiFinders start in this mode to make first
+setup easy.  From a phone, tablet, or computer, connect to the PiFinder's open wireless
+network, PiFinderAP (no password).  Then open your browser and visit:
 ``http://pifinder.local``
 
 
 .. note::
    If you're connected to the PiFinderAP network and can't load the web interface at
-   http://pifinder.local, try http://10.10.10.1 — some systems don't support the network
-   features needed to resolve local computer names.
+   http://pifinder.local, try http://10.10.10.1 instead.  Some systems don't support the
+   network features needed to resolve local computer names.
 
 .. list-table::
    :width: 100%
@@ -66,73 +69,76 @@ To reach the web interface for the first time, make sure the PiFinder is in Acce
 
      - .. image:: images/user_guide/pf_web_home_hamburger.jpg
 
-The home screen shows general PiFinder status and a live view of the screen.  Depending on
-your screen size you'll see either a navigation bar along the top or a 'hamburger' menu in
-the upper-left holding the same options on smaller screens.
+The home screen shows general PiFinder status and a live view of the PiFinder's screen.  On
+a large screen you see a navigation bar along the top.  On a smaller screen the same options
+sit under a 'hamburger' menu in the upper-left.
 
 The home screen needs no password, but most other functions do.  The web interface password
-is the same as the ``pifinder`` user's; changing one changes the other.  The default for new
-images and PiFinders is ``solveit``, and you can change it from the Tools option in the web
-interface.
+is the same as the ``pifinder`` user's password.  If you change one, you change the other.
+The default for new images and PiFinders is ``solveit``.  You can change it from the Tools
+page of the web interface.
 
 The web interface is available in English, German, French, and Spanish.  It follows your
-browser's preferred language, so set the language on your phone or computer and the pages
-follow suit.
+browser's preferred language.  Set the language on your phone or computer, and the web
+interface matches it.
 
 Connecting to a new WiFi network
 ---------------------------------
 
-By default the PiFinder generates its own WiFi network, ``PiFinderAP``, that you connect to
-in order to configure additional networks.  To have the PiFinder connect to an existing
-WiFi network with Internet access, follow these steps:
+By default the PiFinder creates its own WiFi network, ``PiFinderAP``.  Connect to it to
+configure additional networks.  To connect the PiFinder to an existing WiFi network with
+Internet access, follow these steps:
 
 1) Make sure the PiFinder is in Access Point mode
-2) Connect your phone, tablet, or computer to the PiFinder's wifi network called PiFinderAP
-3) Visit http://pifinder.local using your web browser
-4) Click the 'Network' link in the top bar, or on a smaller screen click the three stacked horizontal lines in the upper-right corner and choose 'Network'.
+2) Connect your phone, tablet, or computer to the PiFinder's WiFi network called PiFinderAP
+3) Open http://pifinder.local in your web browser
+4) Click the 'Network' link in the top bar.  On a smaller screen, click the three stacked horizontal lines in the upper-right corner and select 'Network'.
     .. image:: images/user_guide/pf_web_net0.png
-5) When prompted, enter the password for your PiFinder.  The default is `solveit`.
+5) When prompted, enter the password for your PiFinder.  The default is ``solveit``.
 6) Scroll down to the 'Wifi Networks' section and click the + button to add a network
     .. image:: images/user_guide/pf_web_net1.jpg
 7) Enter the name (SSID) and password of your network.  If your network has no password, leave the Password field blank.
 8) Click the 'SAVE' button to save the new network
-9)  The network you added should now appear in the 'Wifi Networks' section
+9)  The network you added now appears in the 'Wifi Networks' section
 10) Scroll up and change the Wifi mode from 'Access Point' to 'Client' so the PiFinder connects to your network on its next restart
 11) Click the 'UPDATE AND RESTART' button
 
-To add more WiFi networks, navigate to the Network Setup page of the :ref:`connectivity:web interface`, click the + button near the WiFi networks list, and repeat the steps above.
+To add more WiFi networks, open the Network Setup page of the
+:ref:`connectivity:web interface`, click the + button near the WiFi networks list, and
+repeat the steps above.
 
 Logging configuration
 ---------------------
 
 When you're tracking down a problem, the Logs page of the web interface can turn up the
-detail the PiFinder records.  Pick one of the built-in configurations — default, debug, or
-webserver — or upload your own, and the PiFinder restarts with it in place.  The richer logs
-make it much easier to capture what happened for a bug report; switch back to default when
-you're done.
+detail the PiFinder records.  Select one of the built-in configurations (default, debug, or
+webserver), or upload your own.  The PiFinder restarts with the new configuration in place.
+The richer logs make it much easier to capture what happened for a bug report.  Switch back
+to default when you're done.
 
 SkySafari and Planetarium Apps
 ==============================
 
-The PiFinder can provide real-time pointing information to SkySafari and other planetarium
-apps via the LX200 protocol, and accept targets they send back.  The :doc:`skysafari` page
-has the connection settings and walks through the setup step by step.
+The PiFinder can send real-time pointing information to SkySafari and other planetarium apps
+over the LX200 protocol.  It also accepts the objects those apps send back.  The
+:doc:`skysafari` page has the connection settings and takes you through the setup step by
+step.
 
 Shared Data Access
 ===================
 
-The PiFinder creates several data files you may want.  They're available via an SMB (samba)
-network share, ``//pifinder.local/shared``.  Access depends on your OS, but the PiFinder
-should appear in a network browser.  No password is required — connect as ``guest`` with no
-password.
+The PiFinder creates several data files you may want.  It shares them over SMB (samba) at
+``//pifinder.local/shared``.  Access depends on your operating system, but the PiFinder
+should appear in a network browser.  The share needs no password.  Connect as ``guest`` and
+leave the password blank.
 
-Once connected, you'll see:
+Once connected, you see:
 
 
-* ``captures/``\ : Images saved when logging objects, named with the observation ID from the database.
+* ``captures/``\ : The images the PiFinder saves when you log an object.  Each name contains the observation ID from the database.
 * ``obslists/``\ : Observing lists.  Copy list files here (subfolders welcome) to load
-  them at the scope — see :ref:`user_guide:observing lists`.
-* ``screenshots/``\ : Screenshots taken while using the PiFinder (hold **SQUARE** and
-  press **0**) are stored here.
-* ``solver_debug_dumps/``\ : If enabled, solver performance information is stored here as a collection of images and json files.
+  them at the telescope.  See :ref:`user_guide:observing lists`.
+* ``screenshots/``\ : Screenshots you take while using the PiFinder.  Hold **SQUARE** and
+  press **0** to take one.
+* ``solver_debug_dumps/``\ : Solver performance information, as a collection of images and json files, if you turn it on.
 * ``observations.db``\ : The SQLite database holding all logged observations.


### PR DESCRIPTION
Full simplified technical English pass over `docs/source/connectivity.rst`, using the `docs` skill's seven rules and approved-term table. Part of the manual-wide conversion, one PR per file.

## Measured change

```
  PASS  docs/source/connectivity.rst
     em-dash 7->0 | semicolon 2->0 | banned 6->1 | words 1044->1044 (-0%)
     terms: choose 2->0, pick 1->0, target 1->0, navigate 2->1
OVERALL: PASS
```

## What the converting agent reported

```
EM_DASHES: 7 -> 0
SEMICOLONS: 2 -> 0
TERMS: choose/pick->select; "navigate to"->"open"; "at the scope"->"at the
  telescope"; "targets they send back"->"the objects those apps send back";
  "the Tools option"->"the Tools page" (matching this page's own "Logs page");
  "wifi network"->"WiFi network" (UI labels 'Wifi Networks' left verbatim).
  DEVICE TRAP: "device" now appears zero times. The intro's "doesn't need
  another device" implicitly framed the product as a device, so it became
  "The PiFinder works on its own".
STRUCTURAL: one-idea splits throughout. AP/Client section de-duplicated: the
  PiFinderAP restatement compressed, no facts dropped. Two long paragraphs
  reflowed to the page's ~92-char width. Passives made active.
LEFT_ALONE: all 9 headings byte for byte. The numbered steps stay one physical
  line each, because the .. image:: directives under steps 4 and 6 are indented
  4 spaces against a 3-space content column and rewrapping would change how
  they parse. All literals kept. Kept the hedge "should appear in a network
  browser" - removing it would assert more than the original.
FACT_CONCERNS:
  1. The page contradicts itself on the hamburger menu: the home-screen
     paragraph puts it in the UPPER-LEFT, step 4 of "Connecting to a new WiFi
     network" puts it in the UPPER-RIGHT. One is wrong. Both preserved as
     written.
  2. The web interface is documented as English, German, French and Spanish,
     but PiFinder's UI ships in German, Spanish, French AND Chinese. The web
     interface may now have a Chinese translation this list omits.
```


## Contains one content fix (not style)

This PR is style-only **except** for the final commit, which corrects a
self-contradiction on this page: the overview said the hamburger menu is in the
upper-left, step 4 of "Connecting to a new WiFi network" said upper-right.

Upper-left is correct on three independent sources: `materialize.css` sets
`nav .sidenav-trigger { float: left }`, `base.html` applies no `.right`
override, and `images/user_guide/pf_web_home_hamburger.jpg` — which this page
already displays — shows the icon top-left with an arrow pointing at it.

Fixed here rather than filed separately because the wrong instruction sits
inside a numbered procedure a new owner follows on a phone, directly beside a
screenshot showing the opposite.

## Content changes (added after review)

**The web interface also speaks Chinese.** The page listed English, German,
French and Spanish. `server.py` best-matches the browser's `Accept-Language`
against `["en", "fr", "de", "es", "zh"]`, and
`python/locale/zh/LC_MESSAGES/messages.po` carries the web strings translated.
Chinese is now listed.

## Safety

Every other change in this PR is style only. No numbers, procedures or step order were changed.

Verified mechanically against `origin/main` that every heading (text *and* underline character), every `:ref:`, `:doc:`, image path, substitution, `include::` and external URL is unchanged. Headings matter because `autosectionlabel` turns each one into a cross-reference target that other pages depend on, and a rename would break them silently.

Sphinx builds clean under `-n` (nitpicky).

Any `FACT_CONCERNS` above that are not listed under **Content changes** were deliberately **not** fixed. They are reported for a maintainer decision, since changing them would be a content edit rather than a style one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqTCarGCgTRWBQ1ysG8XFD


