### PR TITLE
docs: convert the user guide to the house style

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -63,9 +63,9 @@ options.  Scroll through a menu and select items with these keys:
 .. This key list is duplicated in quick_start.rst (Using the PiFinder).  Keep the two in sync.
 
 - The **UP** and **DOWN** arrows scroll the current menu
-- The **RIGHT** arrow selects the current menu item, or moves you to another menu
+- The **RIGHT** arrow selects the current menu item, which either sets an option or opens another menu
 - The **LEFT** arrow takes you back to the previous menu or screen
-- Press and hold **LEFT** for more than a second to return to the TOP of the menus
+- Press and hold **LEFT** for more than a second to jump back to the TOP of the menus
 
 The arrows are the four directions of the joystick.  Pressing the joystick straight in does
 the same as the **SQUARE** key.
@@ -196,7 +196,7 @@ items:
   for observing projects and finding the nearest objects in a particular catalog.
 - **Recent**: Starts empty and builds a history of the objects you've looked at during
   the current session.
-- **Custom**: Enter a right ascension and declination by hand to make a one-off target.
+- **Custom**: Enter a right ascension and declination by hand to make a one-off Custom Target.
   See :ref:`user_guide:custom targets`.
 - **Name Search**: Search for objects by name with the number keypad.  This is how you find
   the Snowball planetary or the Cat's Eye.
@@ -561,7 +561,7 @@ many objects matched, and opens the result as a regular
 
 Entries that match a catalog behave exactly like objects you find by browsing.  Images,
 descriptions, and your observation logs all come along.  An entry the PiFinder cannot
-match, but that includes coordinates, becomes a one-off target under the code OBS, so
+match, but that includes coordinates, becomes a one-off object under the code OBS, so
 nothing on your list is left behind.
 
 .. note::

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -650,12 +650,12 @@ As an example, here are the images available for M57
 
 
 .. image:: ../../images/screenshots/CATALOG_images_002_docs.png
-   :target: ../../images/screenshots/CATALOG_images_002_docs.png
+   :target: _images/CATALOG_images_002_docs.png
    :alt: Catalog Image
 
 
 .. image:: ../../images/screenshots/CATALOG_images_003_docs.png
-   :target: ../../images/screenshots/CATALOG_images_003_docs.png
+   :target: _images/CATALOG_images_003_docs.png
    :alt: Catalog Image
 
 

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -10,40 +10,40 @@ PiFinder™ User Manual
    :ref:`Which PiFinder do I have? <quick_start:which pifinder do i have?>` in the Quick
    Start.
 
-   If you need docs for a previous version please choose `1.x.x <https://pifinder.readthedocs.io/en/v1.11.2/index.html>`_
-   , `2.0.x <https://pifinder.readthedocs.io/en/v2.0.4/index.html>`_
-   or `2.1.x <https://pifinder.readthedocs.io/en/v2.1.1/index.html>`_
+   For docs covering a previous version, see
+   `1.x.x <https://pifinder.readthedocs.io/en/v1.11.2/index.html>`_,
+   `2.0.x <https://pifinder.readthedocs.io/en/v2.0.4/index.html>`_ or
+   `2.1.x <https://pifinder.readthedocs.io/en/v2.1.1/index.html>`_.
 
-Thanks for your interest in the PiFinder!  This guide describes how to use one; if you
-want to build one, see the :doc:`Build Guide <build_guide>` and the
-:doc:`Bill of Materials <BOM>`.
+Thanks for your interest in the PiFinder!  This guide describes how to use one.  To build
+one, see the :doc:`Build Guide <build_guide>` and the :doc:`Bill of Materials <BOM>`.
 
-The manual is divided into sections you can reach from the links to the left.  Let's dig
-into what the PiFinder can do.
+The manual has sections you can reach from the links to the left.  Let's dig into what the
+PiFinder can do.
 
 How It Works
 ===============
 
 The PiFinder is a self-contained telescope positioning device.  It tells you where your
-telescope is pointed, lets you pick a target such as a galaxy or other DSO, and directs
-you on how to move the scope to find it.  There are other nice features alongside these
-core functions, but the PiFinder is designed primarily to get interesting objects into
-your eyepiece for a look.
+telescope is pointed, lets you select an object such as a galaxy or another deep-sky
+object, and directs you on how to move the telescope to find it.  It has other useful
+features alongside these core functions, but its main purpose is to get interesting objects
+into your eyepiece for a look.
 
 To direct you, the PiFinder needs to know where your telescope is pointed.  It works this
-out directly, by photographing the night sky and examining the star patterns to determine
-which section of sky it's seeing — incredibly fast (up to 20 times per second!) and very
-accurately.  This only works while the scope is still, so it pairs that camera with an
-accelerometer (the IMU, as the Status screen and Settings menu call it) that estimates
-how far the scope has moved since the last solve.  The
-estimate carries some error, but the moment you stop, a fresh photo corrects it.  The
-PiFinder works out its own orientation as it solves, so it can be mounted at any angle —
-it doesn't need to sit upright — as long as the camera points the same way as your scope.
+out directly.  It photographs the night sky and examines the star patterns to determine
+which section of sky it sees.  It does this quickly, up to 20 times per second, and very
+accurately.  This only works while the telescope is still, so the PiFinder pairs the camera
+with an accelerometer that estimates how far the telescope has moved since the last solve.
+The Status screen and the Settings menu call this sensor the IMU.  The estimate carries
+some error, but the moment you stop, a fresh photo corrects it.  The PiFinder works out its
+own orientation as it solves, so you can mount it at any angle.  It does not need to sit
+upright, as long as the camera points the same way as your telescope.
 
-Knowing where your scope points and where thousands of interesting objects sit, the
-PiFinder combines the two to show you how to move the scope to bring any of those objects
-into your eyepiece.  Because it observes your actual pointing direction, you can trust
-you're on target.
+The PiFinder knows where your telescope points and where thousands of interesting objects
+sit, so it can show you how to move the telescope to bring any of those objects into your
+eyepiece.  Because it measures where the telescope actually points, you can trust its
+guidance.
 
 .. note::
    For a general overview of using the PiFinder, read the :doc:`quick_start`.  This manual
@@ -52,23 +52,23 @@ you're on target.
 The Menu System
 =====================================
 
-All of the PiFinder's functions are reached through its menu system:
+You reach all of the PiFinder's functions through its menu system:
 
 .. image:: images/quick_start/main_menu_01_docs.png
 
 
-Each menu is a list of items representing a submenu, a screen, or a set of options.  Scroll
-through a menu and make selections with these keys:
+Each menu is a list of items.  A menu item leads to a submenu, a screen, or a set of
+options.  Scroll through a menu and select items with these keys:
 
-.. This key list is duplicated in quick_start.rst (Using the PiFinder) — keep the two in sync.
+.. This key list is duplicated in quick_start.rst (Using the PiFinder).  Keep the two in sync.
 
 - The **UP** and **DOWN** arrows scroll the current menu
-- The **RIGHT** arrow activates the current option, selecting it or moving to another menu
+- The **RIGHT** arrow selects the current menu item, or moves you to another menu
 - The **LEFT** arrow takes you back to the previous menu or screen
-- Holding **LEFT** for more than a second always returns to the TOP of the menus
+- Press and hold **LEFT** for more than a second to return to the TOP of the menus
 
-The arrows are the four directions of the joystick, and pressing the joystick straight in
-does the same as the **SQUARE** key.
+The arrows are the four directions of the joystick.  Pressing the joystick straight in does
+the same as the **SQUARE** key.
 
 .. note::
    On v3 and v2.5 PiFinders the arrows are four separate buttons in a row along the bottom
@@ -77,87 +77,88 @@ does the same as the **SQUARE** key.
 
 The status bar at the top of the screen shows the name of the menu you're viewing.
 
-For a bird's-eye view of every menu and what each option does, see the
+For a bird's-eye view of every menu and what each menu item does, see the
 :doc:`menu_map`.
 
 Screens
 --------
 
-Some menu items, like Camera, lead to a specific screen — a camera preview, a star chart,
-or details about a catalog object.  Each screen is covered in more detail below.
+Some menu items, like Camera, lead to a specific screen: a camera preview, a star chart, or
+details about a catalog object.  The sections below cover each screen in more detail.
 
 Options
 --------
 
-Some menus present a list of options where you choose one or more items to control how the
-PiFinder operates.  For instance, the Set Filters menu items take you to a sub-menu of ways
+Some menus present a list of options where you select one or more items to control how the
+PiFinder operates.  For instance, the Set Filters menu item takes you to a sub-menu of ways
 to filter your object lists:
 
 
 .. image:: images/user_guide/options_menu_01.png
 .. image:: images/user_guide/options_menu_02.png
 
-Selecting Type presents the DSO types you can choose to control which objects appear in
+Select Type to see the deep-sky object types you can use to control which objects appear in
 your object lists.
 
 .. image:: images/user_guide/options_menu_03.png
 .. image:: images/user_guide/options_menu_04.png
 
-Lists that offer selections show a check-mark next to the one or many options selected.
-Pressing the **RIGHT** arrow with an option highlighted selects or de-selects it.
+Lists that offer selections show a check-mark next to each selected option.  Press
+**RIGHT** with an option highlighted to select or de-select it.
 
 
 .. image:: images/user_guide/options_menu_04.png
 .. image:: images/user_guide/options_menu_05.png
 
-For menus that allow only a single selection, such as Altitude, choosing one item
+In menus that allow only a single selection, such as Altitude, selecting one option
 de-selects any others.  Multi-Select menus offer options to select or de-select all items
 at once.
 
-When you're done, press the **LEFT** arrow to return to your last menu or screen.
+When you're done, press **LEFT** to go back to your last menu or screen.
 
 
-With this simple set of scroll-and-select tools you can reach all the PiFinder's powerful
+With this simple set of scroll-and-select tools you can reach all of the PiFinder's
 features.
 
 Quick Menu
 -------------------------------------
 
-You can reach everything through the menu system, but a secondary quick-menu brings some
+You can reach everything through the menu system.  A secondary quick-menu brings some
 functions into easier reach.
 
-Hold the **SQUARE** key to open the Quick Menu
+Press and hold **SQUARE** to open the Quick Menu.
 
 .. image:: images/user_guide/quick_menu_00.png
 
-This menu presents up to four options, one per arrow button; press the arrow to select its
-item.  The menu changes with the screen you're on, but often has
+This menu presents up to four options, one per arrow button.  Press an arrow to select its
+item.  The menu changes with the screen you're on, but it often has
 :ref:`HELP<user_guide:help system>` at the UP option.  The Focus screen above offers HELP
 and Exposure.
 
 Some Quick Menus have a second layer.  The Object List's Quick Menu, for example, offers
-Sort and Filter; pressing LEFT for Sort opens a ring of sort orders, with subtle shading
-marking the current one.
+Sort and Filter.  Press **LEFT** for Sort to open a ring of sort orders, with subtle
+shading marking the current one.
 
 .. image:: images/user_guide/quick_menu_01.png
    :width: 45%
 .. image:: images/user_guide/quick_menu_02.png
    :width: 45%
 
-Pick a sort order to apply it.  Exit the Quick Menu at any time by pressing SQUARE again.
+Select a sort order to apply it.  To exit the Quick Menu at any time, press **SQUARE**
+again.
 
 Help System
 --------------
 
-Many screens offer help with specific button functions and other details about how things
-work or what a page is for.
+Many screens offer help with their button functions, and with other details about how
+things work or what a screen is for.
 
 When available, HELP is the UP option in the Quick Menu
 
 .. image:: images/user_guide/quick_menu_00.png
 
-Pressing the UP arrow selects help and displays one or more pages.  A prompt at the top or
-bottom of the screen shows when more pages are available; press UP or DOWN to scroll
+Press **UP** to select help.  Help opens one or more pages.  A prompt at the top or bottom
+of the screen shows when more pages are available.  Press **UP** or **DOWN** to scroll
 through them.
 
 .. image:: images/user_guide/camera_help_01.png
@@ -166,15 +167,15 @@ through them.
 Observing with PiFinder
 ========================
 
-Out under the stars, you'll be doing four basic things in various combinations:
+Out under the stars, you do four basic things in various combinations:
 
 * Curating a list of objects you're interested in
 * Viewing details about those objects
-* Pushing the scope to bring them into your eyepiece
+* Pushing the telescope to bring them into your eyepiece
 * Logging your observations
 
-Everyone observes their own way, so the PiFinder offers different ways to use (or skip!)
-these features for a great night out.
+Everyone observes their own way, so the PiFinder lets you use these features, or skip them,
+as your night out demands.
 
 Object List
 --------------------
@@ -182,35 +183,34 @@ Object List
 The Object List is one of the PiFinder's main features.  It presents a collection of
 objects you've selected using catalogs, filters, observing lists, and text search.
 
-To pick a starting point, choose Objects from the main PiFinder menu, then choose one of
-five options:
+To start a list, select Objects from the main PiFinder menu, then select one of five menu
+items:
 
 .. image:: images/user_guide/objects_menu.png
 
 - **All Filtered**: All objects across all catalogs that meet your
-  :ref:`filter criteria<user_guide:filters>`.  This could be thousands of objects and is
-  most useful with strict filters, such as globulars above 30 degrees altitude and brighter
-  than magnitude 10.
+  :ref:`filter criteria<user_guide:filters>`.  This could be thousands of objects, and it
+  is most useful with strict filters, such as globulars above 30 degrees altitude and
+  brighter than magnitude 10.
 - **By Catalog**: All objects from a specific catalog that meet your filter criteria.  Great
   for observing projects and finding the nearest objects in a particular catalog.
-- **Recent**: Starts empty and builds a history of the objects you've checked out during
+- **Recent**: Starts empty and builds a history of the objects you've looked at during
   the current session.
 - **Custom**: Enter a right ascension and declination by hand to make a one-off target.
   See :ref:`user_guide:custom targets`.
-- **Name Search**: Using the number keypad, search for objects by name.  The Snowball
-  planetary?  Cat's Eye?  This is the way to find them.
+- **Name Search**: Search for objects by name with the number keypad.  This is how you find
+  the Snowball planetary or the Cat's Eye.
 
 However you build the list, it always displays the same information and offers the same
 sorting and selection.
 
 .. image:: images/user_guide/object_list_01_docs.png
 
-A symbol along the left shows each object's type.  Next to it is the designation — usually
-the catalog abbreviation and index number — then the distance from your current telescope
+A symbol along the left shows each object's type.  Next to it is the designation, usually
+the catalog abbreviation and index number, then the distance from your current telescope
 position.  Each entry's brightness hints at its magnitude.
 
-Pressing the **SQUARE** key cycles through additional information for the objects on the
-list.
+Press **SQUARE** to cycle through additional information for the objects on the list.
 
 .. image:: images/user_guide/object_list_02_docs.png
 
@@ -218,48 +218,48 @@ You can see a scrolling list of common names for each object.
 
 .. image:: images/user_guide/object_list_03_docs.png
 
-And the magnitude and size of each object, with a check mark to indicate whether you've
-observed and logged it before.
+The next press shows the magnitude and size of each object, with a check mark to indicate
+whether you've observed and logged it before.
 
-Holding the **SQUARE** key brings up the Quick Menu to sort and filter this list.
+Press and hold **SQUARE** to open the Quick Menu, where you can sort and filter this list.
 
 .. image:: images/user_guide/object_list_radial_docs.png
 
-Pressing **LEFT** selects SORT
+Press **LEFT** to select SORT
 
 .. image:: images/user_guide/object_list_sort_docs.png
 
-By default, lists use STANDARD order — usually the order they appear in catalogs.  Press
-the indicated arrow to choose another order such as NEAREST, which puts the object closest
-to your current telescope position at the top.
+By default, lists use STANDARD order.  That is usually the order the objects appear in the
+catalogs.  Press the indicated arrow to select another order such as NEAREST, which puts
+the object closest to your current telescope position at the top.
 
 .. image:: images/user_guide/object_list_04_docs.png
 
 If you start typing a number, the Object List jumps to the next object with that index
-number.  Use the **UP/DOWN** arrows to step to the next or previous match, and the
-**SQUARE** key to exit jump mode and select an object.
+number.  Press the **UP/DOWN** arrows to step to the next or previous match.  Press
+**SQUARE** to exit jump mode and select an object.
 
-Pressing the **RIGHT** key brings you to details for the selected object.
+Press **RIGHT** to open the details for the selected object.
 
 Object Details
 --------------------
 
-Pressing the **RIGHT** key from the Object List brings up the Object Details screen for the
-highlighted object.  This screen shows large Push-To instructions,
+Press **RIGHT** from the Object List to open the Object Details screen for the highlighted
+object.  This screen shows large Push-To instructions,
 :ref:`object images<user_guide:object images>`, and catalog details.
 
-Pressing **SQUARE** cycles through the object's information and **UP/DOWN** moves to the
-next or previous object in the list.  **LEFT** returns to the full list, and **RIGHT**
-brings up the :ref:`Logging<user_guide:logging observations>` interface for the current
-object.
+Press **SQUARE** to cycle through the object's information.  Press **UP/DOWN** to move to
+the next or previous object in the list.  **LEFT** goes back to the full list, and
+**RIGHT** opens the :ref:`Logging<user_guide:logging observations>` interface for the
+current object.
 
 .. image:: images/user_guide/object_details_01.png
 
-The Push-To info shows which way, and how far, to move your telescope to put the object in
-your eyepiece.  As you move the scope the numbers dim, indicating the PiFinder is using the
-accelerometer to estimate where the telescope is pointing.  When you stop, or move slowly
-enough, the camera plate solves to provide an absolute position and the numbers brighten
-again.
+The Push-To information shows which way, and how far, to move your telescope to put the
+object in your eyepiece.  As you move the telescope the numbers dim, which means the
+PiFinder is using the accelerometer to estimate where the telescope points.  When you stop,
+or move slowly enough, the camera plate solves to give an absolute position and the numbers
+brighten again.
 
 When the numbers are near 0.00 the object should be in your eyepiece.  The numbers are the
 distance to the object in degrees, so with an eyepiece offering a 0.5 degree true field of
@@ -269,37 +269,37 @@ Closer to zero means more centered.  For a very dim object, knowing it's dead ce
 consulting the object image can make all the difference.
 
 .. note::
-   By default the Push-To arrows guide you in altitude and azimuth — the way an Alt/Az or
+   By default the Push-To arrows guide you in altitude and azimuth, the way an Alt/Az or
    Dobsonian mount moves.  On an equatorial mount or platform, set Mount Type to Equatorial
-   in the :ref:`user_guide:settings menu` and the guidance switches to right ascension and
-   declination to match your mount's axes.
+   in the :ref:`user_guide:settings menu`.  The guidance then switches to right ascension
+   and declination to match your mount's axes.
 
 The number in the upper right is the object's
-:ref:`contrast reserve <user_guide:contrast reserve>` — an estimate of how easily it
+:ref:`contrast reserve <user_guide:contrast reserve>`.  It estimates how easily the object
 should show in your eyepiece tonight.
 
 .. image:: images/user_guide/object_details_02.png
 
-The PiFinder can display images of every object in its catalog.  See the section on
+The PiFinder can show images of every object in its catalog.  See the section on
 :ref:`object images<user_guide:object images>` below for more.
 
 .. image:: images/user_guide/object_details_03.png
 
 Depending on the catalog, the PiFinder may have detailed notes alongside the object's type,
-constellation, magnitude, and size — the size is shown in degrees, arcminutes, or arcseconds,
-whichever best suits the object.  Use the **+/-** keys to scroll the notes.
+constellation, magnitude, and size.  It gives the size in degrees, arcminutes, or
+arcseconds, whichever best suits the object.  Use the **+/-** keys to scroll the notes.
 
 Many objects carry more than one catalog designation, and the notes can gather a description
-from each.  A bright horizontal rule labelled with the catalog and number — for example
-*NGC 6543* — sets one catalog's notes off from the next, so you can see at a glance where
+from each.  A bright horizontal rule labelled with the catalog and number, for example
+*NGC 6543*, separates one catalog's notes from the next, so you can see at a glance where
 each note comes from.  The notes finish with a count of how many times you've logged the
 object, marked by its own rule (it reads *Not Logged* until your first sighting).
 
 What each part of the screen shows
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Object Details screen packs a lot in.  These two views label every part — the Push-To
-screen, and the catalog details you reach by pressing **SQUARE**:
+The Object Details screen packs a lot in.  These two views label every part.  The first is
+the Push-To screen.  The second is the catalog details you reach by pressing **SQUARE**.
 
 .. image:: images/user_guide/object_details_pushto_annotated.png
 
@@ -308,8 +308,8 @@ screen, and the catalog details you reach by pressing **SQUARE**:
 Contrast Reserve
 ^^^^^^^^^^^^^^^^^
 
-The number in the upper right of the Object Details screen is the **contrast reserve** — an
-estimate of how easily an object should stand out in your eyepiece.  It weighs the object's
+The number in the upper right of the Object Details screen is the **contrast reserve**.  It
+estimates how easily an object should stand out in your eyepiece.  It weighs the object's
 brightness and size against your sky brightness, your telescope's aperture, and the
 magnification of your active eyepiece, then compares the result to what the eye can detect.
 A higher number means the object should be easier to see.
@@ -340,56 +340,56 @@ own with a plain-language reading of what to expect:
 The contrast reserve appears only when the PiFinder has everything it needs to work it out:
 an active :ref:`telescope and eyepiece <equipment:choosing your active telescope and eyepiece>`,
 a sky-brightness reading, and an object with a known magnitude and size.  If any of these is
-missing — a double star with no single magnitude, or before the camera has estimated the sky
-brightness — the number is simply left off.
+missing, the PiFinder leaves the number off.  A double star has no single magnitude, for
+example, and the sky brightness is unknown until the camera has estimated it.
 
 .. note::
    The sky-brightness figure comes from the PiFinder's Sky Quality Meter (SQM), its
-   camera-based estimate of how dark your sky is, so the contrast reserve tracks your real
-   conditions: the same object reads higher under a dark sky than from town.  Treat it as a
-   guide rather than a guarantee — averted vision, transparency, and how dark-adapted you
-   are all still play their part at the eyepiece.
+   camera-based estimate of how dark your sky is.  The contrast reserve therefore tracks
+   your real conditions: the same object reads higher under a dark sky than from town.
+   Treat it as a guide rather than a guarantee.  Averted vision, transparency, and how
+   dark-adapted you are all play their part at the eyepiece.
 
 Star Chart
 -------------
 
 The Star Chart, reached from the main PiFinder menu, draws a live map of the sky around
-where your telescope is pointing, with constellation lines and markers for nearby objects.
-It redraws as you move the scope, so it's a quick way to see what's around you and confirm
-your aim.  Zoom in and out with the **+/-** keys.
+where your telescope points, with constellation lines and markers for nearby objects.  It
+redraws as you move the telescope, so it is a quick way to see what is around you and
+confirm your aim.  Zoom in and out with the **+/-** keys.
 
-Deep-sky objects show as small symbols, one shape per object type.  Near where you're
-pointing the chart marks the objects your :ref:`filters <user_guide:filters>` allow,
-revealing fainter ones as you zoom in and keeping only the brightest as you zoom out so the
-field never crowds.  Objects on a loaded observing list are marked too.  Dim these markers,
-or switch them off, with the DSO Display setting under Chart... in the
+Deep-sky objects show as small symbols, one shape per object type.  Near where you point,
+the chart marks the objects your :ref:`filters <user_guide:filters>` allow.  It reveals
+fainter ones as you zoom in and keeps only the brightest as you zoom out, so the field never
+crowds.  The chart also marks objects on a loaded observing list.  To dim these markers, or
+switch them off, use the DSO Display setting under Chart... in the
 :ref:`user_guide:settings menu`.
 
-The object you last opened in :ref:`user_guide:object details` is marked with a brighter
-cross wherever you steer, a quick way to see where it sits relative to your aim.  On the
-chart the cross is labelled with the object's designation — "M 57", say; once it drifts off
-the edge an arrow at the rim points the way instead.  The cross stays bright even with DSO
-Display turned off.
+A brighter cross marks the object you last opened in :ref:`user_guide:object details`,
+wherever you steer.  It is a quick way to see where that object sits relative to your aim.
+On the chart the cross carries the object's designation, "M 57" for example.  Once the
+object drifts off the edge, an arrow at the rim points the way instead.  The cross stays
+bright even with DSO Display turned off.
 
-How the chart is turned is up to you.  Choose Coordinate Sys. under Chart... in the
+You decide how the chart is turned.  Select Coordinate Sys. under Chart... in the
 :ref:`user_guide:settings menu`:
 
 - **Horizontal** (the default) keeps the horizon level and the zenith up, matching what you
   see with the naked eye.
-- **EQ (Auto)** lines the chart up with the celestial pole — north-up in the northern
+- **EQ (Auto)** lines the chart up with the celestial pole: north-up in the northern
   hemisphere, south-up in the southern.
 - **EQ (North-up)** and **EQ (South-up)** force north-up or south-up wherever you are.
 
-The chart labels what's currently at the top — "Zenith up", "NCP up" (north celestial
-pole), or "SCP up" (south celestial pole) — so you always know how it's oriented.  The same
-orientation applies to the Align screen.
+The chart labels what is currently at the top, so you always know how it is oriented.  The
+labels are "Zenith up", "NCP up" (north celestial pole), and "SCP up" (south celestial
+pole).  The same orientation applies to the Align screen.
 
 .. note::
    The chart works before the PiFinder has a GPS fix.  The Horizontal and EQ (Auto) modes
-   need to know where you are to orient themselves, so until GPS locks — or you
-   :ref:`enter your location by hand <user_guide:place & time>` — the chart falls back to
-   north-celestial-pole-up and marks the label with a leading "!" (for example "!NCP up")
-   to show it's a temporary orientation that settles once your location is known.
+   need to know where you are to orient themselves.  Until GPS locks, or you
+   :ref:`enter your location by hand <user_guide:place & time>`, the chart falls back to
+   north-celestial-pole-up.  It marks the label with a leading "!", for example "!NCP up",
+   to show that the orientation is temporary and settles once your location is known.
 
 Filters
 ----------
@@ -400,7 +400,7 @@ Filters menu, the last item in the Objects menu.
 
 .. image:: images/user_guide/main_filter_option.png
 
-You can also jump to the filter options from the :ref:`user_guide:quick menu` on the Object
+You can also reach the filter options from the :ref:`user_guide:quick menu` on the Object
 List screen.
 
 .. image:: images/user_guide/object_list_radial_docs.png
@@ -410,16 +410,16 @@ option to clear every filter.
 
 .. image:: images/user_guide/filter_menu.png
 
-With no filters set, every available object appears — the All Filtered list will show over
-18,000 objects!
+With no filters set, every available object appears.  The All Filtered list then shows over
+18,000 objects.
 
 Some filter types take a single value, like Altitude, and some allow multiple selections,
 like Object type.  Here's a brief explanation of each:
 
-- **Catalogs**: Limit which catalogs are included in the All Filtered list.  This is
-  distinct from the catalog-specific object lists, which are a shortcut to one catalog.
-  Using the Catalogs filter, the All Filtered list can show globular clusters across
-  multiple catalogs at once.
+- **Catalogs**: Limit which catalogs the All Filtered list includes.  This is distinct from
+  the catalog-specific object lists, which are a shortcut to one catalog.  Using the
+  Catalogs filter, the All Filtered list can show globular clusters across multiple
+  catalogs at once.
 - **Type**: Limit by object type.  You can select multiple types to include.
 - **Altitude**: The current apparent altitude of an object from your observing location.
 - **Magnitude**: Limit to objects at least as bright as the selected magnitude.
@@ -432,7 +432,7 @@ The PiFinder has many catalogs, so this menu groups them by category.
 
 .. image:: images/user_guide/filter_catalogs.png
 
-Common catalogs appear at the top level for quick reference; less common ones sit in
+Common catalogs appear at the top level for quick reference.  Less common ones sit in
 sub-categories marked with an ellipsis (...).
 
 Here's the DSO... category as an example:
@@ -446,14 +446,14 @@ multiple spots.  Selecting or de-selecting anywhere changes its state everywhere
 Name Search
 ------------
 
-A powerful way to search the PiFinder's large object database is by name, letting you find
-objects by their common description, like the Cat's Eye nebula.  To reach the Name Search
-screen, select it from the Objects menu:
+Name Search is a powerful way to search the PiFinder's large object database.  It finds
+objects by their common name, like the Cat's Eye nebula.  To reach the Name Search screen,
+select it from the Objects menu:
 
 .. image:: images/user_guide/name_search_01.png
 
 It uses multi-tap text input, like the cellphones from the dawn of text messaging.  The
-on-screen keypad shows the letters available by pressing each number key several times in a
+on-screen keypad shows the letters you get by pressing each number key several times in a
 row.
 
 .. image:: images/user_guide/name_search_02.png
@@ -462,11 +462,11 @@ Each number key generates its number, then the three or four letters shown, in t
 long enough between presses, or press a different key, and the cursor moves to the next
 position.
 
-If you'd rather press each key just once, switch the search input to T9: every press enters
-its digit, and the PiFinder matches the digit sequence against the letters of each object
-name — ``1897`` finds Vega.  Choose between Multi-Tap and T9 under Search Input in the
-:ref:`user_guide:settings menu`, or hold **SQUARE** here and pick Input from the
-:ref:`user_guide:quick menu` to jump straight to the setting.
+To press each key just once, switch the search input to T9.  Every press enters its digit,
+and the PiFinder matches the digit sequence against the letters of each object name, so
+``1897`` finds Vega.  Select Multi-Tap or T9 under Search Input in the
+:ref:`user_guide:settings menu`.  You can also press and hold **SQUARE** here and select
+Input from the :ref:`user_guide:quick menu` to reach the setting directly.
 
 .. image:: images/user_guide/name_search_cat_01.png
 
@@ -479,46 +479,44 @@ The count drops as you add more text.
 
 .. image:: images/user_guide/name_search_cat_03.png
 
-Once you've narrowed the list enough, press the **RIGHT** key to see the full list of
-matches.
+Once you've narrowed the list enough, press **RIGHT** to see the full list of matches.
 
 .. image:: images/user_guide/name_search_results.png
 
 Custom Targets
 ---------------
 
-Sometimes the object you're after isn't in any catalog — a newly discovered comet, or a
-position from a chart or article.  Choose Custom from the Objects menu to enter a right
+Sometimes the object you're after isn't in any catalog: a newly discovered comet, or a
+position from a chart or article.  Select Custom from the Objects menu to enter a right
 ascension and declination by hand, then push to it like any other object.
 
 .. image:: images/user_guide/custom_radec_entry_docs.png
 
-Type the coordinates with the number keys; the **UP/DOWN** arrows move between fields and
-**-** deletes the last digit.  The **SQUARE** key cycles the entry format — full
+Type the coordinates with the number keys.  The **UP/DOWN** arrows move between fields, and
+**-** deletes the last digit.  Press **SQUARE** to cycle the entry format: full
 hours/minutes/seconds (shown above), decimal hours and degrees, or decimal degrees for
-both — with the active format named in the title bar.  With the declination degrees
-selected, **+** flips its sign; on the EPOCH field, **+** cycles between J2000, JNOW, and
-B1950.
+both.  The title bar names the active format.  With the declination degrees selected, **+**
+flips its sign.  On the EPOCH field, **+** cycles between J2000, JNOW, and B1950.
 
 When the numbers look right, press **RIGHT** to create the target.  The PiFinder makes a
 one-off object, opens its :ref:`Object Details<user_guide:object details>` screen with
 Push-To guidance, and adds it to the Recent list so you can return to it during the
-session.  Press **LEFT** to back out without creating anything.
+session.  Press **LEFT** to go back without creating anything.
 
 .. image:: images/user_guide/custom_radec_result_docs.png
 
 Observing Lists
 ---------------
 
-If you like to plan a session ahead of time — in SkySafari, a spreadsheet, or a list a
-fellow observer shared — you can bring that plan to the eyepiece.  Copy the list file into
-the ``obslists/`` folder of the PiFinder's :ref:`shared data
+You can bring a session you planned ahead of time to the eyepiece, whether you built it in
+SkySafari or a spreadsheet, or a fellow observer shared it with you.  Copy the list file
+into the ``obslists/`` folder of the PiFinder's :ref:`shared data
 folder <connectivity:shared data access>`, then load it from Obs Lists in the Objects
 menu.
 
 .. image:: images/user_guide/obs_lists_menu_docs.png
 
-The PiFinder reads observing lists in all of these formats, recognizing each by its file
+The PiFinder reads observing lists in all of these formats.  It recognizes each by its file
 extension and, for ``.txt`` files, by the content itself:
 
 .. list-table::
@@ -545,15 +543,15 @@ extension and, for ``.txt`` files, by the content itself:
    * - Plain text, one object name per line
      - ``.txt``
 
-The Obs Lists screen shows every list it finds, along with any folders — shown in
-``[brackets]`` — so you can organize lists into subfolders by trip, season, or source.
+The Obs Lists screen shows every list it finds, along with any folders.  Folder names appear
+in ``[brackets]``, so you can organize lists into subfolders by trip, season, or source.
 Scroll with the **UP/DOWN** arrows and press **RIGHT** to open a folder or load a list.
 
 .. image:: images/user_guide/obs_lists_browse_docs.png
 
-When two lists share a name — say you have both ``Messier Marathon.skylist`` and
-``Messier Marathon.csv`` — the format is appended to tell them apart, as in the image
-above.
+When two lists share a name, such as ``Messier Marathon.skylist`` and
+``Messier Marathon.csv``, the PiFinder appends the format to tell them apart, as in the
+image above.
 
 Loading a list matches each entry against the PiFinder's catalogs, briefly reports how
 many objects matched, and opens the result as a regular
@@ -561,24 +559,24 @@ many objects matched, and opens the result as a regular
 
 .. image:: images/user_guide/obs_lists_loaded_docs.png
 
-Entries that match a catalog behave exactly like objects you'd find by browsing — images,
-descriptions, and your observation logs all come along.  An entry the PiFinder can't match
-but that includes coordinates becomes a one-off target under the code OBS, so nothing on
-your list is left behind.
+Entries that match a catalog behave exactly like objects you find by browsing.  Images,
+descriptions, and your observation logs all come along.  An entry the PiFinder cannot
+match, but that includes coordinates, becomes a one-off target under the code OBS, so
+nothing on your list is left behind.
 
 .. note::
-   The ``.pifinder`` format is the PiFinder's own JSON list format, and the one to choose
-   when a planning tool offers it: it carries catalog references, magnitudes, object sizes,
-   and coordinate epochs that the other formats drop.  Its fields, JSON schema, and a worked
-   example are documented in the `observing-list formats reference
-   <https://github.com/brickbots/PiFinder/blob/main/docs/ax/catalog/obslist-formats/README.md#the-pifinder-format>`__.
+   The ``.pifinder`` format is the PiFinder's own JSON list format.  Use it when a planning
+   tool offers it, because it carries catalog references, magnitudes, object sizes, and
+   coordinate epochs that the other formats drop.  The `observing-list formats reference
+   <https://github.com/brickbots/PiFinder/blob/main/docs/ax/catalog/obslist-formats/README.md#the-pifinder-format>`__
+   documents its fields, JSON schema, and a worked example.
 
 Importing a CSV list
 ^^^^^^^^^^^^^^^^^^^^^
 
-CSV is the format to reach for when another tool — a spreadsheet, an observing planner, or
-a sky atlas — gives you a list as plain columns.  The first line is a header naming the
-columns; the PiFinder reads them by name, so their order does not matter and the case is
+CSV is the format to reach for when another tool gives you a list as plain columns: a
+spreadsheet, an observing planner, or a sky atlas.  The first line is a header naming the
+columns.  The PiFinder reads them by name, so their order does not matter and the case is
 ignored.  Only ``Name`` is required, plus coordinates so the PiFinder knows where to point:
 
 .. list-table::
@@ -595,10 +593,10 @@ ignored.  Only ``Name`` is required, plus coordinates so the PiFinder knows wher
    * - ``Type``
      - Object type such as ``Gx`` or ``PN``, optional.
 
-Common spellings of those headers are accepted too — ``ra`` / ``dec`` / ``mag`` and
-``RA_deg`` / ``Dec_deg`` all work.  The RA header can also carry the unit: a decimal under
-``RA_h`` or ``RA_hours`` is read as hours, while ``RA`` or ``RA_deg`` is read as degrees.
-Coordinates may be written in any of three forms:
+The PiFinder accepts common spellings of those headers too.  ``ra``, ``dec``, ``mag``,
+``RA_deg`` and ``Dec_deg`` all work.  The RA header can also carry the unit: the PiFinder
+reads a decimal under ``RA_h`` or ``RA_hours`` as hours, and one under ``RA`` or ``RA_deg``
+as degrees.  Write coordinates in any of three forms:
 
 .. list-table::
    :header-rows: 1
@@ -616,38 +614,38 @@ Coordinates may be written in any of three forms:
      - ``13h 43m 26s``
      - ``+28° 14' 39"``
 
-A decimal right ascension is read as **degrees** (0–360) unless its header names hours.  A
-small list might look like this::
+The PiFinder reads a decimal right ascension as **degrees** (0–360) unless its header names
+hours.  A small list looks like this::
 
    Name,RA,Dec,Magnitude
    My target,205.8583,28.2442,6.3
    Comet 2024X,250.667,36.411,11.0
 
-Each row resolves the same way as any other observing list: if its name matches a catalog
-object — spacing and capitalisation are ignored, so ``M 13``, ``M13`` and ``NGC 224`` all
-work — you get that object with its images, descriptions, and your logs; otherwise the
-PiFinder uses the row's own coordinates as an OBS target.  To keep your exact coordinates
-for an object the catalog would otherwise recognize, give the row a name the catalog will
-not match; prefixing it, as in ``_M 3``, is enough.
+Each row resolves the same way as any other observing list.  If its name matches a catalog
+object, you get that object with its images, descriptions, and your logs.  Matching ignores
+spacing and capitalisation, so ``M 13``, ``M13`` and ``NGC 224`` all work.  If the name
+matches nothing, the PiFinder uses the row's own coordinates as an OBS target.  To keep your
+exact coordinates for an object the catalog would otherwise recognize, give the row a name
+the catalog does not match.  A prefix, as in ``_M 3``, is enough.
 
-For the complete column reference — every accepted header spelling, the coordinate forms,
-and import notes — see the `observing-list formats reference
+For the complete column reference, see the `observing-list formats reference
 <https://github.com/brickbots/PiFinder/blob/main/docs/ax/catalog/obslist-formats/README.md#csv-import>`__.
+It covers every accepted header spelling, the coordinate forms, and the import notes.
 
 Object Images
 ---------------
 
-If you used the prebuilt PiFinder image or have :ref:`downloaded<software:catalog image download>`
-the set of catalog images, you can see what the selected object looks like via sky-survey
-images.  These display in the background of the :ref:`user_guide:object details` screen,
-and you can view them in full detail by pressing the **SQUARE** key to cycle through the
-pages of information about each object.
+If you used the prebuilt PiFinder image, or have
+:ref:`downloaded<software:catalog image download>` the set of catalog images, you can see
+what the selected object looks like in sky-survey images.  These appear in the background of
+the :ref:`user_guide:object details` screen.  Press the **SQUARE** key to cycle through the
+pages of information about each object and view the images in full detail.
 
-The images are rotated and oriented as they appear through the eyepiece at your position
-and time, to help you identify the faintest targets.
+The PiFinder rotates each image to match the view through your eyepiece at your position and
+time, which helps you identify the faintest objects.
 
-Zoom in and out with the **+/-** keys; the FOV is displayed at the bottom of the image so
-you can match it to your eyepiece.
+Zoom in and out with the **+/-** keys.  The FOV appears at the bottom of the image, so you
+can match it to your eyepiece.
 
 As an example, here are the images available for M57
 
@@ -662,18 +660,18 @@ As an example, here are the images available for M57
    :alt: Catalog Image
 
 
-These images are oriented to match the view through your eyepiece for the telescope you're
-using, pointing at a specific area of sky from your current location.  By default they're
-oriented for a Newtonian reflector; if you use a refractor or an SCT with a star diagonal,
-set the orientation options for your telescope as described in :doc:`equipment`.  Use the
-**+** and **-** keys to switch between the fields of view of the eyepieces you configured
-via the :ref:`Web Interface <connectivity:web interface>`
+These images match the view through your eyepiece for the telescope you're using, pointing
+at a specific area of sky from your current location.  By default they are oriented for a
+Newtonian reflector.  If you use a refractor, or an SCT with a star diagonal, set the
+orientation options for your telescope as described in :doc:`equipment`.  Use the **+** and
+**-** keys to switch between the fields of view of the eyepieces you configured in the
+:ref:`Web Interface <connectivity:web interface>`.
 
-Two overlays help you read the image.  Letters near the edge of the field mark the
-cardinal directions — two of N, S, E, and W, depending on how the image is rotated — so
-you can relate the view to a chart.  A thin outline traces the object's cataloged size
-and orientation; when only the bright core shows in the eyepiece, it gives you a feel
-for the object's full extent.  Both overlays can be switched off under Image... in the
+Two overlays help you read the image.  Letters near the edge of the field mark the cardinal
+directions, so you can relate the view to a chart.  You see two of N, S, E, and W,
+depending on how the image is rotated.  A thin outline traces the object's cataloged size
+and orientation.  When only the bright core shows in the eyepiece, that outline gives you a
+feel for the object's full extent.  You can switch both overlays off under Image... in the
 :ref:`user_guide:settings menu`.
 
 .. image:: images/user_guide/object_image_overlays_docs.png
@@ -685,8 +683,8 @@ shows the current FOV information.
 Logging Observations
 -----------------------
 
-Pressing the **RIGHT** arrow while viewing any object's details brings up the logging
-interface, where you can add context about your observation and save it to your log.
+Press the **RIGHT** arrow while viewing any object's details to open the logging interface.
+There you add context about your observation and save it to your log.
 
 .. image:: images/user_guide/logging_01_docs.png
 .. image:: images/user_guide/logging_02_docs.png
@@ -694,10 +692,10 @@ interface, where you can add context about your observation and save it to your 
 Use the **UP/DOWN** arrows to select one of the four context items to change:
 
 - **Observability**: How easy is it to spot and recognize this object
-- **Appeal**: Overall rating — would you refer a friend?
+- **Appeal**: Your overall rating.  Would you recommend it to a friend?
 
-Set these first two by choosing a number from 1 to 5, or pressing the **RIGHT** arrow to
-cycle through the stars.
+Set these first two with a number key from 1 to 5, or press the **RIGHT** arrow to cycle
+through the stars.
 
 - **Conditions**...
 
@@ -707,48 +705,49 @@ cycle through the stars.
 
 - **Eyepiece**: Note which of your eyepieces you're using.
 
-When you're done — or if you just want to note that you observed an object without context
-— use the **UP/DOWN** arrows to select **SAVE LOG** and record your observation.
+When you're done, use the **UP/DOWN** arrows to select **SAVE LOG** and record your
+observation.  You can also save straight away, with no context, just to note that you
+observed an object.
 
 
 Observing Projects
 --------------------
 
 If you're like me, you may enjoy observing projects, such as working through all the
-Messier or Herschel objects.  The PiFinder makes these long-term efforts easy: log each
-object, and it will then show you only the objects you have left that are visible during
-any session.
+Messier or Herschel objects.  The PiFinder makes these long-term efforts easy.  Log each
+object, and it then shows you only the objects you have left that are visible during a
+session.
 
-Combining a :ref:`filter<user_guide:filters>` on observation status with an object list
-sorted by NEAREST lets you work through a collection easily.
+Combine a :ref:`filter<user_guide:filters>` on observation status with an object list
+sorted by NEAREST to work through a collection easily.
 
 Power & Charging
 =====================================
 
-Every rev4 PiFinder has an internal battery, good for a full night on a single charge, and
-you can keep one going indefinitely from any USB-C power source.  This section covers the
-power button, how charging behaves, what the battery indicator is telling you, how long a
-charge lasts, and how to look after the cell.  For the very first power-on, the
+Every rev4 PiFinder has an internal battery, good for a full night on a single charge.  You
+can also keep one running indefinitely from any USB-C power source.  This section covers the
+power button, how charging behaves, what the battery indicator tells you, how long a charge
+lasts, and how to look after the cell.  For the first time you turn one on, the
 :ref:`quick_start:powering the pifinder` section of the Quick Start walks through it step
 by step.
 
 Power button and shutdown
 -------------------------
 
-Press the button marked **PWR**, on the front below the keypad, and hold it for about two
-seconds to start the PiFinder.  The **PWR** label lights while it boots and goes out once
-the screen and keypad come up.
+To turn the PiFinder on, press and hold the button marked **PWR**, on the front below the
+keypad, for about two seconds.  The **PWR** label lights while the PiFinder starts up, and
+goes out once the screen and keypad come up.
 
 .. image:: images/quick_start/rev4_power.jpeg
 
-To shut down, press the button again and hold it for about a second.  The screen goes
-straight to the shutdown confirmation; a second press confirms, a tone plays, and the
-PiFinder switches itself off once it has closed everything down safely.  In normal use you
-never need to cut the power by hand; if the software ever hangs and won't shut down, holding
-**PWR** for more than 14 seconds resets the power system — see
+To shut down, press and hold the button again for about a second.  The screen goes straight
+to the shutdown confirmation.  A second press confirms it, a tone plays, and the PiFinder
+turns itself off once it has closed everything down safely.  In normal use you never need to
+cut the power by hand.  If the software ever hangs and will not shut down, press and hold
+**PWR** for more than 14 seconds to reset the power system.  See
 :ref:`troubleshooting:the pifinder won't turn on`.
 
-The menus get you to the same place if your hands are already on the keypad — see
+The menus get you to the same place if your hands are already on the keypad.  See
 :ref:`user_guide:shutdown`.
 
 .. note::
@@ -767,14 +766,14 @@ Two USB-C ports sit on top of the case, each named on the faceplate just below i
 - **DATA** is for connecting accessories, such as the PiFinder remote or other USB
   devices.
 
-From empty, a full charge takes about six hours with the PiFinder switched off.  Charging
-draws up to **1.5A**, so use a supply that can deliver it — a source that can't will charge
+From empty, a full charge takes about six hours with the PiFinder turned off.  Charging
+draws up to **1.5A**, so use a supply that can deliver it.  A weaker source charges
 proportionally slower.
 
-You can carry on observing while the battery charges; there's no need to switch the
-PiFinder off first.  Expect the charge to take considerably longer that way, since the unit
-consumes much of what the charger supplies.  A long charge that leaves the battery still low
-almost always means the PiFinder was running the whole time.
+You can carry on observing while the battery charges.  There is no need to turn the
+PiFinder off first.  Expect the charge to take considerably longer that way, because the
+PiFinder consumes much of what the charger supplies.  A long charge that leaves the battery
+still low almost always means the PiFinder was running the whole time.
 
 A charge indicator labelled **CHG** lights while the battery is charging and goes out once
 it's full.  It is red, but bright enough to be distracting once your eyes are dark adapted,
@@ -787,12 +786,11 @@ so it's worth knowing what it is before it appears beside you at the eyepiece.
 
 .. note::
    v3 PiFinders charge through the optional **PiSugar S Plus** board rather than an
-   on-board charger, and should be charged with the slide switch **off** — a v3 left
-   running barely fills at all.  Charge through the port nearest the back of the case; its
-   indicator glows blue while charging and green when full, and a full charge takes roughly
-   three hours.  The port nearest the keypad runs the unit without charging, and is wired
-   ahead of the slide switch, so plugging into it turns a v3 on regardless of the switch
-   position.
+   on-board charger.  Charge a v3 with the slide switch **off**, because one left running
+   barely fills at all.  Use the port nearest the back of the case.  Its indicator glows
+   blue while charging and green when full, and a full charge takes roughly three hours.
+   The port nearest the keypad runs the PiFinder without charging.  It is wired ahead of
+   the slide switch, so plugging into it turns a v3 on regardless of the switch position.
    |v3_docs|
 
 The battery indicator
@@ -832,12 +830,12 @@ The PiFinder warns you twice as the battery runs down: once when the estimate re
 .. image:: images/user_guide/low_battery_warning_docs.png
 
 Measured on the bench under a continuously solving load, the 10% warning arrives about an
-hour and a half before the end and the 5% warning about half an hour before it; lighter use
-stretches both.  Each warning appears once per discharge rather than repeating, so it won't
-nag you for the rest of the night.  Plugging in re-arms them for next time.
+hour and a half before the end, and the 5% warning about half an hour before it.  Lighter
+use stretches both.  Each warning appears once per discharge rather than repeating, so it
+does not nag you for the rest of the night.  Plugging in re-arms them for next time.
 
 When the battery is nearly flat, the PiFinder shows a final warning, plays the shutdown tone
-and shuts itself down cleanly — stopping deliberately rather than letting the power cut out
+and shuts itself down cleanly.  It stops deliberately rather than letting the power cut out
 on its own.
 
 .. image:: images/user_guide/low_battery_shutdown_docs.png
@@ -846,80 +844,80 @@ Battery life
 ------------
 
 A full charge of the 8,000mAh cell runs the PiFinder for about **ten hours**.  Treat that as
-a floor rather than an average — it was measured with the camera solving continuously, the
-screen at full brightness and the display sleep turned off, which is harder work than a real
-night at the eyepiece.  Sitting on one object, or stepping away from the scope, lets the
+a floor rather than an average.  It was measured with the camera solving continuously, the
+screen at full brightness and the screen sleep turned off, which is harder work than a real
+night at the eyepiece.  Sitting on one object, or stepping away from the telescope, lets the
 PiFinder drop into power-save mode and stretches the time considerably.  Turning the
-brightness down helps too: hold **SQUARE** and press **+** or **-** to adjust the screen and
-keypad at any time.
+brightness down helps too.  Hold **SQUARE** and press **+** or **-** to adjust the screen
+and keypad at any time.
 
 .. note::
-   The PiFinder drops into power-save mode after it has been idle for a while, dimming the
-   screen and slowing the camera to save power.  Any button press or movement of the scope
-   wakes it.  The idle time can be changed, or turned off entirely, in the
+   The PiFinder drops into power-save mode after it has been idle for a while.  It dims the
+   screen and slows the camera to save power.  Any key press, or movement of the telescope,
+   wakes it.  You can change the idle time, or turn it off entirely, in the
    :ref:`user_guide:settings menu`.
 
 Running on external power
 -------------------------
 
-Any USB-C source rated for at least **2A** will run the PiFinder — a wall charger, a USB
-power bank, or a portable power station's USB output.  Plug it into the **POWER** port and
-the PiFinder runs from it and tops the battery up at the same time; you can add external
-power mid-session without restarting.  As a rough guide, about 1,000mAh of power-bank
-capacity runs the PiFinder for an hour, so a 10,000mAh bank is good for the better part of
-a night.
+Any USB-C source rated for at least **2A** runs the PiFinder: a wall charger, a USB power
+bank, or a portable power station's USB output.  Plug it into the **POWER** port.  The
+PiFinder then runs from it and tops the battery up at the same time, and you can add
+external power mid-session without restarting.  As a rough guide, about 1,000mAh of
+power-bank capacity runs the PiFinder for an hour, so a 10,000mAh bank is good for the
+better part of a night.
 
-If you hit power dropouts, suspect the cable first — some USB-C cables are unreliable at
+If you hit power dropouts, suspect the cable first.  Some USB-C cables are unreliable at
 the ~2A the PiFinder draws, especially on long runs.
 
 .. note::
-   On a v3, the port nearest the keypad runs the unit without charging.  That makes a useful
-   trick for stretching a long night: plug a power bank into that port and switch the
-   battery **off**, and the PiFinder runs on external power with the cell held in reserve
-   for after the bank is unplugged.
+   On a v3, the port nearest the keypad runs the PiFinder without charging.  That makes a
+   useful trick for stretching a long night.  Plug a power bank into that port and turn the
+   battery **off**.  The PiFinder then runs on external power, with the cell held in
+   reserve for after you unplug the bank.
    |v3_docs|
 
 .. warning::
    Feed the PiFinder **5V USB-C power only**.  To run it from a telescope's 12V supply, you
    must use a 12V-to-5V step-down (DC-DC) converter with a USB-C output.  Never connect 12V
-   directly to the PiFinder — doing so will damage it.
+   directly to the PiFinder.  That will damage it.
 
 Battery safety & care
 ---------------------
 
-The internal battery is a lithium-polymer (LiPo) cell.  Treated sensibly it will last for
+The internal battery is a lithium-polymer (LiPo) cell.  Treat it sensibly and it lasts for
 years, but like any lithium battery it deserves a little respect.
 
 .. warning::
    Stop using the battery and disconnect power if it ever becomes **swollen, damaged,
    unusually hot, or develops an odour**.  A puffed-up or punctured LiPo cell can vent or
-   catch fire.  Do not continue to charge or use a cell in this condition — contact us about
-   a replacement.
+   catch fire.  Do not continue to charge or use a cell in this condition.  Contact us
+   about a replacement.
 
 .. warning::
    Do not **puncture, crush, drop, or open** the battery, and don't open the case to get at
-   it.  Keep the unit dry; the battery and electronics are not waterproof.
+   it.  Keep the PiFinder dry.  The battery and electronics are not waterproof.
 
 A few habits keep the cell healthy:
 
-- **Charge through the POWER port only.**  The PiFinder's own charger looks after the cell;
-  just supply 5V USB-C as described above.  There is no need for an external LiPo charger,
-  and you should not connect one.
-- **Charge where you can keep an eye on it,** and not on or near anything flammable.  Avoid
-  charging or leaving the unit in extreme heat — a closed car on a sunny day is the classic
+- **Charge through the POWER port only.**  The PiFinder's own charger looks after the cell,
+  so just supply 5V USB-C as described above.  There is no need for an external LiPo
+  charger, and you should not connect one.
+- **Charge where you can keep an eye on it,** and not on or near anything flammable.  Do not
+  charge or leave the PiFinder in extreme heat.  A closed car on a sunny day is the classic
   way to cook a battery.
-- **Mind the temperature.**  The PiFinder has been used from about -15°C (5°F) to 40°C
+- **Mind the temperature.**  Owners have used the PiFinder from about -15°C (5°F) to 40°C
   (100°F).  Capacity drops in the cold, though the computer's own heat keeps the cell warm
-  enough to work in most conditions.  Avoid charging a battery that is below freezing.
+  enough to work in most conditions.  Do not charge a battery that is below freezing.
 - **For long-term storage,** leave the cell partly charged rather than full or empty and keep
   it somewhere cool and dry.  Top it up every few months so it does not discharge completely.
-- **Dispose of it responsibly.**  A worn-out lithium battery should go to a battery-recycling
+- **Dispose of it responsibly.**  Take a worn-out lithium battery to a battery-recycling
   drop-off, not the household rubbish.
 
 .. note::
    On a v3, the battery and its charger are the optional **PiSugar S Plus 5000mAh** board,
-   which is also the only compatible replacement part — other PiSugar models share the I2C
-   bus with the PiFinder's motion sensor and will cause problems, so make sure you fit the
+   which is also the only compatible replacement part.  Other PiSugar models share the I2C
+   bus with the PiFinder's motion sensor and cause problems, so make sure you fit the
    S Plus.  Don't attempt to disassemble the board itself.
    |v3_docs|
 
@@ -937,23 +935,23 @@ more options below.
 
 .. image:: images/user_guide/settings_02.png
 
-Below the general UI options are settings to change which :ref:`connectivity:wifi` mode your
-PiFinder is in and its physical configuration.
+Below the general UI options are settings for which :ref:`connectivity:wifi` mode your
+PiFinder is in, and for its physical configuration.
 
 .. image:: images/user_guide/settings_03.png
 
-Hardware setup that's normally configured once — PiFinder Type, Camera Type, and GPS
-Settings (type and baud rate) — lives under the Advanced submenu near the bottom of the
-Settings Menu.  Opening it shows a brief "Options for DIY PiFinders" reminder, since on a
-fully built unit these are already set to match your hardware.
+The Advanced submenu, near the bottom of the Settings Menu, holds the hardware setup you
+normally configure once: PiFinder Type, Camera Type, and GPS Settings (type and baud rate).
+Opening it shows a brief "Options for DIY PiFinders" reminder, because on a fully built
+PiFinder these already match your hardware.
 
 Sounds
 ------
 
-A rev4 PiFinder has a small buzzer that plays a short tone on each key press, at startup
-and shutdown, and with every low-battery warning.  Volume, in User Preferences, sets how
-loud they are — Off, or 1 through 5.  Choosing a level plays a sample tone at that level,
-so you can set it by ear.
+A rev4 PiFinder has a small buzzer.  It plays a short tone on each key press, at startup
+and shutdown, and with every low-battery warning.  The Volume menu item, in User
+Preferences, sets how loud they are.  Its options are Off, or 1 through 5.  Selecting a
+level plays a sample tone at that level, so you can set it by ear.
 
 .. image:: images/user_guide/volume_setting_docs.png
 
@@ -970,18 +968,18 @@ Connectivity
 ==============
 
 The PiFinder hosts its own WiFi network, ``PiFinderAP`` (no password), so your phone or
-tablet can join it anywhere; it can also join your home network instead.  Switch between
+tablet can join it anywhere.  It can also join your home network instead.  Switch between
 the two modes from the :ref:`user_guide:settings menu`, and check the current mode and
-address on the :ref:`user_guide:status screen` — from a connected device the PiFinder
-answers at ``http://pifinder.local``.  The web interface, SkySafari and other planetarium
-apps, and the shared data folder are all covered in :doc:`connectivity`.
+address on the :ref:`user_guide:status screen`.  From a connected device the PiFinder
+answers at ``http://pifinder.local``.  The :doc:`connectivity` page covers the web
+interface, SkySafari and other planetarium apps, and the shared data folder.
 
 Tools
 ==========================
 
-Near the bottom of the main PiFinder menu, the Tools option leads to a set of screens that
-aren't observing-related but provide useful information or let you perform actions —
-checking the PiFinder's :ref:`status<user_guide:status screen>`, choosing your active
+Near the bottom of the main PiFinder menu, the Tools menu item leads to a set of screens
+that aren't observing-related but provide useful information or let you perform actions:
+checking the PiFinder's :ref:`status<user_guide:status screen>`, selecting your active
 :doc:`telescope and eyepiece <equipment>`, setting your place and time by hand,
 :ref:`updating the software<user_guide:update software>`, and
 :ref:`shutting down<user_guide:shutdown>` or restarting.
@@ -989,8 +987,8 @@ checking the PiFinder's :ref:`status<user_guide:status screen>`, choosing your a
 .. image:: images/user_guide/tools_menu_docs.png
 
 For the full tree and a note on what every item does, see the
-:ref:`Tools section of the Menu Map<menu_map:tools>`.  The screens you'll reach for
-most often are covered below.
+:ref:`Tools section of the Menu Map<menu_map:tools>`.  The sections below cover the screens
+you reach for most often.
 
 Status Screen
 ----------------------------------
@@ -1011,36 +1009,36 @@ Place & Time
 ----------------------------------
 
 The PiFinder needs to know where and when it is to turn the sky's coordinates into the
-directions it gives you.  Its built-in GPS handles this automatically, but you don't have
-to wait for a fix — or have GPS at all — to get going.  Open Tools, then Place & Time, to
-set everything by hand.
+directions it gives you.  Its built-in GPS handles this automatically.  You do not have to
+wait for a fix, or have GPS at all, to get going.  Open Tools, then Place & Time, to set
+everything by hand.
 
 Set Location gathers the ways to manage your observing site:
 
 - **Enter Coords** lets you type your latitude, then longitude, then altitude with the
   number keys.  The **+** key flips the sign for southern latitudes and western longitudes.
 - **Load Location** recalls one of your saved sites, and **Save Location** stores the
-  current one so you can pick it again next time.
+  current one so you can select it again next time.
 
-Set Time/Date sets the clock when there's no GPS: enter the time and the PiFinder moves on
-to a date-entry screen.  A time you set by hand is protected — a later GPS fix won't
-overwrite it — so your manual clock stays put.  Reset Location and Reset Time/Date discard
-what's set if you'd rather start fresh or hand control back to GPS.
+Set Time/Date sets the clock when there's no GPS.  Enter the time, and the PiFinder moves on
+to a date-entry screen.  The PiFinder protects a time you set by hand, so a later GPS fix
+does not overwrite it and your manual clock stays put.  Reset Location and Reset Time/Date
+discard what's set, if you'd rather start fresh or hand control back to GPS.
 
 .. note::
    With your location and time set by hand, the PiFinder is fully usable without a GPS
-   signal — you can focus, align, browse objects, and push to them.  The
+   signal.  You can focus, align, browse objects, and push to them.  The
    :ref:`user_guide:star chart` and Align screens also work before a GPS lock.
 
 Update Software
 ------------------
 
 The PiFinder can download and install software updates directly from its screen and keypad.
-To start, choose Software Upd from the :ref:`user_guide:tools`
+To start, select Software Upd from the :ref:`user_guide:tools` menu.
 
-Updates happen right on the device — there is no need to send your PiFinder anywhere.  New
-units often ship a version or two behind the latest release, so running an update is a
-normal part of your first night out.
+Updates happen on the PiFinder itself, so there is no need to send it anywhere.  New units
+often ship a version or two behind the latest release, so running an update is a normal part
+of your first night out.
 
 .. image:: images/user_guide/software_update_01_docs.png
 
@@ -1054,14 +1052,14 @@ to the one installed.
 
 .. note::
    If the release version shows as **unknown**, the PiFinder cannot reach the internet to
-   check — it is either in Access Point mode or its WiFi is not configured.  Put it in
+   check.  It is either in Access Point mode, or its WiFi is not configured.  Put it in
    Client mode on a network with internet access (see
-   :ref:`connectivity:connecting to a new wifi network`); re-imaging the SD card is not the
+   :ref:`connectivity:connecting to a new wifi network`).  Re-imaging the SD card is not the
    fix for this.  If WiFi is configured but the check still fails, move closer to the
    router or re-enter the network details.
 
-If a new version is available, use the presented option to start the update.  This may take
-several minutes, and the PiFinder restarts when it's done.
+If a new version is available, select the option presented to start the update.  This may
+take several minutes, and the PiFinder restarts when it's done.
 
 .. image:: images/user_guide/software_update_04_docs.png
 
@@ -1079,135 +1077,139 @@ Polar Alignment
 ---------------------------
 
 An equatorial platform or equatorial mount tracks the sky by turning your telescope around a
-single axis that's meant to point at the celestial pole — the platform's pivot, or the
-mount's right ascension axis.  The closer that axis is to the true pole, the longer objects
+single axis that's meant to point at the celestial pole.  That axis is the platform's pivot,
+or the mount's right ascension axis.  The closer it is to the true pole, the longer objects
 stay put in the eyepiece.  The Polar Alignment tool measures how far your axis sits from the
-pole and walks you through correcting it — using ordinary plate solves, with no polar scope
-or sight of Polaris needed.
+pole and walks you through correcting it.  It works from ordinary plate solves, so you need
+no polar scope and no sight of Polaris.
 
 It lives near the bottom of the main menu: open Tools, scroll down to Experimental, and
-choose Polar Align.
+select Polar Align.
 
-It works by solving the sky at two or three points while you rotate around that axis between
-them — turning the platform, or slewing the mount in right ascension only — then working out
-where the axis points from how the view shifts.  The measurement is only as good as the
-solves behind it, so before you start make sure the PiFinder has a GPS lock, is focused, and
-is solving reliably.  Turn off your mount's or platform's sidereal tracking as well — the
-measurement assumes the scope holds still except when you rotate it yourself.
+The tool solves the sky at two or three points while you rotate around that axis between
+them.  You turn the platform, or slew the mount in right ascension only.  The PiFinder then
+works out where the axis points from how the view shifts.  The measurement is only as good
+as the solves behind it, so before you start make sure the PiFinder has a GPS lock, is
+focused, and is solving reliably.  Turn your mount's or platform's sidereal tracking off as
+well, because the measurement assumes the telescope holds still except when you rotate it
+yourself.
 
 .. image:: images/user_guide/polar_align_intro_docs.png
 
 .. note::
    This aligns the rotation *axis*, not the PiFinder to your eyepiece.  The one rule that
-   matters: between captures, move only *around* that axis.  On a platform, keep the scope
-   clamped to the platform and rotate the platform; on an equatorial mount, lock the
-   declination axis and slew only in right ascension.  During adjustment, move the axis
-   itself with your altitude and azimuth adjusters — not by slewing the scope.
+   matters: between captures, move only *around* that axis.  On a platform, keep the
+   telescope clamped to the platform and rotate the platform.  On an equatorial mount, lock
+   the declination axis and slew only in right ascension.  During adjustment, move the axis
+   itself with your altitude and azimuth adjusters, not by slewing the telescope.
 
 To take a measurement, open Polar Align and press **SQUARE** to begin, then:
 
-1. Aim the telescope near the pole — :ref:`user_guide:getting a good measurement` below
-   gives the best aim and sweep for each mount — and wait for the screen to report a recent
-   solve.  Press **SQUARE** to capture the first point.
-2. Rotate around the axis by at least about 10° — turn the platform, or slew in right
-   ascension only — wait for a fresh solve, and press **SQUARE** for the second point.
-3. For a stronger result, rotate farther and capture a third point — three points let the
+1. Aim the telescope near the pole and wait for the screen to report a recent solve.  Press
+   **SQUARE** to capture the first point.  :ref:`user_guide:getting a good measurement`
+   below gives the best aim and sweep for each mount.
+2. Rotate around the axis by at least about 10°, turning the platform or slewing in right
+   ascension only.  Wait for a fresh solve, then press **SQUARE** for the second point.
+3. For a stronger result, rotate farther and capture a third point.  Three points let the
    PiFinder check how well the captures agree.  To stop at two points instead, press **0**
    to solve now.
 
 .. image:: images/user_guide/polar_align_aim_docs.png
 
-If the screen says 'Rotate more', the captures were too close together to pin down the axis;
-rotate farther and capture again.
+If the screen says 'Rotate more', the captures were too close together to pin down the axis.
+Rotate farther and capture again.
 
-Once it has enough rotation, the PiFinder switches to a live target showing how far the axis
-is from the pole, as push-to offsets in altitude and azimuth.  Turn your altitude and azimuth
-adjusters — the platform's, or the mount's polar-alignment bolts — to follow the arrows until
-both readings fall to zero.  The display refreshes with each new solve; if it shows 'No
-solve', hold everything still until the PiFinder solves again.
+Once it has enough rotation, the PiFinder switches to a live readout showing how far the
+axis is from the pole, as push-to offsets in altitude and azimuth.  Turn your altitude and
+azimuth adjusters to follow the arrows until both readings fall to zero.  On a platform
+those are the platform's adjusters.  On a mount they are the polar-alignment bolts.  The
+readout refreshes with each new solve.  If it shows 'No solve', hold everything still until
+the PiFinder solves again.
 
 .. note::
    Before touching the adjusters, lock *both* of the mount's axes.  Right ascension is the
-   one everyone forgets — you unlocked it to rotate between captures — and a clutch that
+   one everyone forgets, because you unlocked it to rotate between captures.  A clutch that
    slips while you work the adjusters quietly ruins the correction.  On a platform, leave
-   the scope alone entirely and adjust only the platform.
+   the telescope alone entirely and adjust only the platform.
 
 .. image:: images/user_guide/polar_align_adjust_docs.png
 
-The top line summarises the measurement: the number of points used, the total sweep, and —
-for a three-point solve — a fit rating of ``ok``, ``mid``, or ``bad``.  A poor fit usually
+The top line summarises the measurement: the number of points used, the total sweep, and,
+for a three-point solve, a fit rating of ``ok``, ``mid``, or ``bad``.  A poor fit usually
 means something moved between captures that shouldn't have, so it's worth redoing.
 
-Hold **SQUARE** for the marking menu, which gathers the advanced actions.  **STATS** opens a
-read-only detail view, **REDO PT** drops just the last point so you can recapture it, and
-**Roll On/Off** switches between a full three-axis fit and an RA/Dec-only fit that ignores
-camera roll — useful after a camera flop, and :ref:`user_guide:getting a good measurement`
-covers which fit suits each mount.
+Press and hold **SQUARE** for the marking menu, which gathers the advanced actions.
+**STATS** opens a read-only detail view.  **REDO PT** drops just the last point so you can
+recapture it.  **Roll On/Off** switches between a full three-axis fit and an RA/Dec-only fit
+that ignores camera roll, which is useful after a camera flop.
+:ref:`user_guide:getting a good measurement` covers which fit suits each mount.
 
 .. image:: images/user_guide/polar_align_marking_menu_docs.png
 
 The STATS view spells out the correction in both degrees and arcminutes for each axis, the
-fitted axis position, the fit quality, and how the captures were spaced in time — handy for
-judging whether a measurement is trustworthy.
+fitted axis position, the fit quality, and how the captures were spaced in time.  That
+detail helps you judge whether a measurement is trustworthy.
 
 .. image:: images/user_guide/polar_align_stats_docs.png
 
-To start a fresh measurement at any time, press **SQUARE**; to leave the tool, press
+To start a fresh measurement at any time, press **SQUARE**.  To exit the tool, press
 **MINUS**.
 
 Getting a good measurement
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The PiFinder-to-scope connection is never perfectly rigid, and small flexures — felt most
-strongly in camera roll — grow with how much the PiFinder's attitude changes between
-captures.  Wider sweeps are better in theory, but in practice the sweet spot is a moderate
-sweep taken close to the pole, keeping the PiFinder's attitude nearly constant.
+The connection between the PiFinder and the telescope is never perfectly rigid.  Small
+flexures grow with how much the PiFinder's attitude changes between captures, and they show
+most strongly in camera roll.  Wider sweeps are better in theory, but in practice the sweet
+spot is a moderate sweep taken close to the pole, which keeps the PiFinder's attitude nearly
+constant.
 
 On an equatorial mount:
 
-- Point the declination axis so the scope sits roughly 7–10° off the mount's polar axis —
-  wherever that axis points now, not where the true pole is.
+- Point the declination axis so the telescope sits roughly 7–10° off the mount's polar axis.
+  Measure from wherever that axis points now, not from where the true pole is.
 - Sweep roughly 30–45° in right ascension: take the middle capture with the PiFinder's
   screen roughly vertical, and the first and last captures 15–22° either side of it.
-- Set Roll Off in the marking menu — flexure shows up most strongly in roll, so the fit is
-  better off without it.
+- Set Roll Off in the marking menu.  Flexure shows up most strongly in roll, so the fit is
+  better without it.
 
 On an equatorial platform:
 
-- Aim the scope close to Polaris, ideally within 5°.
-- Keep Roll On — aimed this close to the axis the pointing barely shifts between captures,
+- Aim the telescope close to Polaris, ideally within 5°.
+- Keep Roll On.  Aimed this close to the axis, the pointing barely shifts between captures,
   so the roll change carries most of the rotation information.
-- Position the PiFinder so its screen is vertical at the middle of the platform's travel;
-  that also keeps the altitude and azimuth arrows matching the real directions while you
+- Position the PiFinder so its screen is vertical at the middle of the platform's travel.
+  That also keeps the altitude and azimuth arrows matching the real directions while you
   adjust.
 
-Expect the result to land within 20–30 arcminutes of the pole; a very rigid PiFinder-to-scope
-connection and a wider sweep can bring that down to around 10.  That won't match a polar
-scope, or a routine that images through a rigidly mounted scope with a much smaller field of
-view — but it's a solid alignment when the pole is hidden from your site or you have no
-polar scope, and close enough to put Polaris into a polar scope's reticle.
+Expect the result to land within 20–30 arcminutes of the pole.  A very rigid connection
+between the PiFinder and the telescope, plus a wider sweep, can bring that down to around
+10.  That won't match a polar scope, or a routine that images through a rigidly mounted
+telescope with a much smaller field of view.  It is still a solid alignment when the pole is
+hidden from your site or you have no polar scope, and it is close enough to put Polaris into
+a polar scope's reticle.
 
 Shutdown
 ---------------------------
 
-Shutting down isn't strictly required before power-off, but the PiFinder is a computer and
-there's a chance of file corruption if you skip it.  Some MicroSD cards are more sensitive
-than others.
+You do not strictly have to shut down before you cut the power, but the PiFinder is a
+computer and skipping the shutdown risks file corruption.  Some MicroSD cards are more
+sensitive than others.
 
-The quickest route is the power button: press it and hold for about a second, and the
+The quickest route is the power button.  Press and hold it for about a second, and the
 confirmation below appears from wherever you are.
 
 .. image:: images/quick_start/shutdown_confirm.png
 
-Press the power button again — or the **RIGHT** arrow — to confirm, or the **LEFT** arrow
-to go back.  The screen and keypad turn off within a few seconds and the PiFinder switches
+Press the power button again, or the **RIGHT** arrow, to confirm.  Press the **LEFT** arrow
+to go back.  The screen and keypad turn off within a few seconds, and the PiFinder turns
 itself off.
 
-The keypad gets you to the same screen.  The Tools menu offers a Shutdown option under
+The keypad gets you to the same screen.  The Tools menu offers a Shutdown menu item under
 Power, and the Quick Menu is faster:
 
-- Hold the **LEFT** arrow button for more than a second to jump to the main menu
-- Hold the **SQUARE** button to access the Quick Menu
+- Press and hold **LEFT** for more than a second to jump to the main menu
+- Press and hold **SQUARE** to open the Quick Menu
 
 .. image:: images/quick_start/main_menu_01_docs.png
 .. image:: images/quick_start/main_menu_marking.png

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -174,8 +174,7 @@ Out under the stars, you do four basic things in various combinations:
 * Pushing the telescope to bring them into your eyepiece
 * Logging your observations
 
-Everyone observes their own way, so the PiFinder lets you use these features, or skip them,
-as your night out demands.
+Everyone observes their own way, so use the features you want and skip the rest.
 
 Object List
 --------------------
@@ -198,8 +197,8 @@ items:
   the current session.
 - **Custom**: Enter a right ascension and declination by hand to make a one-off Custom Target.
   See :ref:`user_guide:custom targets`.
-- **Name Search**: Search for objects by name with the number keypad.  This is how you find
-  the Snowball planetary or the Cat's Eye.
+- **Name Search**: Search for objects by name with the number keypad.  The Snowball planetary?
+  Cat's Eye?  This is the way to find them.
 
 However you build the list, it always displays the same information and offers the same
 sorting and selection.

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -906,7 +906,7 @@ A few habits keep the cell healthy:
 - **Charge where you can keep an eye on it,** and not on or near anything flammable.  Do not
   charge or leave the PiFinder in extreme heat.  A closed car on a sunny day is the classic
   way to cook a battery.
-- **Mind the temperature.**  Owners have used the PiFinder from about -15°C (5°F) to 40°C
+- **Mind the temperature.**  The PiFinder has been used from about -15°C (5°F) to 40°C
   (100°F).  Capacity drops in the cold, though the computer's own heat keeps the cell warm
   enough to work in most conditions.  Do not charge a battery that is below freezing.
 - **For long-term storage,** leave the cell partly charged rather than full or empty and keep

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -959,7 +959,7 @@ others, so a cue pitched away from its loudest note sounds softer.  Set Volume t
 you'd rather observe in silence.
 
 .. note::
-   v3 and v2.5 PiFinders have no buzzer.  The Volume setting appears on those units too,
+   v3 and v2.5 PiFinders have no buzzer.  The Volume setting appears on those PiFinders too,
    but nothing sounds.
    |v3_docs|
 
@@ -1035,7 +1035,7 @@ Update Software
 The PiFinder can download and install software updates directly from its screen and keypad.
 To start, select Software Upd from the :ref:`user_guide:tools` menu.
 
-Updates happen on the PiFinder itself, so there is no need to send it anywhere.  New units
+Updates happen on the PiFinder itself, so there is no need to send it anywhere.  New PiFinders
 often ship a version or two behind the latest release, so running an update is a normal part
 of your first night out.
 

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -279,7 +279,7 @@ should show in your eyepiece tonight.
 
 .. image:: images/user_guide/object_details_02.png
 
-The PiFinder can show images of every object in its catalog.  See the section on
+The PiFinder can show images of all the extended objects in its catalogs.  See the section on
 :ref:`object images<user_guide:object images>` below for more.
 
 .. image:: images/user_guide/object_details_03.png


### PR DESCRIPTION
Full simplified technical English pass over `docs/source/user_guide.rst`, using the `docs` skill's seven rules and approved-term table. Part of the manual-wide conversion, one PR per file.

## Measured change

```
  PASS  docs/source/user_guide.rst
     em-dash 99->0 | semicolon 30->0 | banned 55->20 | words 8514->8491 (-0%)
     terms: choose 17->1, pick 5->0, the display 2->0, the unit 6->1, the device 1->0, target 13->9, DSO 5->3
OVERALL: PASS
```

## What the converting agent reported

```
EM_DASHES: 99 -> 0    (baseline was 99, not the 93 in the brief)
SEMICOLONS: 30 -> 0
TERMS: choose/choosing->select x12; pick->select x4; activates->selects;
  scope->telescope x18 (4 survivors are "polar scope", an approved fixed
  compound); the unit/the device->the PiFinder x6; display->screen/show x4;
  "switched off"->"turned off" x2; boot/booting->starts up x2;
  "back out"/"return to"->"go back" x4; "Holding X"->"press and hold X" plus 9
  further gesture normalisations, with the "Hold SQUARE and press +" chord left
  intact; "Pressing X brings up Y"->"Press X to open Y" x8;
  option->menu item x5 where the row was meant; DSO->deep-sky object x2 (the
  on-screen labels DSO Display / DSO... kept); "live target"->"live readout" in
  Polar Align, to avoid the object sense
STRUCTURAL: ~110 sentence splits, no procedure or step reordered. The IMU gloss
  lifted out of parentheses into its own sentence. The CSV row-resolution
  sentence split into five. Polar Align step 1 re-led with its command verb,
  same instruction and order. "And the magnitude and size..." (opened with a
  conjunction) rewritten.
LEFT_ALONE: all heading text, underlines and levels; "polar scope" x4; the
  on-screen DSO labels; "browse" x3 (the sense is looking through objects, not
  moving within a menu); the page's existing +/- and UP/DOWN key notation,
  since changing it would churn 12 lines for no rule; contractions; en-dashes
  in numeric ranges (7-10 deg, 0-360) and the U+2212 minus signs in the
  Contrast Reserve table; the rev4-default / v3-in-a-note convention.
FACT_CONCERNS:
  1. CROSS-PR ITEM. The key list under "The Menu System" carries an in-file
     comment saying it is duplicated in quick_start.rst and must be kept in
     sync. This pass converted it here (activates->selects, Holding->Press and
     hold), and the quick_start agent independently converted its own copy.
     The two must be reconciled before both PRs merge.
  2. "The Focus screen above offers HELP and Exposure" points at
     images/user_guide/quick_menu_00.png, introduced two lines earlier as the
     generic Quick Menu shot. If that image is not the Focus screen, the
     sentence is stale.
  3. The paragraph that began "And the magnitude and size..." had no explicit
     trigger; rendered as "The next press shows...", inferring it continues the
     SQUARE cycle described two paragraphs up. Worth a maintainer glance.
  4. Battery life said "the display sleep turned off"; written as "the screen
     sleep" for term consistency, but the real menu item appears to be Sleep
     Time under User Preferences.
  5. "images of every object in its catalog" - singular where the manual
     elsewhere says catalogs. Left as a fact.
```

## Content changes (added after review)

- **"images of every object in its catalog" overstated what ships.**
  `astro_data/pifinder_objects.db` holds 149,329 objects, of which 134,158 are
  double stars, 742 single stars and 90 triples. The non-stellar remainder is
  13,758, which matches `software.rst`'s "13,000+ images" almost exactly: the
  image set covers the extended objects, not the star catalogs. The sentence now
  reads "images of all the extended objects in its catalogs", which also fixes
  the singular "catalog" flagged in `FACT_CONCERNS`.
- **Two escapes from the unit -> PiFinder rule.** "appears on those units too"
  and "New units often ship a version or two behind" are now "PiFinders".

- **Two dead click-to-enlarge links.** Same defect as `build_guide`: Sphinx
  emits a `:target:` value verbatim as an href, so a source-tree path 404s. The
  two `CATALOG_images` screenshots pointed at `../../images/screenshots/`.
  Audited the built HTML: 5 of 7 targets resolved before, 7 of 7 after. The
  other five already used the `_images/` form.

## Safety

Every other change in this PR is style only. No numbers, procedures or step order were changed.

Verified mechanically against `origin/main` that every heading (text *and* underline character), every `:ref:`, `:doc:`, image path, substitution, `include::` and external URL is unchanged. Headings matter because `autosectionlabel` turns each one into a cross-reference target that other pages depend on, and a rename would break them silently.

Sphinx builds clean under `-n` (nitpicky).

Any `FACT_CONCERNS` above that are not listed under **Content changes** were deliberately **not** fixed. They are reported for a maintainer decision, since changing them would be a content edit rather than a style one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqTCarGCgTRWBQ1ysG8XFD

