### PR TITLE
docs: convert the SD card page to the house style

### DIFF
--- a/docs/source/sd_card.rst
+++ b/docs/source/sd_card.rst
@@ -93,10 +93,9 @@ slack.
 Flat configuration
 ^^^^^^^^^^^^^^^^^^
 
-The three screws hold one side of the flat cradle.  Remove them.  The cradle then
-flexes enough for you to pull the flat holder gently down and expose the card.  The
-image below shows this.  It was taken during assembly, before the camera was
-installed.  You don't need to remove the camera to reach the card.
+Remove the three screws that hold one side of the flat cradle.  The cradle then
+flexes enough to pull the flat holder gently down and expose the card.  The image
+below shows this, taken during assembly before the camera was installed.  You don't need to remove the camera to reach the card.
 
 .. image:: images/sd_card/flat_open.jpeg
    :width: 70%

--- a/docs/source/sd_card.rst
+++ b/docs/source/sd_card.rst
@@ -5,41 +5,40 @@ Swapping the SD Card
    This page covers rev4, v3 and v2.5 PiFinders, and the procedure differs on each.  If
    you're not sure which one you have, the :ref:`quick_start:which pifinder do i have?`
    section of the Quick Start tells them apart.  The microSD card holds everything the
-   PiFinder runs — the operating system, the PiFinder software, your settings,
-   and the deep sky catalog images — so swapping it is how you recover from a
-   corrupt card or move to a fresh or larger one.
+   PiFinder runs: the operating system, the PiFinder software, your settings, and the
+   deep-sky catalog images.  Swapping it is how you recover from a corrupt card or move
+   to a fresh or larger one.
 
 The PiFinder boots from a microSD card.  On rev4 that card sits in a slot on the
-side of the case, reachable from outside, so swapping it takes no tools and
-nothing has to come apart.  This page covers getting at the card and swapping it.
+side of the case, reachable from outside.  Swapping it takes no tools, and
+nothing has to come apart.  This page covers how to reach the card and swap it.
 To put software on the new card first, see :doc:`Software Setup <software>`.
 
 .. note::
    On v3 and v2.5 PiFinders the card is inside the case, in the slot between the
-   Raspberry Pi and the power board, and you have to open the case to reach it.
+   Raspberry Pi and the power board.  You have to open the case to reach it.
    See :ref:`sd_card:reaching the card on v3 and v2.5 units` below.
    |v3_docs|
 
 When you'd swap the card
 ------------------------
 
-* The card has become corrupt and the PiFinder won't boot reliably (see
+* The card is corrupt and the PiFinder won't boot reliably (see
   :doc:`troubleshooting`).
 * You'd rather re-image onto a spare card and keep your original as a backup.
 
-Image the new card before you start — the
-:ref:`software:prebuilt release image` is the quickest way, and it already
-includes the catalog images.
+Image the new card before you start.  The :ref:`software:prebuilt release image`
+is the quickest way, and it already includes the catalog images.
 
 Before you start
 ----------------
 
-If the PiFinder is on, shut it down cleanly and wait for the screen and keypad to
-go dark before you touch the card — see :ref:`user_guide:shutdown`.  Pulling a
-card from a running unit can corrupt it.
+If the PiFinder is on, shut it down cleanly.  Wait for the screen and keypad to
+go dark before you touch the card.  See :ref:`user_guide:shutdown`.  Pulling a
+card from a running PiFinder can corrupt it.
 
 .. note::
-   On v3 and v2.5 PiFinders, switch the power off at the slide switch once the
+   On v3 and v2.5 PiFinders, turn the power off at the slide switch once the
    screen and keypad have gone dark, before you open the case.
    |v3_docs|
 
@@ -47,12 +46,12 @@ Swapping the card
 -----------------
 
 Face the screen and look at the left-hand side of the case.  The card slot is a thin
-opening in that side panel with the edge of the microSD card sitting in it — no tools,
-and nothing to take apart.
+opening in that side panel with the edge of the microSD card sitting in it.  You need
+no tools, and nothing has to come apart.
 
 The slot is spring-loaded, so the card comes out with a push rather than a pull:
 
-1. Press the card in until it clicks, then let go.  The spring pushes it part-way out.
+1. Push the card in until it clicks, then let go.  The spring pushes it part-way out.
 2. Slide the card clear of the slot.
 3. Push the replacement in until it clicks and stays put.
 
@@ -62,14 +61,14 @@ don't flex it against the case.
 Reaching the card on v3 and v2.5 units
 --------------------------------------
 
-On these units the card sits inside the case, so you'll need to open it up first.
-The card sits in a friction slot — there's no spring to push it in or out, so you
-pull it straight out and push the new one straight in.
+On these PiFinders the card is inside the case, so you must open the case first.
+It sits in a friction slot.  There is no spring, so you pull the card straight
+out and push the new one straight in.
 
 Opening a v3 case
 ~~~~~~~~~~~~~~~~~
 
-You'll need a small Phillips screwdriver.  On every v3 unit, start by removing
+You need a small Phillips screwdriver.  On every v3 PiFinder, start by removing
 the three screws on the right-hand side as you face the screen.
 
 .. image:: images/sd_card/sd_card_remove_screws.jpeg
@@ -82,22 +81,22 @@ photos of each.
 Right configuration
 ^^^^^^^^^^^^^^^^^^^
 
-Simply lift off the separate cover held on by the three screws to expose the card.
+Lift off the separate cover held on by the three screws to expose the card.
 
 Left configuration
 ^^^^^^^^^^^^^^^^^^
 
-For the left configuration, the three screws hold the camera assembly in place.
-Gently tilt the camera assembly out of the way to reach the card. Be mindful of
-the cable, but there should be plenty of slack.
+The three screws hold the camera assembly in place.  Tilt it gently out of the
+way to reach the card.  Be careful with the cable, but there should be plenty of
+slack.
 
 Flat configuration
 ^^^^^^^^^^^^^^^^^^
 
-The three screws hold one side of the flat cradle. Removing them allows enough flex to
-gently pull the flat holder down to expose the card.  The image below shows this, but
-was taken during assembly before the camera is installed.  There is no need to remove
-the camera to access the sd card.
+The three screws hold one side of the flat cradle.  Remove them.  The cradle then
+flexes enough for you to pull the flat holder gently down and expose the card.  The
+image below shows this.  It was taken during assembly, before the camera was
+installed.  You don't need to remove the camera to reach the card.
 
 .. image:: images/sd_card/flat_open.jpeg
    :width: 70%
@@ -105,8 +104,8 @@ the camera to access the sd card.
 Opening a v2.5 case
 ~~~~~~~~~~~~~~~~~~~
 
-A v2.5 unit has an access door that snaps out to expose the card — no tools
-needed.  The alternative is to undo the three faceplate screws with a small
+A v2.5 PiFinder has an access door that snaps out to expose the card.  You need
+no tools.  The alternative is to undo the three faceplate screws with a small
 Phillips screwdriver and slide the whole shroud off.  Those are the faceplate
 screws, not the side screws a v3 uses.
 
@@ -114,8 +113,8 @@ Removing and replacing the card
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The card sits in the slot between the Raspberry Pi board and the power board.
-The white camera ribbon cable runs nearby — move it gently aside if it's in the
-way, taking care not to crease or unseat it.
+The white camera ribbon cable runs nearby.  Move it gently aside if it's in the
+way, and take care not to crease or unseat it.
 
 .. image:: images/sd_card/sd_card_closup.jpg
    :width: 47%
@@ -131,21 +130,22 @@ Reassembling
 
 Reverse the steps you took to get in: refit the cover, holder or shroud, check
 that the camera ribbon is sitting flat and isn't pinched, and replace the three
-screws — snug, not forced.  An access door presses back into place on its own.
+screws.  Tighten them snug, but don't force them.  An access door presses back
+into place on its own.
 
 First boot
 ----------
 
-Power the PiFinder on.  The first boot from a freshly imaged card takes longer
-than usual while it expands the filesystem to fill the card, so give it a couple
+Turn the PiFinder on.  The first boot from a freshly imaged card takes longer
+than usual, because it expands the filesystem to fill the card.  Give it a couple
 of minutes.
 
 .. important::
-   After swapping the card you'll most likely need to set the **Camera Type**
-   again.  A freshly imaged card defaults to one sensor, and if it doesn't match
-   your unit the camera view will be blank.  Set it under Settings → Advanced → Camera Type
-   — the v3 sensors are ``imx462`` and ``imx296`` — then **fully power the
-   PiFinder off and on**, as a software restart alone won't apply the change.
-   See :ref:`troubleshooting:the camera view is blank or black` for more.  It's
-   also worth re-checking your WiFi settings, since they won't carry over to a
-   freshly imaged card.
+   After swapping the card you usually need to set the **Camera Type** again.  A
+   freshly imaged card defaults to one sensor, and if it doesn't match your
+   PiFinder the camera view is blank.  From the main menu, select Settings,
+   scroll down to Advanced, then select Camera Type.  The v3 sensors are
+   ``imx462`` and ``imx296``.  Then **turn the PiFinder fully off and on again**,
+   because a software restart alone won't apply the change.  See
+   :ref:`troubleshooting:the camera view is blank or black` for more.  Re-check
+   your WiFi settings too.  They don't carry over to a freshly imaged card.


### PR DESCRIPTION
Full simplified technical English pass over `docs/source/sd_card.rst`, using the `docs` skill's seven rules and approved-term table. Part of the manual-wide conversion, one PR per file.

## Measured change

```
  PASS  docs/source/sd_card.rst
     em-dash 11->0 | semicolon 0->0 | banned 7->6 | words 1008->990 (-2%)
     terms: the unit 1->0
OVERALL: PASS
```

## What the converting agent reported

```
EM_DASHES: 11 occurrences -> 0
SEMICOLONS: 0 -> 0
TERMS: unit/units -> PiFinder at 5 sites; power verbs unified on turn on/turn
  off; the arrow path "Settings -> Advanced -> Camera Type" replaced with the
  prose chain, matching troubleshooting.rst verbatim in form (0 arrows remain);
  card-handling verb unified on "push" - chosen over "press" deliberately,
  because the term table reserves "press" for operating a key and "push" was
  already this page's dominant verb for the card;
  "deep sky catalog images" -> "deep-sky catalog images" (rule 6)
STRUCTURAL: 16 sentence splits inside existing paragraphs. Zero paragraph
  splits, zero reorders, zero moved content. Every dash pattern got its
  section-5 fix.
LEFT_ALONE: the heading "Reaching the card on v3 and v2.5 units" and the :ref:
  that targets it keep "units", per the frozen-heading rule. This leaves one
  heading/body mismatch on the page, which ste-style explicitly prefers over
  renaming a cross-reference target.
  "boot" KEPT at four sites. The term table bans "boot" for the user action of
  powering on, which was converted. These four name the machine's startup
  sequence, a genuinely different concept - and changing "won't boot reliably"
  to "won't turn on reliably" would alter the fact, since a card fault lets the
  PiFinder power on but fail to boot.
  The duplicated crack warning appears in both procedures; both kept, since it
  is a safety caution.
FACT_CONCERNS: the .. important:: block names only the v3 sensors (imx462,
  imx296) for Camera Type, but this page explicitly covers v2.5 PiFinders too.
  troubleshooting.rst adds that older v2 cameras are imx477, corroborated by
  menu_map.rst. A v2.5 owner following this page after a re-image has no sensor
  value to pick. Left as written - content, not style.
```

## Safety

Style only. No facts, numbers, procedures or step order were changed.

Verified mechanically against `origin/main` that every heading (text *and* underline character), every `:ref:`, `:doc:`, image path, substitution, `include::` and external URL is unchanged. Headings matter because `autosectionlabel` turns each one into a cross-reference target that other pages depend on, and a rename would break them silently.

Sphinx builds clean under `-n` (nitpicky).

Any `FACT_CONCERNS` above were deliberately **not** fixed. They are reported for a maintainer decision, since changing them would be a content edit rather than a style one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqTCarGCgTRWBQ1ysG8XFD
