### PR TITLE
docs: convert the troubleshooting page to the house style

### DIFF
--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -3,51 +3,50 @@ Troubleshooting & FAQ
 
 .. note::
    This page applies to rev4, v3 and v2.5 PiFinders running software |min_software| or above.  If
-   you're on older software, updating is often the fix in itself — see
+   you're on older software, updating is often the fix in itself.  See
    :ref:`user_guide:update software`.
 
    Not sure which you have?  See
    :ref:`Which PiFinder do I have? <quick_start:which pifinder do i have?>` in the Quick Start.
 
-Most PiFinder hiccups have a quick fix, and the cause is usually something simple —
-focus, or a settings mismatch — rather than a fault.  This page is organised by
-*symptom*: find the line that matches what you're seeing and follow it to the cure.
-If your symptom isn't listed, or a fix doesn't sort it out, the PiFinder community on
-the `Discord server <https://discord.gg/Nk5fHcAtWD>`_ is quick to help.
+Most PiFinder problems have a quick fix.  The cause is usually something simple, such as focus
+or a settings mismatch, rather than a fault.  This page is organised by *symptom*.  Find the
+line that matches what you're seeing and follow it to the fix.  If your symptom isn't listed,
+or a fix doesn't work, the PiFinder community on the
+`Discord server <https://discord.gg/Nk5fHcAtWD>`_ is quick to help.
 
 
 The PiFinder won't turn on
 --------------------------
 
 Power is the button marked **PWR**, on the front below the keypad.  Press and hold it for
-about two seconds to switch the PiFinder on — the **PWR** label lights while it boots.
-Press and hold it while the unit is running to bring up the shutdown confirmation.  (The
-**SQUARE** key never controls power.)
+about two seconds to turn the PiFinder on.  The **PWR** label lights while it boots.  Press
+and hold it while the PiFinder is running to bring up the shutdown confirmation.  The
+**SQUARE** key never controls power.
 
 Things to check:
 
-- **Is the battery charged?**  Plug a USB-C cable into the **POWER** port — the **CHG**
-  light comes on while the battery charges.  Once the PiFinder is running, the title bar
-  shows roughly how much longer it will run; see
-  :ref:`user_guide:the battery indicator`.
-- **Try a different cable and supply.**  Some USB-C cables are unreliable at the current
-  the PiFinder draws.  If it runs on external power but not on battery, the trouble is the
-  battery, not the computer.
+- **Is the battery charged?**  Plug a USB-C cable into the **POWER** port.  The **CHG** light
+  comes on while the battery charges.  Once the PiFinder is running, the title bar shows
+  roughly how much longer it will run.  See :ref:`user_guide:the battery indicator`.
+- **Try a different cable and supply.**  Some USB-C cables cannot reliably carry the current
+  the PiFinder draws.  If the PiFinder runs on external power but not on battery, the fault
+  is in the battery, not the computer.
 
-If none of that helps, hold the **PWR** button down for more than **14 seconds**.  That
-resets the power system itself rather than the software: it cuts power to a unit whose
-software has hung and won't shut down, and it will let one power on again when something is
-stopping it from starting normally.  It's a hard cut rather than a clean shutdown, so keep
-it for when the PiFinder is genuinely unresponsive.
+If none of that helps, press and hold the **PWR** button for more than **14 seconds**.  This
+resets the power system itself rather than the software.  It cuts power to a PiFinder whose
+software has hung and will not shut down.  It also lets a PiFinder turn on again when
+something is stopping it from starting normally.  This is a hard cut rather than a clean
+shutdown, so keep it for when the PiFinder is genuinely unresponsive.
 
 .. note::
-   On v3 and v2.5 PiFinders, power is a small white **slide switch** — it slides side to
-   side, not a push button.  Facing the screen, slide right for on, left for off.  There's
-   no battery indicator on a v3, so plug in to charge if you're unsure; the charging light
-   glows blue while charging and green when full.  The port closest to the keypad powers
-   the unit *immediately, regardless of switch position*, which is a quick way to tell a
-   flat battery or a failed switch from a dead computer.  If you built your own unit and it
-   won't power up at all, double-check the PiSugar battery board connections.
+   On v3 and v2.5 PiFinders, power is a small white **slide switch**.  It slides side to side
+   and is not a push button.  Facing the screen, slide right for on, left for off.  A v3 has
+   no battery indicator, so plug in to charge if you're unsure.  The charging light glows
+   blue while charging and green when full.  The port closest to the keypad powers the
+   PiFinder *immediately, regardless of switch position*, which is a quick way to tell a flat
+   battery or a failed switch from a dead computer.  If you built your own PiFinder and it
+   won't turn on at all, double-check the connections to the PiSugar battery board.
    |v3_docs|
 
 
@@ -56,27 +55,27 @@ The screen is blank, or it won't finish booting
 
 Rule out the simple explanations first:
 
-- **Brightness turned all the way down.**  If the PiFinder was last used at a dark site,
-  the screen may be dimmed to nothing.  Hold **SQUARE** and tap **+** several times to
-  bring it back.
-- **Give it time on the first boot.**  A normal start-up reaches the welcome screen in
-  about 20 seconds.  The *first* boot after re-imaging takes a minute or two and restarts
-  itself several times while it sets up — that's expected.  Wait a full five minutes
-  before deciding something is wrong.
+- **Brightness turned all the way down.**  If you last used the PiFinder at a dark site, the
+  screen may be dimmed to nothing.  Hold **SQUARE** and press **+** several times to bring it
+  back.
+- **Give it time on the first boot.**  A normal boot reaches the welcome screen in about
+  20 seconds.  The *first* boot after re-imaging takes a minute or two and restarts itself
+  several times while it sets up.  This is expected.  Wait a full five minutes before
+  deciding something is wrong.
 
 If the screen is still blank, the keypad backlight tells you where the problem is:
 
-- **No keypad light and no screen** (a faint red LED inside the case means the Pi has
-  power but isn't booting): this is almost always **SD card corruption**, the most common
-  hardware issue.  Re-image the card with the latest release, or request a fresh one
-  (:doc:`sd_card` covers getting at the card on each revision).  SD card faults are
-  all-or-nothing — they stop the PiFinder booting rather than causing subtle misbehaviour,
-  so don't re-image to explain slow solves or the occasional position jump.
-- **Keypad lights up, but the screen is blank or garbled**: that points to the screen's
+- **No keypad light and no screen**: this is almost always **SD card corruption**, the most
+  common hardware issue.  A faint red LED inside the case means the Pi has power but is not
+  booting.  Re-image the card with the latest release, or request a fresh one.  :doc:`sd_card`
+  covers getting at the card on each revision.  SD card faults are all-or-nothing.  They stop
+  the PiFinder booting rather than causing subtle misbehaviour, so don't re-image to explain
+  slow solves or the occasional position jump.
+- **Keypad lights up, but the screen is blank or garbled**: this points to the screen's
   connection, not the software.  Confirm it through the
-  :ref:`web interface <connectivity:web interface>` — if the remote screen looks correct
-  there, the software is fine and the physical screen connection needs attention (a solder
-  reflow on DIY builds).
+  :ref:`web interface <connectivity:web interface>`.  If the remote screen looks correct
+  there, the software is fine and the physical screen connection needs attention.  On DIY
+  builds that usually means a solder reflow.
 
 For re-imaging instructions, see :ref:`user_guide:update software` and the
 :doc:`software` page.
@@ -85,88 +84,86 @@ For re-imaging instructions, see :ref:`user_guide:update software` and the
 The camera view is blank or black
 ---------------------------------
 
-The Focus screen opens on its magnified star tiles, which stay black whenever no stars are
-detected — so a perfectly healthy camera looks dead there in daylight or under cloud.  Don't
-judge the camera by that screen.
+The Focus screen opens on its magnified star tiles, which stay black whenever the PiFinder
+detects no stars.  A perfectly healthy camera therefore looks dead there in daylight or under
+cloud.  Don't judge the camera by that screen.
 
-To see what the camera actually sees, open the Start menu and choose Align (Day).  It
-switches the camera to a short daytime exposure and shows a full live image, which is the
-quickest way to tell whether the camera is alive at all.  Point the PiFinder at something
-bright and you should get a recognisable picture; even with the lens cap on you should see
-faint noise rather than pure black.
+To see what the camera sees, open the Start menu and select Align (Day).  It switches the
+camera to a short daytime exposure and shows a full live image, which is the quickest way to
+tell whether the camera works at all.  Point the PiFinder at something bright and you should
+get a recognisable picture.  Even with the lens cap on you should see faint noise rather than
+pure black.
 
 If Align (Day) shows nothing whatsoever, the **Camera Type** setting probably doesn't match
-the camera in your unit.
+the camera in your PiFinder.
 
 - From the main menu, select Settings, scroll down to Advanced, then select Camera Type and
-  try a different one.  The v3 sensors are ``imx462`` and ``imx296``; older v2 cameras are
-  ``imx477``.  It won't hurt to try each.
-- **After changing Camera Type you must fully power the PiFinder off and on** — a software
-  restart alone won't apply it.
+  try a different option.  The v3 sensors are ``imx462`` and ``imx296``.  Older v2 cameras are
+  ``imx477``.  Trying each one does no harm.
+- **After changing Camera Type, turn the PiFinder fully off and on again.**  A software
+  restart alone does not apply it.
 - A software update can quietly reset this setting, so re-check it after you update.
 
 
 It won't plate solve ("can't find stars")
 ------------------------------------------
 
-Plate solving is how the PiFinder works out where it's pointed (see
-:ref:`quick_start:setting focus & first solve`).  When it won't solve, **focus is the
-cause far more often than anything else** — and stars that look fine at normal zoom are
-often not tight enough.
+Plate solving is how the PiFinder works out where it points.  See
+:ref:`quick_start:setting focus & first solve`.  When it won't solve, **focus is the cause far
+more often than anything else**.  Stars that look fine at normal zoom are often not tight
+enough.
 
 Work through these in order:
 
 - **Focus, properly.**  On the Focus screen, rotate the lens until the four magnified stars
   are as small as possible and the central HFD reaches its lowest value.  The difference
-  between fair and good focus is less than half a turn, so work in steps of an eighth to a
-  quarter of a turn with a pause for vibration to settle, and judge by the HFD rather than
-  the camera icon, which lags a second or so behind each change of the lens.  Tight focus matters *even
-  more* under bright, light-polluted skies, where slightly soft dim stars vanish into the
-  background.  If you're starting from way off, set the lens so about 6 mm of thread is
-  showing — roughly a pencil's width — which is close to in focus.
+  between fair and good focus is less than half a turn.  Work in steps of an eighth to a
+  quarter of a turn, and pause after each step for vibration to settle.  Judge by the HFD
+  rather than the camera icon, which lags a second or so behind each change of the lens.
+  Tight focus matters *even more* under bright, light-polluted skies, where slightly soft dim
+  stars vanish into the background.  If you're starting from far off, set the lens so about
+  6 mm of thread shows, roughly a pencil's width.  That is close to in focus.
 - **Lens cap off, and hold still.**  The PiFinder can only solve a sharp, stationary
   image.
-- **Exposure.**  The PiFinder defaults to **AUTO**, setting the exposure itself from each
-  solve — leave it there unless you have a reason not to.  To set it by hand, 0.2 s suits
-  most skies, bright urban skies want 0.4 s, and dark skies solve well at 0.1 s.
-  (Software older than 2.2 doesn't have the AUTO option — another reason to update.)
-- **High, thin cloud.**  An invisible drifting cloudbank will stop solves at an otherwise
-  perfect site.  If solves come and go while the scope is dead still, suspect the sky
-  before the hardware.
+- **Exposure.**  The PiFinder defaults to **AUTO** and sets the exposure itself from each
+  solve.  Leave it there unless you have a reason not to.  To set it by hand, 0.2 s suits most
+  skies, bright urban skies want 0.4 s, and dark skies solve well at 0.1 s.  Software older
+  than 2.2 has no AUTO option, which is another reason to update.
+- **High, thin cloud.**  An invisible drifting cloudbank stops solves at an otherwise perfect
+  site.  If solves come and go while the telescope is dead still, suspect the sky before the
+  hardware.
 
 .. note::
-   On older v2 cameras the lens has two rings — a focus ring and an aperture ring.  The
+   On older v2 cameras the lens has two rings, a focus ring and an aperture ring.  The
    **aperture must be fully open** for the PiFinder to see enough stars to solve.
 
 
 An object has "disappeared" from a list (for example, M45)
 ----------------------------------------------------------
 
-Objects are never deleted.  If something you expect is missing, it's being hidden by an
-active **filter** — magnitude, altitude, type, observed status, or which catalogs are
-selected.  To bring everything back, open the Filter menu and choose **Reset All**.  See
-:ref:`user_guide:filters` for what each filter does.
+The PiFinder never deletes objects.  If something you expect is missing, an active **filter**
+is hiding it.  The filters cover magnitude, altitude, type, observed status, and which
+catalogs are selected.  To bring everything back, open the Filter menu and select
+**Reset All**.  See :ref:`user_guide:filters` for what each filter does.
 
 
 The chart or Push-To directions look backwards
 ----------------------------------------------
 
 **Reversed Push-To directions are the classic sign that the PiFinder Type setting doesn't
-match your hardware.**  You push the scope the way the arrows point and the target moves
+match your hardware.**  You push the telescope the way the arrows point, and the object moves
 further away instead of closer.  A mirrored star chart is the same fault showing itself
-somewhere else — one setting drives both.
+somewhere else.  One setting drives both.
 
-On rev4, suspect this first.  The body rotates between the Left, Right and Straight
-positions without tools, so it's easy to reposition the unit for a different scope and
-leave the setting describing where the screen used to face.  Set it to match under
-Settings, as described in
-:ref:`Configuration Setup <quick_start:configuration setup>`.
+On rev4, suspect this first.  The body rotates between the Left, Right and Straight positions
+without tools, so it's easy to reposition the PiFinder for a different telescope and leave the
+setting describing where the screen used to face.  Set it to match under Settings, as
+described in :ref:`Configuration Setup <quick_start:configuration setup>`.
 
 .. note::
-   The clockwise / counter-clockwise Push-To arrows are also *configurable* to suit how
-   you picture turning your scope.  If only the left/right (azimuth) direction feels
-   reversed, try flipping that preference in Settings rather than changing the PiFinder
-   Type.
+   You can also configure the clockwise / counter-clockwise Push-To arrows to suit how you
+   picture turning your telescope.  If only the left/right (azimuth) direction feels reversed,
+   change that preference in Settings rather than the PiFinder Type.
 
 
 "Is this normal?"
@@ -175,56 +172,55 @@ Settings, as described in
 A few PiFinder behaviours surprise people into thinking something is broken.  These are
 all expected:
 
-- **The alignment reticle isn't centred.**  The Telrad-style reticle on the Align screen
-  shows where your scope points *within* the camera's wide 10° view — it isn't meant to
-  sit in the middle, and a reticle off to one side is normal.  See
-  :ref:`quick_start:alignment`.
-- **The star chart is "zenith up", not eyepiece-matched.**  The on-screen chart is a
-  naked-eye view, oriented as you'd see the sky looking up, so it won't match the flipped
-  or rotated view through your eyepiece.  The object *image* previews, by contrast, are
-  rotated to match the eyepiece.
-- **Push-To numbers dim while you move the scope.**  While moving, the PiFinder estimates
-  position from its motion sensor and dims the numbers to say so; the instant you stop, it
-  takes a fresh photo, the numbers brighten, and the position is exact again.  (This is
-  separate from the whole screen dimming in power-save mode.)
-- **The charging light is slow to turn green.**  Near a full charge the current tapers
-  off, so the final stretch from blue to green takes a while.  That's normal, not a fault.
+- **The alignment reticle isn't centred.**  The Telrad-style reticle on the Align screen shows
+  where your telescope points *within* the camera's wide 10° view.  It is not meant to sit in
+  the middle, and a reticle off to one side is normal.  See :ref:`quick_start:alignment`.
+- **The star chart is "zenith up", not eyepiece-matched.**  The on-screen chart is a naked-eye
+  view, oriented as you'd see the sky looking up, so it won't match the flipped or rotated
+  view through your eyepiece.  The object *image* previews, by contrast, are rotated to match
+  the eyepiece.
+- **Push-To numbers dim while you move the telescope.**  While you move, the PiFinder
+  estimates position from its motion sensor and dims the numbers to say so.  The instant you
+  stop, it takes a fresh photo, the numbers brighten, and the position is exact again.  This
+  is separate from the whole screen dimming in power-save mode.
+- **The charging light is slow to turn green.**  Near a full charge the current tapers off, so
+  the final stretch from blue to green takes a while.  That's normal, not a fault.
 
 
 Frequently Asked Questions
 --------------------------
 
 **Do I still need a finder scope or Telrad?**
-   Not for finding objects — once aligned to your scope, the PiFinder replaces a
-   traditional finder.  A zero-power finder (a red dot or Telrad) is handy for the
-   *initial* alignment, since that step asks you to put a bright star in your eyepiece to
+   Not for finding objects.  Once aligned to your telescope, the PiFinder replaces a
+   traditional finder.  A zero-power finder, such as a red dot or a Telrad, is handy for the
+   *initial* alignment, because that step asks you to put a bright star in your eyepiece to
    select it on the PiFinder's chart.
 
 **Does it work in light-polluted skies?**
-   Yes — very well.  Leave the exposure on **AUTO** and the PiFinder adapts it to the sky;
-   setting it by hand, a longer 0.4 s helps pull stars out under heavy light pollution.
-   Good focus matters most of all here.
+   Yes, very well.  Leave the exposure on **AUTO** and the PiFinder adapts it to the sky.  If
+   you set it by hand, a longer 0.4 s helps pull stars out under heavy light pollution.  Good
+   focus matters most of all here.
 
 **How do I update the software?**
-   From the unit, go to Tools → Software Upd while connected to a WiFi network with
-   internet access (Client mode).  If the version reads "unknown", the PiFinder can't
-   reach the internet to check — that's a connectivity issue, not a reason to re-image.
+   Connect the PiFinder to a WiFi network with internet access (Client mode).  From the main
+   menu, select Tools, then select Software Upd.  If the version reads "unknown", the PiFinder
+   can't reach the internet to check.  That is a connectivity issue, not a reason to re-image.
    Full details are in :ref:`user_guide:update software`.
 
 **What's the default password for the web interface?**
-   ``solveit`` — all lowercase, one word.  The home screen is viewable without it; other
-   pages require it.  You can change it under the web interface's Tools page.
+   ``solveit``, all lowercase, one word.  You can view the home screen without it.  The other
+   pages require it.  You can change it on the web interface's Tools page.
 
 **How long does the battery last?**
-   About ten hours, and that's a floor: it was measured with the camera solving
+   About ten hours, and that is a floor.  It was measured with the camera solving
    continuously, the screen at full brightness and sleep off, so ordinary observing runs
-   longer.  Runtime is highly activity-dependent — sitting on a single object lets the
-   PiFinder drop into a lower-power mode and stretches it, while a fast tour through many
-   objects shortens it.  You don't have to guess, though: the title bar's
+   longer.  Runtime depends heavily on what you do.  Sitting on a single object lets the
+   PiFinder drop into a lower-power mode and stretches the runtime, while a fast tour through
+   many objects shortens it.  You don't have to guess.  The title bar's
    :ref:`battery indicator <user_guide:the battery indicator>` shows how much longer it
-   will run, and the PiFinder warns at 10% and 5% before performing
+   will run, and the PiFinder warns at 10% and 5% before it performs
    :ref:`an orderly shutdown <user_guide:low-battery warnings and automatic shutdown>`
-   rather than cutting out.  For long sessions keep a USB-C power bank handy — you can
+   rather than cutting out.  For long sessions keep a USB-C power bank handy.  You can
    hot-plug it while the PiFinder is running.
 
    .. note::
@@ -237,43 +233,43 @@ Frequently Asked Questions
    guest, no password).  See :ref:`connectivity:shared data access`.
 
 **Can I connect SkySafari?**
-   Yes — the PiFinder talks to SkySafari and other planetarium apps over WiFi.  See the
+   Yes.  The PiFinder talks to SkySafari and other planetarium apps over WiFi.  See the
    :doc:`skysafari` page for setup.
 
 **Can I enter my own coordinates?**
-   Yes.  You can type an arbitrary RA/Dec for objects that aren't in the built-in catalogs
-   — handy for asteroids, comets, or newly discovered objects — and you can also send
-   targets from SkySafari.  See :ref:`user_guide:custom targets` for how.
+   Yes.  You can type an RA/Dec of your own for objects that aren't in the built-in catalogs,
+   which is handy for asteroids, comets, or newly discovered objects.  You can also send
+   objects from SkySafari.  See :ref:`user_guide:custom targets` for how.
 
-**I rotated my PiFinder to fit a different scope — do I need to change anything?**
-   Yes.  rev4 is one unit whose body rotates between the Left, Right and Straight
-   positions, and the software has to be told which one you've moved it to.  Skip that and
-   the **Push-To directions come out reversed**: you push the scope the way the arrows
-   point and the target moves further away.  Set **PiFinder Type** under Settings to match,
-   as described in :ref:`Configuration Setup <quick_start:configuration setup>`.
+**I rotated my PiFinder to fit a different telescope.  Do I need to change anything?**
+   Yes.  One rev4 PiFinder covers all three positions, because its body rotates between Left,
+   Right and Straight, and the software has to know which one you moved it to.  Skip that step
+   and the **Push-To directions come out reversed**.  You push the telescope the way the
+   arrows point, and the object moves further away.  Set **PiFinder Type** under Settings to
+   match, as described in :ref:`Configuration Setup <quick_start:configuration setup>`.
 
 **Can I use the PiFinder on an EQ mount?**
-   Yes — the PiFinder works with any mount, and plate solving behaves the same whatever the
+   Yes.  The PiFinder works with any mount, and plate solving behaves the same whatever the
    mount type.  Switch it to EQ mode in the :ref:`user_guide:settings menu` by setting
    "Mount Type" to EQ, which presents Push-To distances in RA/Dec instead of Alt/Az.  On
-   software 2.5.0 and earlier the accelerometer tracking doesn't work correctly in EQ mode,
-   so the Push-To numbers are unreliable while you move the scope; once you stop and the
-   camera solves, the correct distances appear.  From version 2.6.0 on, EQ mode is fully
-   supported with accelerometer tracking.
+   software 2.5.0 and earlier the accelerometer tracking doesn't work correctly in EQ mode, so
+   the Push-To numbers are unreliable while you move the telescope.  Once you stop and the
+   camera solves, the correct distances appear.  Version 2.6.0 and later support EQ mode
+   fully, with accelerometer tracking.
 
 **Can I control my motorized (GoTo) mount with the PiFinder?**
-   Not yet — this is in active development.  It will rely on INDI support for your mount,
-   so even once the software is ready it may not work with every one; check INDI's
-   supported-mount list at http://drivers.indilib.org/mounts/.  There's no arrival date
-   yet, as it depends on a planned move to a newer OS distribution with a more current
-   version of INDI.
+   Not yet.  This is in active development.  It will rely on INDI support for your mount, so
+   even once the software is ready it may not work with every mount.  Check INDI's
+   supported-mount list at http://drivers.indilib.org/mounts/.  There is no arrival date yet,
+   because it depends on a planned move to a newer OS distribution with a more current version
+   of INDI.
 
-**The operating system clock is wrong — does that matter?**
-   No.  The PiFinder runs standalone without internet, and the Raspberry Pi has no
-   real-time clock, so it can't keep accurate time on its own.  It saves the time at
-   shutdown and reads it back at startup as a rough estimate, which can be off by days if
-   the unit has been powered down for a while.  The software doesn't trust the system clock
-   — it uses GPS time for everything except log-file timestamps.
+**The operating system clock is wrong.  Does that matter?**
+   No.  The PiFinder runs standalone without internet, and the Raspberry Pi has no real-time
+   clock, so it can't keep accurate time on its own.  It saves the time at shutdown and reads
+   it back at startup as a rough estimate.  That estimate can be off by days if the PiFinder
+   has been turned off for a while.  The software doesn't trust the system clock.  It uses GPS
+   time for everything except log-file timestamps.
 
    To sync the system clock to GPS time, run these commands in a terminal on the PiFinder:
 
@@ -288,10 +284,10 @@ Frequently Asked Questions
 
       refclock SHM 0 poll 3 refid gps1
 
-   This lets chrony use GPS time as a reference.  In WiFi client mode chrony will usually
-   prefer internet NTP servers over GPS, so the OS time may still be a second or two off.
-   When running off-grid, the system clock stays inaccurate until you get a GPS lock.
+   This lets chrony use GPS time as a reference.  In WiFi client mode chrony usually prefers
+   internet NTP servers over GPS, so the OS time may still be a second or two off.  When
+   running off-grid, the system clock stays inaccurate until you get a GPS lock.
 
-Have another question?  Send it to `info@PiFinder.io <mailto:info@pifinder.io>`_ and I'll
-do my best to help, and maybe add it here.  Better yet, fork the repo and contribute the
-answer via a pull request.
+Have another question?  Send it to `info@PiFinder.io <mailto:info@pifinder.io>`_ and I'll do
+my best to help, and maybe add it here.  Better yet, fork the repo and contribute the answer
+in a pull request.


### PR DESCRIPTION
Full simplified technical English pass over `docs/source/troubleshooting.rst`, using the `docs` skill's seven rules and approved-term table. Part of the manual-wide conversion, one PR per file.

## Measured change

```
  PASS  docs/source/troubleshooting.rst
     em-dash 34->0 | semicolon 9->0 | banned 16->4 | words 2578->2578 (-0%)
     terms: choose 2->0, tap 1->0, the unit 6->0, target 4->1
OVERALL: PASS
```

## What the converting agent reported

```
EM_DASHES: 34 -> 0
SEMICOLONS: 9 -> 0
TERMS: "tap +" -> "press +" (both in the chord form "Hold SQUARE and press +");
  unit/your unit -> the PiFinder x6; power verbs normalised to turn on/turn off
  ("won't power up" -> "won't turn on"); "hold the PWR button down" -> "press
  and hold the PWR button" (approved long-press form); choose->select x3;
  scope->telescope x10 ("finder scope" kept as a fixed compound);
  target->object x3 (the Custom Targets feature name untouched);
  the glyph path "Tools -> Software Upd" replaced with a prose chain, the path
  confirmed against menu_map.rst and user_guide.rst
STRUCTURAL: 30 sentence splits, no diagnostic step or list item reordered.
  4 parentheticals promoted to sentences. The longest bullet (Focus, properly)
  split from one 5-clause sentence into four. Two FAQ question lines were
  re-punctuated - these are definition-list terms, not rST headings, so they
  are not autosectionlabel targets. Word count unchanged at 2578.
LEFT_ALONE: all 8 section headings byte-identical.
  "boot"/"booting" kept rather than converted, because the heading "The screen
  is blank, or it won't finish booting" is frozen, and body text saying "start
  up" would read as a different thing. "turn on" now covers only the power
  action and "boot" only the process.
  British spellings and two-space sentence spacing kept as house convention.
FACT_CONCERNS: none. The PWR button location, the two-second hold, the shutdown
  confirmation and the 14-second power-system reset were all cross-checked
  against quick_start.rst and user_guide.rst and agree.
```

## Safety

Style only. No facts, numbers, procedures or step order were changed.

Verified mechanically against `origin/main` that every heading (text *and* underline character), every `:ref:`, `:doc:`, image path, substitution, `include::` and external URL is unchanged. Headings matter because `autosectionlabel` turns each one into a cross-reference target that other pages depend on, and a rename would break them silently.

Sphinx builds clean under `-n` (nitpicky).

Any `FACT_CONCERNS` above were deliberately **not** fixed. They are reported for a maintainer decision, since changing them would be a content edit rather than a style one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqTCarGCgTRWBQ1ysG8XFD
