### PR TITLE
docs: convert the build guide to the house style

### DIFF
--- a/docs/source/build_guide.rst
+++ b/docs/source/build_guide.rst
@@ -644,7 +644,7 @@ Connect the cable to the new camera module first.
 .. include:: includes/camera_cable_connect.rst
 
 .. note::
-   The photos in the rest of this guide do not yet show the v2.5 camera.
+   The photos in the rest of this guide do not yet show the v3 camera.
    The build proceeds just the same, and we will update the photos soon.
 
 

--- a/docs/source/build_guide.rst
+++ b/docs/source/build_guide.rst
@@ -110,7 +110,7 @@ IMU
 Fit the Inertial Measurement Unit next. It has an annoyingly bright green LED. Paint over it with a few layers of black nail polish, or destroy it with your soldering iron. You can deal with it after soldering if you forget, but it is much easier beforehand. The image below shows the offending component.
 
 .. image:: ../../images/build_guide/adafruit_IMU.png
-   :target: ../../images/build_guide/adafruit_IMU.png
+   :target: _images/adafruit_IMU.png
    :alt: Green led on IMU
 
 
@@ -128,13 +128,13 @@ Unscrew the stand-offs from the front and remove them.
 
 
 .. image:: ../../images/build_guide/IMG_4648.jpeg
-   :target: ../../images/build_guide/IMG_4648.jpeg
+   :target: _images/IMG_4648.jpeg
    :alt: Display as shipped
 
 
 
 .. image:: ../../images/build_guide/IMG_4649.jpeg
-   :target: ../../images/build_guide/IMG_4649.jpeg
+   :target: _images/IMG_4649.jpeg
    :alt: Display with standoffs removed
 
 
@@ -142,7 +142,7 @@ Next, remove the plug from the underside of the board. This step isn't strictly 
 
 
 .. image:: ../../images/build_guide/IMG_4650.jpeg
-   :target: ../../images/build_guide/IMG_4650.jpeg
+   :target: _images/IMG_4650.jpeg
    :alt: Connector cut free
 
 
@@ -150,7 +150,7 @@ Sand back or cut the bottom tabs on the screen PCB. This makes the top plate fit
 
 
 .. image:: ../../images/build_guide/IMG_4652.jpeg
-   :target: ../../images/build_guide/IMG_4652.jpeg
+   :target: _images/IMG_4652.jpeg
    :alt: Cut/Sand tabs on display
 
 
@@ -158,7 +158,7 @@ Test-fit the screen with the header installed and the top plate in place. Everyt
 
 
 .. image:: ../../images/build_guide/IMG_4653.jpeg
-   :target: ../../images/build_guide/IMG_4653.jpeg
+   :target: _images/IMG_4653.jpeg
    :alt: Screen test fit
 
 
@@ -269,7 +269,7 @@ Right and Left configurations
 The photo below shows all the parts for a left- or right-hand PiFinder. The edge inserts let these pieces assemble into either configuration, so you need just one set of parts whichever side your focuser faces. The assembly guide covers how to orient the pieces as you put them together.
 
 .. image:: images/build_guide/parts_1.jpeg
-   :target: images/build_guide/parts_1.jpeg
+   :target: _images/parts_1.jpeg
 
 
 
@@ -279,7 +279,7 @@ Flat Configuration
 The photo below shows the pieces for the flat version. The parts are the same with or without a PiSugar battery.
 
 .. image:: images/build_guide/parts_2.jpeg
-   :target: images/build_guide/parts_2.jpeg
+   :target: _images/parts_2.jpeg
 
 
 Printing
@@ -300,10 +300,10 @@ Pi Mount
 The Pi Mount takes eight inserts total: four in the printed stand-offs and four in the edges.
 
 .. image:: images/build_guide/parts_3.jpeg
-   :target: images/build_guide/parts_3.jpeg
+   :target: _images/parts_3.jpeg
 
 .. image:: images/build_guide/parts_4.jpeg
-   :target: images/build_guide/parts_4.jpeg
+   :target: _images/parts_4.jpeg
 
 Bottom
 ^^^^^^^
@@ -311,7 +311,7 @@ Bottom
 For left/right builds this is the bottom piece. It needs four inserts to attach the dovetail mount.
 
 .. image:: images/build_guide/parts_5.jpeg
-   :target: images/build_guide/parts_5.jpeg
+   :target: _images/parts_5.jpeg
 
 
 Flat Adaptor
@@ -323,7 +323,7 @@ Flat Adaptor
 This piece replaces the bottom and back pieces from the left/right build. It needs eight inserts: four to attach the dovetail mount and four to attach the camera.
 
 .. image:: images/build_guide/parts_6.jpeg
-   :target: images/build_guide/parts_6.jpeg
+   :target: _images/parts_6.jpeg
 
 
 Back
@@ -332,7 +332,7 @@ Back
 The back piece holds the camera for left/right builds. It also reinforces the Pi Mount and the Bottom piece to keep everything square and sturdy. It needs six inserts: four to mount the camera and two in the bottom edge to connect with the bottom piece.
 
 .. image:: images/build_guide/parts_7.jpeg
-   :target: images/build_guide/parts_7.jpeg
+   :target: _images/parts_7.jpeg
 
 Dovetail Bottom
 ^^^^^^^^^^^^^^^^
@@ -340,7 +340,7 @@ Dovetail Bottom
 The dovetail bottom has two inserts for the longer 12mm screws that allow angle adjustment. These inserts go in the side opposite where the top piece connects. The screws pass through the top piece and part of the bottom before they engage the inserts. This makes the assembly strong enough to hold the angle you set once the screws are tight enough.
 
 .. image:: images/build_guide/parts_8.jpeg
-   :target: images/build_guide/parts_8.jpeg
+   :target: _images/parts_8.jpeg
 
 
 Installation
@@ -350,7 +350,7 @@ I use a lot of these inserts, so I use a tool to seat them plumb into the parts.
 
 
 .. image:: ../../images/build_guide/v1.4/build_guide_02.jpg
-   :target: ../../images/build_guide/v1.4/build_guide_02.jpg
+   :target: _images/build_guide_02.jpg
    :alt: Insert Inserting
 
 
@@ -362,7 +362,7 @@ Most people print the dovetail mount. It fits the finder shoe included on most t
 
 
 .. image:: ../../images/finder_shoe_angle.png
-   :target: ../../images/finder_shoe_angle.png
+   :target: _images/finder_shoe_angle.png
    :alt: Finder shoe angle
 
 
@@ -483,7 +483,7 @@ First, mount the Pi and the PiSugar battery to the Pi Mount piece. The photo bel
 
 
 .. image:: images/build_guide/common_1.jpeg
-   :target: images/build_guide/common_1.jpeg
+   :target: _images/common_1.jpeg
    :alt: Build Guide Step
 
 
@@ -502,7 +502,7 @@ Snip off the loose ends of the zip ties, then move on.
 
 
 .. image:: images/build_guide/common_1c.jpeg
-   :target: images/build_guide/common_1c.jpeg
+   :target: _images/common_1c.jpeg
 
 
 
@@ -524,12 +524,12 @@ Return to the Raspberry Pi assembly and thread the camera cable through as shown
 .. list-table::
 
    * - .. image:: images/build_guide/left_1.jpeg
-          :target: images/build_guide/left_1.jpeg
+          :target: _images/left_1.jpeg
 
        Left hand cable routing
 
      - .. image:: images/build_guide/right_1.jpeg
-          :target: images/build_guide/right_1.jpeg
+          :target: _images/right_1.jpeg
 
        Right hand cable routing
 
@@ -542,7 +542,7 @@ Return to the Raspberry Pi assembly and thread the camera cable through as shown
 
 
 .. image:: ../../images/build_guide/pisugar_setup.jpg
-   :target: ../../images/build_guide/pisugar_setup.jpg
+   :target: _images/pisugar_setup.jpg
    :alt: Build Guide Step
 
 
@@ -550,7 +550,7 @@ The PiSugar ships with a protective film on the screw posts, as shown below. Rem
 
 
 .. image:: ../../images/build_guide/v1.6/build_guide_01.jpeg
-   :target: ../../images/build_guide/v1.6/build_guide_01.jpeg
+   :target: _images/build_guide_01.jpeg
    :alt: Build Guide Step
 
 
@@ -689,7 +689,7 @@ Now plug the UI Hat carefully into the Raspberry Pi. Make sure both rows of pins
 The screw holes on the UI Hat should line up with three of the four stand-offs. The fourth provides support but does not secure the outer case. Collect the Shroud, the Bezel, and the cover plate, along with three of the 12mm screws, for the next steps.
 
 .. image:: images/build_guide/common_5.jpeg
-   :target: images/build_guide/common_5.jpeg
+   :target: _images/common_5.jpeg
 
 
 The shroud has three optional openings: one on top for the PiSugar power switch, one for the USB ports, and one on the side for easier access to the SD card. Remove these with a little force or a sharp knife. If you use a PiSugar battery, you must remove the power switch tab. See the photo below:
@@ -732,7 +732,7 @@ If you haven't already prepared an SD card, continue to the :doc:`software setup
 
 
 .. image:: images/build_guide/common_11.jpeg
-   :target: images/build_guide/common_11.jpeg
+   :target: _images/common_11.jpeg
 
 
 Flat Assembly
@@ -742,7 +742,7 @@ This section covers a Flat build. This configuration is great for refractors, SC
 
 
 .. image:: ../../images/flat_mount.png
-   :target: ../../images/flat_mount.png
+   :target: _images/flat_mount.png
    :alt: Flat example
 
 
@@ -750,7 +750,7 @@ Follow the :ref:`general assembly guide <build_guide:assembly>` through to the p
 
 
 .. image:: ../../images/build_guide/v1.6/build_guide_11.jpeg
-   :target: ../../images/build_guide/v1.6/build_guide_11.jpeg
+   :target: _images/build_guide_11.jpeg
    :alt: Pi Module Assembled
 
 
@@ -759,27 +759,27 @@ If you routed the cable as above, pull the camera cable out of the RPI assembly.
 Collect the flat adapter and the dovetail. The dovetail secures to the underside of the flat adapter with screws through the adapter. The Pi Mount assembly slots into the flat adapter, and screws into the edge inserts hold it there. See the photos below for details.
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_01.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_01.jpeg
+   :target: _images/flat_build_guide_01.jpeg
    :alt: Assembly Steps
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_02.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_02.jpeg
+   :target: _images/flat_build_guide_02.jpeg
    :alt: Assembly Steps
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_03.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_03.jpeg
+   :target: _images/flat_build_guide_03.jpeg
    :alt: Assembly Steps
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_04.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_04.jpeg
+   :target: _images/flat_build_guide_04.jpeg
    :alt: Assembly Steps
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_05.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_05.jpeg
+   :target: _images/flat_build_guide_05.jpeg
    :alt: Assembly Steps
 
 
@@ -787,7 +787,7 @@ Note the one additional screw on the other side, visible in the next photo. Once
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_06.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_06.jpeg
+   :target: _images/flat_build_guide_06.jpeg
    :alt: Assembly Steps
 
 
@@ -795,7 +795,7 @@ Turn the PiFinder around and screw in the three thumbscrews as shown. Check the 
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_07.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_07.jpeg
+   :target: _images/flat_build_guide_07.jpeg
    :alt: Assembly Steps
 
 
@@ -803,7 +803,7 @@ Next, position the camera module and secure it with the longer M2.5 screw. Inser
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_09.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_09.jpeg
+   :target: _images/flat_build_guide_09.jpeg
    :alt: Assembly Steps
 
 
@@ -811,17 +811,17 @@ Gently plug in the UI Hat and tuck the cable underneath it. Take your time and m
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_10.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_10.jpeg
+   :target: _images/flat_build_guide_10.jpeg
    :alt: Assembly Steps
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_11.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_11.jpeg
+   :target: _images/flat_build_guide_11.jpeg
    :alt: Assembly Steps
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_12.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_12.jpeg
+   :target: _images/flat_build_guide_12.jpeg
    :alt: Assembly Steps
 
 
@@ -834,28 +834,28 @@ Once the UI Hat is plugged in all the way and the cable is tidy, gather the rema
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_13.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_13.jpeg
+   :target: _images/flat_build_guide_13.jpeg
    :alt: Assembly Steps
 
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_14.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_14.jpeg
+   :target: _images/flat_build_guide_14.jpeg
    :alt: Assembly Steps
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_15.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_15.jpeg
+   :target: _images/flat_build_guide_15.jpeg
    :alt: Assembly Steps
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_16.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_16.jpeg
+   :target: _images/flat_build_guide_16.jpeg
    :alt: Assembly Steps
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_17.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_17.jpeg
+   :target: _images/flat_build_guide_17.jpeg
    :alt: Assembly Steps
 
 
@@ -863,7 +863,7 @@ One task remains: fit the camera lens. Unscrew the cap from the camera module, b
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_19.jpeg
-   :target: ../../images/build_guide/v1.6/flat/flat_build_guide_19.jpeg
+   :target: _images/flat_build_guide_19.jpeg
    :alt: Assembly Steps
 
 

--- a/docs/source/build_guide.rst
+++ b/docs/source/build_guide.rst
@@ -7,37 +7,37 @@ Introduction and Overview
 =================================
 
 .. note::
-   This guide covers the self-built (DIY) PiFinder, which uses the v2.5 hardware
+   This guide covers the self-built (DIY) PiFinder. It uses the v2.5 hardware
    and comes together in one of three configurations: Left, Right, or Flat.
-   v3 PiFinders are sold assembled and aren't built from these instructions.
+   v3 PiFinders ship assembled and do not use these instructions.
 
-Welcome to the PiFinder build guide. It's split into three main parts: building the :ref:`UI Board<build_guide:pifinder ui hat>` with its screen and buttons, :ref:`3d printing<build_guide:printed parts>` and preparing the case parts, and :ref:`final assembly<build_guide:assembly>`. Alongside these, consult the :doc:`Bill of Materials<BOM>` for the full parts list, and reach out with any questions via `email <mailto:info@pifinder.io>`_ or `discord <https://discord.gg/Nk5fHcAtWD>`_
+Welcome to the PiFinder build guide. The build has three main parts: the :ref:`UI Hat <build_guide:pifinder ui hat>` with its screen and buttons, :ref:`3d printing <build_guide:printed parts>` and preparing the case parts, and :ref:`final assembly <build_guide:assembly>`. The :doc:`Bill of Materials <BOM>` lists every part you need. Send any questions by `email <mailto:info@pifinder.io>`_ or on `discord <https://discord.gg/Nk5fHcAtWD>`_.
 
 
 PiFinder UI Hat
 ========================
 
-A key part of the PiFinder is a custom 'Hat' that matches the general form factor of the Raspberry Pi and connects to its GPIO header. It carries the switches, screen, Inertial Measurement Unit, and the keypad backlight components.
+A key part of the PiFinder is the UI Hat, a custom board that matches the general form factor of the Raspberry Pi and connects to its GPIO header. It carries the switches, the screen, the Inertial Measurement Unit, and the keypad backlight components.
 
-Everything is through-hole, so this is approachable even for beginners. The build order matters, though, as some components block access to others.
+Every component is through-hole, so this build is approachable even for beginners. The build order matters, though, because some components block access to others.
 
 Some photos here still show the v1 non-backlit board, but the assembly is the same once the backlight components are in place.
 
-You'll need the TWO PCBs to start. One holds the electronic components; the other carries the shine-through legends and goes on top of the assembled board at the end. Gerber files for both are in the main `PiFinder git repo <https://github.com/brickbots/PiFinder/tree/release/gerbers>`_
+You need both PCBs to start. One holds the electronic components. The other carries the shine-through legends and goes on top of the assembled board at the end. The main `PiFinder git repo <https://github.com/brickbots/PiFinder/tree/release/gerbers>`_ holds the Gerber files for both.
 
 Backlight Components
 ------------------------
 
-Start with the LEDs. They sit close to the board, and doing them first makes it easier to keep them aligned.
+Start with the LEDs. They sit close to the board, so fitting them first makes them easier to align.
 
 .. image:: images/build_guide/ui_module_1.jpeg
 
 
-Polarity matters, so mind the direction. The longer lead of the LED goes through the round hole in the footprint. The photo below shows the orientation.
+Polarity matters, so check the direction of each LED. The longer lead goes through the round hole in the footprint. The photo below shows the orientation.
 
 .. image:: ../../images/build_guide/led_build_03.jpeg
 
-Position each one carefully. They should be fairly uniform, though small inconsistencies don't matter much. Place them all in the board, then tape them in place.
+Position each LED carefully. Keep them fairly uniform, though small inconsistencies don't matter much. Place them all in the board, then tape them in place.
 
 .. image:: images/build_guide/ui_module_2.jpeg
 
@@ -47,33 +47,33 @@ Pull the legs straight and solder one leg of each LED. Remove the tape and check
 
 .. image:: images/build_guide/ui_module_4.jpeg
 
-When satisfied, solder the remaining legs and clip the leads down to a single pair. We'll check the LEDs in the next section before moving on, so leave one pair of legs long to power the backlight for testing.
+When you are happy with the alignment, solder the remaining legs and clip the leads down to a single pair. Leave one pair of legs long. You need them to power the backlight for the test in the next section.
 
 .. image:: images/build_guide/ui_module_5.jpeg
 
-The two resistors and the transistor are next. R2 is the vertical 330 ohm part; R1 is the 22 ohm part oriented horizontally. Direction doesn't matter for the resistors, but it does for the transistor. Check the photo below for orientation, and make sure the transistor sits flat against the PCB and the resistors are low. Solder from the back and clip the leads once they look good.
+Fit the two resistors and the transistor next. R2 is the 330 ohm part and stands vertically. R1 is the 22 ohm part and lies horizontally. Direction doesn't matter for the resistors, but it does for the transistor. Check the photo below for the orientation. Make sure the transistor sits flat against the PCB and the resistors sit low. Solder from the back and clip the leads once they look good.
 
 .. image:: images/build_guide/ui_module_6a.jpeg
 
 Testing the Backlight
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Test the backlight (and LEDs) now using any 3V coin cell, such as a CR2032. Connect the positive side of the battery to the longer pin of an LED and the negative side to the shorter pin, as shown below with a single LED. This works for all the LEDs at once since they're wired in parallel on the board. Once connected, every LED should light up:
+Test the backlight and the LEDs now with any 3V coin cell, such as a CR2032. Connect the positive side of the battery to the longer pin of an LED and the negative side to the shorter pin, as shown below with a single LED. The LEDs are wired in parallel on the board, so this lights all of them at once. Every LED should light up:
 
 .. image:: images/build_guide/test_leds_1.jpeg
 
-Replace any LEDs that aren't working properly before proceeding.
+Replace any LED that doesn't light before you continue.
 
 Switches
 ------------------------
 
-Switches go next. Place each one on its footprint and press it down fully. Before soldering, visually inspect them for any that are tilted.
+Fit the switches next. Place each one on its footprint and press it down fully. Before you solder, check that none of them sit tilted.
 
 
 .. image:: images/build_guide/ui_module_6b.jpeg
 
 
-It's also worth placing the top legend plate over them to confirm they all clear the holes properly. Then solder them up. You don't need to clip the leads on the switches; they have plenty of room.
+Place the top legend plate over them to confirm they all clear the holes properly. Then solder them. You don't need to clip the switch leads, because they have plenty of room.
 
 .. image:: images/build_guide/ui_module_6c.jpeg
 
@@ -81,15 +81,15 @@ It's also worth placing the top legend plate over them to confirm they all clear
 Headers
 ---------
 
-Do the headers next. These will receive the IMU, GPS, and Screen. The procedure is the same for all three: insert the header, solder one pin, check that it's flat and straight, then solder the rest. Clip the pins flush and apply some insulating tape.
+Fit the headers next. They receive the IMU, the GPS module, and the screen. The procedure is the same for all three: insert the header, solder one pin, check that it sits flat and straight, then solder the rest. Clip the pins flush and apply some insulating tape.
 
-Start with the IMU header. It goes on the underside of the board and is soldered from the top.
+Start with the IMU header. It goes on the underside of the board. Solder it from the top.
 
 .. image:: images/build_guide/ui_module_7.jpeg
 
 .. image:: images/build_guide/ui_module_8.jpeg
 
-Apply the insulating tape and move on to the screen header, which goes in from the top side:
+Apply the insulating tape. Fit the screen header next. It goes in from the top side:
 
 .. image:: images/build_guide/ui_module_9.jpeg
 
@@ -97,7 +97,7 @@ Trim the pins and tape it up.
 
 .. image:: images/build_guide/ui_module_10.jpeg
 
-The GPS header is next. The modules ship with a yellow header, but any will do. It inserts from the bottom, then gets soldered and taped like the rest.
+Fit the GPS header next. The modules ship with a yellow header, but any header works. Insert it from the bottom, then solder and tape it like the rest.
 
 .. image:: images/build_guide/ui_module_11.jpeg
 
@@ -107,14 +107,14 @@ The GPS header is next. The modules ship with a yellow header, but any will do. 
 IMU
 ------------------------
 
-The Inertial Measurement Unit is next. It has an annoyingly bright green LED that you'll want to either paint over with a few layers of black nail polish or destroy with your soldering iron. You can deal with it after soldering if you forget, but it's much easier beforehand. See the image below to identify the offending component.
+Fit the Inertial Measurement Unit next. It has an annoyingly bright green LED. Paint over it with a few layers of black nail polish, or destroy it with your soldering iron. You can deal with it after soldering if you forget, but it is much easier beforehand. The image below shows the offending component.
 
 .. image:: ../../images/build_guide/adafruit_IMU.png
    :target: ../../images/build_guide/adafruit_IMU.png
    :alt: Green led on IMU
 
 
-The photo below shows the orientation on the back of the PCB. Make sure it sits flat and square with the board. It doesn't need to be perfect, but should be secure and low-profile. Solder it into position and you're good to go.
+The photo below shows the orientation on the back of the PCB. Make sure the IMU sits flat and square with the board. It doesn't need to be perfect, but it must be secure and low-profile. Solder it into position.
 
 .. image:: images/build_guide/ui_module_13.jpeg
 
@@ -122,9 +122,9 @@ The photo below shows the orientation on the back of the PCB. Make sure it sits 
 Display
 ------------------
 
-The display comes next and will cover the IMU header's solder points, so double-check those joints before proceeding.
+The screen comes next. It covers the solder points of the IMU header, so check those joints before you continue.
 
-Remove the stand-offs by unscrewing them from the front.
+Unscrew the stand-offs from the front and remove them.
 
 
 .. image:: ../../images/build_guide/IMG_4648.jpeg
@@ -138,7 +138,7 @@ Remove the stand-offs by unscrewing them from the front.
    :alt: Display with standoffs removed
 
 
-Next, remove the plug from the underside of the board. This isn't strictly necessary, but it helps the display sit lower and flatter. Use sharp cutters to cut each lead to the connector first, cutting low though the exact spot isn't critical. Then use clippers to cut away the plastic at the attachment points on both short sides.
+Next, remove the plug from the underside of the board. This step isn't strictly necessary, but it helps the screen sit lower and flatter. First cut each lead to the connector with sharp cutters. Cut low, though the exact spot isn't critical. Then cut away the plastic at the attachment points on both short sides with clippers.
 
 
 .. image:: ../../images/build_guide/IMG_4650.jpeg
@@ -146,7 +146,7 @@ Next, remove the plug from the underside of the board. This isn't strictly neces
    :alt: Connector cut free
 
 
-To make the top plate fit better and look tidier, sand back or cut the bottom tabs on the display PCB. There's no circuitry there; they just provide unneeded screw points.
+Sand back or cut the bottom tabs on the screen PCB. This makes the top plate fit better and look tidier. The tabs carry no circuitry and only provide screw points you don't need.
 
 
 .. image:: ../../images/build_guide/IMG_4652.jpeg
@@ -154,7 +154,7 @@ To make the top plate fit better and look tidier, sand back or cut the bottom ta
    :alt: Cut/Sand tabs on display
 
 
-Test-fit the screen with the header installed and the top plate in place. Everything should fit nicely and sit square.
+Test-fit the screen with the header installed and the top plate in place. Everything should fit neatly and sit square.
 
 
 .. image:: ../../images/build_guide/IMG_4653.jpeg
@@ -162,7 +162,7 @@ Test-fit the screen with the header installed and the top plate in place. Everyt
    :alt: Screen test fit
 
 
-When you're ready, solder the screen in place. Do one pin first and check all around to make sure it's sitting flat. If not, heat that one joint and adjust.
+Solder the screen in place. Solder one pin first and check all around to make sure the screen sits flat. If it doesn't, heat that one joint and adjust.
 
 .. image:: images/build_guide/ui_module_14.jpeg
 
@@ -170,22 +170,22 @@ GPS
 ------------------
 
 .. danger::
-   Complete the :ref:`Testing the Backlight<build_guide:testing the backlight>` step before soldering on the GPS unit. The GPS unit blocks access to some LED pins and would need to be removed to replace any blocked LEDs. Removing it is difficult and can destroy the PCB. It has happened to us. Make sure the LEDs work before proceeding.
+   Complete the :ref:`Testing the Backlight <build_guide:testing the backlight>` step before you solder on the GPS module. The GPS module blocks access to some LED pins. To replace a blocked LED, you have to remove the module first. Removing it is difficult and can destroy the PCB. It has happened to us. Make sure the LEDs work before you continue.
 
-   If you do need to desolder the GPS unit later, be very careful and patient, and use a desoldering pump.
+   If you do need to desolder the GPS module later, work slowly and carefully, and use a desoldering pump.
 
 
 .. caution::
-   If you want to test the switches, you can leave the GPS unit out entirely until the end, since it also blocks access to some switch pins. The GPIO connector for attaching the hat to the Raspberry Pi will then make this awkward.
+   The GPS module also blocks access to some switch pins, so you can leave it out entirely until the end if you want to test the switches. The GPIO connector that attaches the UI Hat to the Raspberry Pi then makes this awkward.
 
-   This isn't recommended: the LEDs have given us trouble in the past, but the switches have usually been rock solid.
+   We don't recommend it. The LEDs have given us trouble in the past, but the switches have usually been rock solid.
 
 
 The last active component is the GPS module. It goes component side up so you can access the antenna plug. Check the photo below and solder it securely.
 
 .. image:: images/build_guide/ui_module_15.jpeg
 
-Connect the antenna to the GPS module. It's fiddly, so check the alignment carefully before applying too much force. It will snap in and then rotate easily.
+Connect the antenna to the GPS module. The plug is fiddly, so check the alignment carefully before you apply much force. It snaps in and then rotates easily.
 
 .. list-table::
 
@@ -194,7 +194,7 @@ Connect the antenna to the GPS module. It's fiddly, so check the alignment caref
      - .. image:: images/build_guide/common_4.jpeg
 
 
-Routing the antenna cable well matters for reception. Following the photo below, tape it to the back of the board to keep it secure and out of the way during the build.
+The route of the antenna cable matters for reception. Tape the cable to the back of the board as shown below. This keeps it secure and out of the way during the build.
 
 
 .. image:: images/build_guide/ui_module_15b.jpeg
@@ -202,32 +202,32 @@ Routing the antenna cable well matters for reception. Following the photo below,
 Connector
 ------------------
 
-The GPIO connector is the last soldered part of the Hat. To space it correctly, mount the PCB to your Pi using the stand-offs you'll use for final assembly.
+The GPIO connector is the last soldered part of the UI Hat. To space it correctly, mount the PCB to your Pi with the stand-offs you use for final assembly.
 
-The connector's pins are long to accommodate various spacings. Plug the connector firmly into your Pi, mount the PiFinder hat with stand-offs and screws, and then solder the connector at the correct spacing.
+The pins of the connector are long, so they suit a range of spacings. Plug the connector firmly into your Pi, mount the UI Hat with stand-offs and screws, then solder the connector at the correct spacing.
 
-Add any heatsinks you plan to use first. Take your time and make sure the hat is secured properly to the Pi, that there's no mechanical interference, and that you're happy with the spacing before soldering.
+Add any heatsinks you plan to use first. Before you solder, take your time and check that the UI Hat sits securely on the Pi, that no parts interfere mechanically, and that you are happy with the spacing.
 
-Check the photos below for the procedure; it's easier than it sounds. There are a lot of pins, so make sure each is secure, as this part takes force every time the hat is installed and removed.
+The photos below show the procedure, which is easier than it sounds. There are a lot of pins, so solder each one securely. This part takes force every time you install or remove the UI Hat.
 
 .. image:: images/build_guide/ui_module_16.jpeg
 
 .. image:: images/build_guide/ui_module_17.jpeg
 
-With all the pins soldered, insert the SD card and power it up to double-check everything works.
+With all the pins soldered, insert the SD card and turn the PiFinder on to check that everything works.
 
 .. image:: images/build_guide/ui_module_18.jpeg
 
-Once it has started completely, you'll be greeted with :ref:`"the menu"<user_guide:the menu system>`. Use the buttons below the screen to navigate; see the faceplate for button functions.
+Once it has started completely, the :ref:`menu system <user_guide:the menu system>` appears. Use the buttons below the screen to scroll and select. The faceplate shows what each button does.
 
-Navigate to the ``Tools > Status`` :ref:`screen<user_guide:status screen>` and verify the IMU is detected: the "IMU" lines should show some numbers. Then go to ``Objects > Name Search`` and enter a few letters of an object name to test the keypad. The keypad is now working properly.
+From the main menu, select Tools, then select Status to open the :ref:`Status screen <user_guide:status screen>`. Check that the PiFinder detects the IMU. The "IMU" lines show some numbers when it does. Then select Objects, select Name Search, and enter a few letters of an object name to test the keypad. The keypad is now working properly.
 
-There you go. The PiFinder hat is fully assembled, and you can move on to printing your parts or :ref:`final assembly<build_guide:assembly>`
+The UI Hat is now fully assembled. Move on to printing your parts or to :ref:`final assembly <build_guide:assembly>`.
 
 Configurations Overview
 ========================
 
-There are three ways to build a PiFinder so it works conveniently on a variety of telescopes.
+You can build the PiFinder in three configurations, so that it works conveniently on a wide range of telescopes.
 
 
 .. list-table::
@@ -244,29 +244,29 @@ There are three ways to build a PiFinder so it works conveniently on a variety o
 
           Flat
 
-Any configuration can work with any scope, but since the camera always needs to face the sky, the different configurations let you place the screen and keyboard for easy access. The Left and Right configurations are mainly for newtonian-style scopes, like dobsonians, whose focuser sits perpendicular to the light path.
+Any configuration works with any telescope. The camera always needs to face the sky, so the configurations differ in where they put the screen and the keypad for easy access. The Left and Right configurations mainly suit newtonian-style telescopes, such as Dobsonians, whose focuser sits perpendicular to the light path.
 
-The Flat configuration puts the keypad and screen in easy reach for refractors, SCTs, and other rear-focuser scopes. When the scope points upward, the screen tilts towards you for quick access.
+The Flat configuration puts the keypad and the screen in easy reach on refractors, SCTs, and other rear-focuser telescopes. When the telescope points upward, the screen tilts towards you for quick access.
 
-All the STL files for the PiFinder case parts are in the main `PiFinder git repo case folder <https://github.com/brickbots/PiFinder/tree/release/case>`_
+All the STL files for the PiFinder case parts are in the main `PiFinder git repo case folder <https://github.com/brickbots/PiFinder/tree/release/case>`_.
 
 
 Printed Parts
 ===========================
 
 
-The PiFinder can be built in a left, right, or flat configuration to suit many telescopes. See the :ref:`configurations overview<build_guide:configurations overview>` for more, including example photos. Each configuration needs only a subset of the available parts.
+You can build the PiFinder in a left, right, or flat configuration to suit many telescopes. See the :ref:`configurations overview <build_guide:configurations overview>` for more, including example photos. Each configuration needs only some of the available parts.
 
 
 Common Parts
 -----------------------
 
-Some parts are common to all three configurations. The Bezel, Camera Cover, and RPI Mount are used in every build.
+Some parts are common to all three configurations. Every build uses the Bezel, the Camera Cover, and the Pi Mount.
 
 Right and Left configurations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Below are all the parts needed to build a left- or right-hand PiFinder. Thanks to the edge inserts, these pieces assemble into either configuration, so you need just one set of parts regardless of which side your focuser faces. The assembly guide covers how to orient the pieces as you put them together.
+The photo below shows all the parts for a left- or right-hand PiFinder. The edge inserts let these pieces assemble into either configuration, so you need just one set of parts whichever side your focuser faces. The assembly guide covers how to orient the pieces as you put them together.
 
 .. image:: images/build_guide/parts_1.jpeg
    :target: images/build_guide/parts_1.jpeg
@@ -276,7 +276,7 @@ Below are all the parts needed to build a left- or right-hand PiFinder. Thanks t
 Flat Configuration
 ^^^^^^^^^^^^^^^^^^
 
-The pieces for the flat version are pictured below. The same parts are used with or without a PiSugar battery.
+The photo below shows the pieces for the flat version. The parts are the same with or without a PiSugar battery.
 
 .. image:: images/build_guide/parts_2.jpeg
    :target: images/build_guide/parts_2.jpeg
@@ -285,14 +285,14 @@ The pieces for the flat version are pictured below. The same parts are used with
 Printing
 --------
 
-These pieces print without supports in the orientation shown. I use 3 perimeter layers and 15% infill, but the parts are small and don't take heavy forces, so almost any print settings will work.
+These pieces print without supports in the orientation shown. I use 3 perimeter layers and 15% infill. The parts are small and don't take heavy forces, so almost any print settings work.
 
-Use a material other than PLA, since your PiFinder will likely see some sunlight and PLA degrades under moderate heat and UV. PETG or a co-polymer like NGen is a good choice. Prusament Galaxy PETG is the official PiFinder filament and appears in most of the build guide, except where grey provided needed contrast.
+Print in a material other than PLA. Your PiFinder probably sees some sunlight, and PLA degrades under moderate heat and UV. PETG or a co-polymer such as NGen is a good choice. Prusament Galaxy PETG is the official PiFinder filament and appears in most of this guide, except where grey provided needed contrast.
 
 Inserts
 -------
 
-Only some holes receive inserts; the rest take M2.5 screws that pass through into inserts in other pieces. The brass inserts used here are M2.5 x 4mm long. Some go into holes through the full thickness of the piece, and some go into blind holes in the edges. Each part with inserts is pictured below for reference:
+Only some holes take inserts. The rest take M2.5 screws that pass through into inserts in other pieces. The brass inserts used here are M2.5 x 4mm long. Some go into holes through the full thickness of the piece, and some go into blind holes in the edges. The photos below show each part that takes inserts:
 
 Pi Mount
 ^^^^^^^^^
@@ -317,8 +317,8 @@ For left/right builds this is the bottom piece. It needs four inserts to attach 
 Flat Adaptor
 ^^^^^^^^^^^^^
 .. note::
-   The photos for the Flat Adaptor and the Back shown here are for the v2 build. The v2.5 parts
-   are almost identical, but have 2 camera mount holes rather than 4.
+   The photos for the Flat Adaptor and the Back show the v2 build. The v2.5 parts
+   are almost identical, but they have 2 camera mount holes rather than 4.
 
 This piece replaces the bottom and back pieces from the left/right build. It needs eight inserts: four to attach the dovetail mount and four to attach the camera.
 
@@ -329,7 +329,7 @@ This piece replaces the bottom and back pieces from the left/right build. It nee
 Back
 ^^^^^^^^^
 
-The back piece holds the camera for left/right builds and reinforces the PiMount and Bottom piece to keep everything square and sturdy. It needs six inserts: four to mount the camera and two in the bottom edge to connect with the bottom piece.
+The back piece holds the camera for left/right builds. It also reinforces the Pi Mount and the Bottom piece to keep everything square and sturdy. It needs six inserts: four to mount the camera and two in the bottom edge to connect with the bottom piece.
 
 .. image:: images/build_guide/parts_7.jpeg
    :target: images/build_guide/parts_7.jpeg
@@ -337,7 +337,7 @@ The back piece holds the camera for left/right builds and reinforces the PiMount
 Dovetail Bottom
 ^^^^^^^^^^^^^^^^
 
-The dovetail bottom has two inserts for the longer 12mm screws that allow angle adjustment. These inserts go in the side opposite where the top piece connects. The screws pass through the top piece and part of the bottom before engaging the inserts. This makes the assembly strong enough to hold the set angle once the screws are sufficiently tight.
+The dovetail bottom has two inserts for the longer 12mm screws that allow angle adjustment. These inserts go in the side opposite where the top piece connects. The screws pass through the top piece and part of the bottom before they engage the inserts. This makes the assembly strong enough to hold the angle you set once the screws are tight enough.
 
 .. image:: images/build_guide/parts_8.jpeg
    :target: images/build_guide/parts_8.jpeg
@@ -346,7 +346,7 @@ The dovetail bottom has two inserts for the longer 12mm screws that allow angle 
 Installation
 ^^^^^^^^^^^^^
 
-Because I use a lot of these inserts, I use a tool to seat them plumb into the parts, but I've done plenty freehand and it's not difficult. Use a temperature a bit below your normal printing temperature (I print PETG at 230c and use 170-200c for inserts) and give the plastic time to melt around them.
+I use a lot of these inserts, so I use a tool to seat them plumb into the parts. I have also done plenty freehand, and it isn't difficult. Use a temperature a bit below your normal printing temperature (I print PETG at 230c and use 170-200c for inserts) and give the plastic time to melt around them.
 
 
 .. image:: ../../images/build_guide/v1.4/build_guide_02.jpg
@@ -358,7 +358,7 @@ Because I use a lot of these inserts, I use a tool to seat them plumb into the p
 Mounting
 --------
 
-Most people will print the dovetail mount, which fits the finder shoe included on most telescopes. The dovetail mount is angle adjustable, letting you orient the screen surface roughly vertical and perpendicular to the ground. This puts the inertial motion sensor into its expected position. See the image below for a clearer explanation:
+Most people print the dovetail mount. It fits the finder shoe included on most telescopes. The angle of the dovetail mount adjusts, so you can set the screen surface roughly vertical and perpendicular to the ground. This puts the IMU into its expected position. The image below explains it more clearly:
 
 
 .. image:: ../../images/finder_shoe_angle.png
@@ -369,9 +369,9 @@ Most people will print the dovetail mount, which fits the finder shoe included o
 Adjustable Dovetail Assembly
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you print your own parts, add heat-set inserts as pictured in the photo above. The inserts must go in from the outside of the bottom piece, as pictured. The holes on the inside aren't large enough for inserts; they just let the screws pass through into the inserts.
+If you print your own parts, add heat-set inserts as pictured in the photo above. The inserts must go in from the outside of the bottom piece, as pictured. The holes on the inside aren't large enough for inserts. They only let the screws pass through into the inserts.
 
-See the photos below for how the pieces fit together. Once assembled, loosen both screws to adjust the angle up to 40 degrees from horizontal, then secure them again. No need to go too tight, but a bit of friction is required to hold the angle.
+The photos below show how the pieces fit together. Once assembled, loosen both screws to adjust the angle up to 40 degrees from horizontal, then secure them again. They don't need to be too tight, but they need a bit of friction to hold the angle.
 
 
 .. image:: images/build_guide/dovetail_1.jpeg
@@ -383,14 +383,14 @@ See the photos below for how the pieces fit together. Once assembled, loosen bot
 .. image:: images/build_guide/dovetail_4.jpeg
 
 
-If you need more flexibility, there's also a go-pro compatible plate that bolts into the bottom plate. You'll need to add inserts into the bottom plate mounting footprint to use this option.
+If you need more flexibility, a go-pro compatible plate also bolts into the bottom plate. To use it, add inserts to the mounting footprint on the bottom plate.
 
-Once all the parts are printed and the inserts are seated, you're ready to :ref:`assemble<build_guide:assembly>`!
+Once all the parts are printed and the inserts are seated, you're ready to :ref:`assemble <build_guide:assembly>`.
 
 Rigel Quickfinder Assembly
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You'll need the following for a Rigel Quickfinder adapter:
+You need the following for a Rigel Quickfinder adapter:
 
 .. list-table::
    :header-rows: 1
@@ -402,23 +402,23 @@ You'll need the following for a Rigel Quickfinder adapter:
    * - 1
      - PiToQuickfinder v2 - Part 1.stl
      - `git repo quikfinder <https://github.com/brickbots/PiFinder/tree/release/case/adapter/quikfinder>`_
-     - You'll need both this and the next item
+     - You need both this and the next item
    * - 1
      - PiToQuickfinder v2 - Part 2.stl
      - `git repo quikfinder <https://github.com/brickbots/PiFinder/tree/release/case/adapter/quikfinder>`_
-     - You'll need both this and the previous item
+     - You need both this and the previous item
    * - 2
      - heat-set insert M2.5 x 4 mm
      -
      - Same as for the case
 
-Print "Part 2" to maximize the strength of the "hook". Print it with supports, like this:
+Print "Part 2" to maximize the strength of the "hook". Print it with supports, as shown below:
 
 .. image:: images/build_guide/quickfinder_base_4.jpeg
 
 If you print your own parts, add heat-set inserts as pictured below. Space is limited, so fix it to the PiFinder first and then insert the second part. Tighten the screws just a little to hold the second part so it can't fall off.
 
-After putting it on a Rigel Quickfinder base, tighten the screws fully. Note that the double-sided foam adhesive supplied with the Rigel Quikfinder may compress under the weight of the PiFinder (about 6 times the weight of a Quikfinder), so you may need to reconsider how the base plate is fixed to your scope.
+After you put it on a Rigel Quickfinder base, tighten the screws fully. The double-sided foam adhesive supplied with the Rigel Quikfinder may compress under the weight of the PiFinder, which is about 6 times the weight of a Quikfinder. You may need to fix the base plate to your telescope another way.
 
 
 .. image:: images/build_guide/quickfinder_base_1.jpeg
@@ -428,7 +428,7 @@ After putting it on a Rigel Quickfinder base, tighten the screws fully. Note tha
 .. image:: images/build_guide/quickfinder_base_3.jpeg
 
 
-Optionally, if you need to adjust your PiFinder's orientation to make it vertical on your scope, you'll also need these:
+To adjust the orientation of your PiFinder so it stands vertical on your telescope, you also need these:
 
 .. list-table::
    :header-rows: 1
@@ -440,29 +440,29 @@ Optionally, if you need to adjust your PiFinder's orientation to make it vertica
    * - 1
      - Pi2Q2Dovetail.stl
      - `git repo quikfinder <https://github.com/brickbots/PiFinder/tree/release/case/adapter/quikfinder>`_
-     - You'll at least need this and the next item
+     - You need at least this and the next item
    * - 1
      - dovetail_top.stl
      - `git repo dovetail <https://github.com/brickbots/PiFinder/tree/release/case/v2>`_
-     - You'll at least need this and the previous item
+     - You need at least this and the previous item
    * - 6
      - heat-set insert M2.5 x 4 mm
      -
      - Same as for the case
 
-Add 4 heat-set inserts as indicated in the following pictures:
+Add 4 heat-set inserts as shown in the photos below:
 
 .. image:: images/build_guide/quickfinder_base_5.jpeg
 
 .. image:: images/build_guide/quickfinder_base_6.jpeg
 
-Assembly then follows the dovetail assembly in the previous section. Depending on your needs, you can fix the optional adapter in two orientations. Make sure the "long lip" points the same direction as the PiFinder. The fully assembled adapter looks like this:
+Assembly then follows the dovetail assembly in the previous section. You can fix the optional adapter in either of two orientations, depending on your needs. Make sure the "long lip" points in the same direction as the PiFinder. The photos below show the fully assembled adapter:
 
 .. image:: images/build_guide/quickfinder_base_7.jpeg
 
 .. image:: images/build_guide/quickfinder_base_8.jpeg
 
-Once all the parts are printed and the inserts are seated, you're ready to :ref:`assemble<build_guide:assembly>`!
+Once all the parts are printed and the inserts are seated, you're ready to :ref:`assemble <build_guide:assembly>`.
 
 
 Assembly
@@ -472,14 +472,14 @@ Assembly
 Assembly Overview
 -----------------
 
-From here you'll need the M2.5 screws, stand-offs, and thumbscrews along with the 3d printed parts, UI hat, and the camera, lens, and GPS unit. Most photos in this part show a build with the PiSugar, but if you're powering the PiFinder another way the assembly is almost identical.
+From here you need the M2.5 screws, stand-offs, and thumbscrews, along with the 3d printed parts, the UI Hat, and the camera, lens, and GPS module. Most photos in this part show a build with the PiSugar. If you power the PiFinder another way, the assembly is almost identical.
 
-*In all cases, don't over tighten the hardware.* There's no need, and you could damage the 3d printed pieces, inserts, or screws. Once they feel snug, that's enough. The case forms a rigid assembly once everything is in place and will easily support the camera and other bits.
+*In all cases, don't over tighten the hardware.* There's no need, and you could damage the 3d printed pieces, inserts, or screws. Once they feel snug, that's enough. Once everything is in place, the case forms a rigid assembly that easily supports the camera and the other parts.
 
 Pi Mounting
 ---------------------------
 
-First, mount the Pi and PiSugar battery to the Pi Mount piece. The pieces you'll need are shown below.
+First, mount the Pi and the PiSugar battery to the Pi Mount piece. The photo below shows the pieces you need.
 
 
 .. image:: images/build_guide/common_1.jpeg
@@ -487,18 +487,18 @@ First, mount the Pi and PiSugar battery to the Pi Mount piece. The pieces you'll
    :alt: Build Guide Step
 
 
-Whatever your build's orientation, the Raspberry Pi and battery always mount this same way, on top of the posts in the RPI Holder.
+Whatever the orientation of your build, the Raspberry Pi and the battery always mount this same way, on top of the posts in the Pi Mount.
 
-If you're using a PiSugar, mount the battery pack now; otherwise skip this step. Flip the PiMount piece over and use the zip ties to secure the battery as shown. Don't tighten these much, as that may damage the battery, just enough to keep it from moving too much.
+If you use a PiSugar, mount the battery pack now. Otherwise, skip this step. Flip the Pi Mount piece over and secure the battery with the zip ties as shown. Don't tighten these much, because that may damage the battery. Tighten them just enough to keep the battery from moving too much.
 
-Mind the orientation of the battery pack so the connector sits in the notch as shown below.
+Orient the battery pack so the connector sits in the notch, as shown below.
 
 
 .. image:: images/build_guide/common_1b.jpeg
    :target: _images/common_1b.jpeg
 
 
-Snip the zip-ties off and you're ready to move on.
+Snip the zip ties off, then move on.
 
 
 .. image:: images/build_guide/common_1c.jpeg
@@ -509,7 +509,7 @@ Snip the zip-ties off and you're ready to move on.
 Camera Prep
 ---------------------------
 
-The new v3 camera may come with one of two lens holders already installed. Either way, you'll remove and replace it.
+The new v3 camera comes with one of two lens holders already installed. Remove and replace it in either case.
 
 .. include:: includes/camera_prep.rst
 
@@ -517,7 +517,7 @@ The new v3 camera may come with one of two lens holders already installed. Eithe
 Cable Routing
 ---------------------------
 
-For a flat unit, set the camera cable aside, as it's routed differently. For left/right builds, it's easier to position the cable roughly now.
+For a flat build, set the camera cable aside, because it routes differently. For left/right builds, it's easier to position the cable roughly now.
 
 Return to the Raspberry Pi assembly and thread the camera cable through as shown. Note the orientation of the silver contacts at each end of the cable. The photos below show the cable routing for left- and right-hand builds.
 
@@ -534,11 +534,11 @@ Return to the Raspberry Pi assembly and thread the camera cable through as shown
        Right hand cable routing
 
 .. important::
-    If you're using the recommended S Plus unit, prepare it now.
+    If you use the recommended PiSugar S Plus, prepare it now.
 
-    * Turn the 'Auto Startup' switch on the bottom of the unit to OFF. Leaving it ON prevents i2c from working and the IMU won't be used. The switch is outlined in orange in the image below, shown in the correct OFF position.
+    * Set the 'Auto Startup' switch on the bottom of the PiSugar to OFF. If you leave it ON, i2c does not work and the PiFinder cannot use the IMU. The orange outline in the image below shows the switch in the correct OFF position.
 
-    * The blue power light on the PiSugar board is very bright. Cover it with black nail polish or destroy it with a soldering iron. Plug it into the battery and turn it on to confirm it's subdued. The orange arrow in the image below indicates which LED to cover; it's already blacked out with nail polish in the photo.
+    * The blue power light on the PiSugar board is very bright. Cover it with black nail polish or destroy it with a soldering iron. Plug the board into the battery and turn it on to confirm the light is subdued. The orange arrow in the image below points to the LED you need to cover. The photo shows it already blacked out with nail polish.
 
 
 .. image:: ../../images/build_guide/pisugar_setup.jpg
@@ -546,7 +546,7 @@ Return to the Raspberry Pi assembly and thread the camera cable through as shown
    :alt: Build Guide Step
 
 
-The PiSugar ships with a protective film on the screw posts, as seen below. Remove it, or you'll have a frustrating time getting everything screwed together.
+The PiSugar ships with a protective film on the screw posts, as shown below. Remove it, or the screws are frustrating to fit.
 
 
 .. image:: ../../images/build_guide/v1.6/build_guide_01.jpeg
@@ -554,9 +554,9 @@ The PiSugar ships with a protective film on the screw posts, as seen below. Remo
    :alt: Build Guide Step
 
 
-The PiSugar sits under the Raspberry Pi with the gold pogo pins pressed against the bottom of the Pi. The side facing up in the image above is the side that should press against the bottom of the Raspberry Pi. The PiSugar documentation has more info if needed.
+The PiSugar sits under the Raspberry Pi with the gold pogo pins pressed against the bottom of the Pi. The side facing up in the image above presses against the bottom of the Raspberry Pi. The PiSugar documentation covers this in more detail.
 
-The combined PiSugar/RPI stack then gets secured to the PI Mount using the 20mm stand-offs. The photos below show the right/left-hand stack with their respective cable routing. Flat configurations build the same way, without any camera cable.
+Secure the combined PiSugar/RPI stack to the Pi Mount with the 20mm stand-offs. The photos below show the right- and left-hand stacks with their respective cable routing. Flat configurations build the same way, without any camera cable.
 
 .. list-table::
 
@@ -581,9 +581,9 @@ The combined PiSugar/RPI stack then gets secured to the PI Mount using the 20mm 
 Right / Left Configuration
 ---------------------------
 
-Continue here to build a Right/Left-hand unit. The build is the same for both versions, with some differences in part orientation. Each step shows photos with the left-hand version on the left and the right on the right.
+Continue here to build a right- or left-hand PiFinder. The build is the same for both versions, with some differences in part orientation. Each step shows photos with the left-hand version on the left and the right-hand version on the right.
 
-Now that the RPI is mounted, secure the mount plate to the bottom plate. The bottom plate can be flipped so the screen faces the right or left side, as the two photos below show.
+Now that the RPI is mounted, secure the Pi Mount to the bottom plate. You can flip the bottom plate so the screen faces the right or the left side, as the two photos below show.
 
 In both cases, the RPI/Screen always faces the same direction as the long, flat side of the bottom piece. The angled cutout is always on the camera side, and the lens faces the angled portion.
 
@@ -605,7 +605,7 @@ First, screw the Pi Mount assembly to the bottom plate. Use two screws from unde
 
 
 
-The back piece is next, but first screw in the four short stand-offs that support the camera module. These can go on either side for left- or right-hand configurations. Check the photos below to match how the back piece fits each configuration and decide which side to put the stand-offs in.
+The back piece is next. First screw in the four short stand-offs that support the camera module. These can go on either side for left- or right-hand configurations. Check the photos below to see how the back piece fits each configuration, then decide which side takes the stand-offs.
 
 .. list-table::
 
@@ -617,7 +617,7 @@ The back piece is next, but first screw in the four short stand-offs that suppor
 
      - .. image:: images/build_guide/right_7.jpeg
 
-The back piece then secures to the assembly with three M2.5 8mm screws. One goes through the back plate into the side-insert in the RPI Mount; there's one of these inserts on either side of the RPI Mount for left/right-hand builds. The other two go through the bottom plate into the side-inserts on the back plate.
+Secure the back piece to the assembly with three M2.5 8mm screws. One goes through the back plate into the side-insert in the Pi Mount. The Pi Mount has one of these inserts on either side, for left- and right-hand builds. The other two go through the bottom plate into the side-inserts on the back plate.
 
 
 .. list-table::
@@ -630,30 +630,29 @@ The back piece then secures to the assembly with three M2.5 8mm screws. One goes
 
      - .. image:: images/build_guide/right_9.jpeg
 
-Now mount the camera module. You'll need the module, camera tray, and 2x 12mm M2.5 screws.
+Now mount the camera module. You need the module, the camera tray, and 2x 12mm M2.5 screws.
 
 .. note::
    The images here show an older back piece and camera tray. New kits have a back piece
    with two holes which match the camera holder. In this simpler arrangement the camera
-   tray is not directly secured to the back piece, but rather has two holes through it.
-   The camera holder is secured with longer screws through the tray into the two holes
-   in the back piece
+   tray has two holes through it and does not screw directly to the back piece.
+   Longer screws pass through the tray and into the two holes in the back piece to hold
+   the camera holder.
 
-Start by connecting the cable to the new camera module.
+Connect the cable to the new camera module first.
 
 .. include:: includes/camera_cable_connect.rst
 
 .. note::
-   The remainder of the build guide is yet to be updated with new photos
-   including the v2.5 camera. The build proceeds just the same and we
-   will be updating the photos soon.
+   The photos in the rest of this guide do not yet show the v2.5 camera.
+   The build proceeds just the same, and we will update the photos soon.
 
 
-Flip the unit over and connect the RPI end of the camera cable. The photo below shows the proper cable orientation into the connector, with the silver contacts facing the white portion of the connector.
+Flip the PiFinder over and connect the RPI end of the camera cable. The photo below shows the proper cable orientation into the connector, with the silver contacts facing the white portion of the connector.
 
 .. image:: images/build_guide/assembly_insert_cable.jpeg
 
-For the left-hand version you'll need a twist in the cable before it enters the connector on the RPI. Be gentle, and you'll be able to adjust it as you put on the UI Module later.
+The left-hand version needs a twist in the cable before it enters the connector on the RPI. Work gently. You can adjust the twist when you fit the UI Hat later.
 
 .. list-table::
 
@@ -662,11 +661,11 @@ For the left-hand version you'll need a twist in the cable before it enters the 
      - .. image:: images/build_guide/right_14.jpeg
 
 .. note::
-   The remainder of the build is almost the same for left- or right-hand units. The photos below are a mix of left and
-   right handed builds, but where there are important differences, you'll see both indicated for clarity.
+   The rest of the build is almost the same for left- and right-hand builds. The photos below mix left and
+   right handed builds. Where the difference is important, both appear for clarity.
 
 
-Next, connect the UI Board and affix the shroud. Lay out the board as it will be connected and slide the antenna into the holder on the Pi Mount piece. The ceramic top with the silver dimple needs to face upwards. Consult the photos below.
+Next, connect the UI Hat and fit the shroud. Lay the board out as it connects and slide the antenna into the holder on the Pi Mount piece. The ceramic top with the silver dimple needs to face upwards. See the photos below.
 
 .. image:: images/build_guide/right_16.jpeg
 
@@ -675,10 +674,10 @@ Next, connect the UI Board and affix the shroud. Lay out the board as it will be
 .. image:: images/build_guide/right_18.jpeg
 
 .. note::
-   The images above have the GPS cable loose and not routed properly. Please use the
-   routing shown in the :ref:`GPS<build_guide:gps>` section
+   The images above show the GPS cable loose and routed incorrectly. Use the
+   routing shown in the :ref:`GPS <build_guide:gps>` section.
 
-Now carefully plug the UI Module into the Raspberry Pi. Make sure both rows of pins are aligned and take your time to manage the camera and GPS cables. The photos below show the left and right configurations for the cable routing.
+Now plug the UI Hat carefully into the Raspberry Pi. Make sure both rows of pins line up, and take your time with the camera and GPS cables. The photos below show the cable routing for the left and right configurations.
 
 .. list-table::
 
@@ -687,17 +686,17 @@ Now carefully plug the UI Module into the Raspberry Pi. Make sure both rows of p
      - .. image:: images/build_guide/right_20.jpeg
 
 
-The screw holes on the UI Board should line up with three of the four stand-offs. The fourth provides support but isn't used to secure the outer case. Collect the Shroud, Bezel, and cover plate along with three of the 12mm screws for the next steps.
+The screw holes on the UI Hat should line up with three of the four stand-offs. The fourth provides support but does not secure the outer case. Collect the Shroud, the Bezel, and the cover plate, along with three of the 12mm screws, for the next steps.
 
 .. image:: images/build_guide/common_5.jpeg
    :target: images/build_guide/common_5.jpeg
 
 
-The shroud has three optional openings: one for the PiSugar power switch on top, one for the USB ports, and one for the SD Card on the side for easier access. Remove these with a little force or a sharp knife. If you're using a PiSugar battery, you'll definitely need to remove that tab. See the photo below:
+The shroud has three optional openings: one on top for the PiSugar power switch, one for the USB ports, and one on the side for easier access to the SD card. Remove these with a little force or a sharp knife. If you use a PiSugar battery, you must remove the power switch tab. See the photo below:
 
 .. image:: images/build_guide/common_6.jpeg
 
-Slide the shroud over the unit, then stack the bezel and the front PCB plate on top and secure them all with the three screws.
+Slide the shroud over the PiFinder, then stack the bezel and the front PCB plate on top. Secure them all with the three screws.
 
 .. image:: images/build_guide/common_7.jpeg
 
@@ -707,7 +706,7 @@ Slide the shroud over the unit, then stack the bezel and the front PCB plate on 
 
 .. image:: images/build_guide/common_10.jpeg
 
-That's looking great. Now you just need a way to mount it to the scope. The top portion of the adjustable dovetail screws directly to the bottom of the PiFinder, then the bottom portion secures to the top. The orientation of the top part matters so the dovetail adjusts the proper way. See the left/right-hand photos below:
+That's looking great. The PiFinder now needs a way to mount to the telescope. The top portion of the adjustable dovetail screws directly to the bottom of the PiFinder. The bottom portion then secures to the top. The orientation of the top part matters, so that the dovetail adjusts the proper way. See the left- and right-hand photos below:
 
 
 .. image:: images/build_guide/right_21.jpeg
@@ -715,7 +714,7 @@ That's looking great. Now you just need a way to mount it to the scope. The top 
 .. image:: images/build_guide/right_22.jpeg
 
 
-The final dovetail assembly is tricky to photograph on the PiFinder, so check these photos below and secure the bottom dovetail portion to the top:
+The final dovetail assembly is tricky to photograph on the PiFinder. Follow the photos below and secure the bottom dovetail portion to the top:
 
 .. image:: images/build_guide/dovetail_1.jpeg
 
@@ -729,7 +728,7 @@ The final dovetail assembly is tricky to photograph on the PiFinder, so check th
 
 That's it! You now have a fully assembled PiFinder.
 
-Continue to the :doc:`software setup<software>` if you haven't already prepared an SD card.
+If you haven't already prepared an SD card, continue to the :doc:`software setup <software>`.
 
 
 .. image:: images/build_guide/common_11.jpeg
@@ -739,7 +738,7 @@ Continue to the :doc:`software setup<software>` if you haven't already prepared 
 Flat Assembly
 ----------------
 
-This section covers a Flat build. This configuration is great for refractors, SCTs, and other rear-focuser scopes, as the screen is 'flat' when mounted and the camera faces forward:
+This section covers a Flat build. This configuration is great for refractors, SCTs, and other rear-focuser telescopes. The screen sits 'flat' when mounted and the camera faces forward:
 
 
 .. image:: ../../images/flat_mount.png
@@ -747,7 +746,7 @@ This section covers a Flat build. This configuration is great for refractors, SC
    :alt: Flat example
 
 
-If you haven't already followed the :ref:`general assembly guide<build_guide:assembly>` through to the point pictured below, do so and then return here.
+Follow the :ref:`general assembly guide <build_guide:assembly>` through to the point pictured below, then return here.
 
 
 .. image:: ../../images/build_guide/v1.6/build_guide_11.jpeg
@@ -755,9 +754,9 @@ If you haven't already followed the :ref:`general assembly guide<build_guide:ass
    :alt: Pi Module Assembled
 
 
-If you routed the cable as above, pull the camera cable out to remove it from the RPI assembly, as the routing differs for a flat build.
+If you routed the cable as above, pull the camera cable out of the RPI assembly. The routing differs for a flat build.
 
-Collect the flat adapter and dovetail. The dovetail secures to the underside of the flat adapter via screws through the adapter, and the RPI mount assembly slots into the flat adapter and is secured via screws into the edge inserts. See the photos below for details.
+Collect the flat adapter and the dovetail. The dovetail secures to the underside of the flat adapter with screws through the adapter. The Pi Mount assembly slots into the flat adapter, and screws into the edge inserts hold it there. See the photos below for details.
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_01.jpeg
    :target: ../../images/build_guide/v1.6/flat/flat_build_guide_01.jpeg
@@ -784,7 +783,7 @@ Collect the flat adapter and dovetail. The dovetail secures to the underside of 
    :alt: Assembly Steps
 
 
-Note the one additional screw on the other side, visible in the next photo. Once the RPI Mount is secured to the flat adapter, connect the camera cable to the RPi and the camera as shown below.
+Note the one additional screw on the other side, visible in the next photo. Once the Pi Mount is secure in the flat adapter, connect the camera cable to the RPi and to the camera as shown below.
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_06.jpeg
@@ -792,7 +791,7 @@ Note the one additional screw on the other side, visible in the next photo. Once
    :alt: Assembly Steps
 
 
-Turn the PiFinder around and screw in the three thumbscrews as shown. Check for excess plastic in the threads; if you hit resistance, try screwing them from the other side first to clear any obstruction. Screw them most of the way in, but leave some room for adjustment.
+Turn the PiFinder around and screw in the three thumbscrews as shown. Check the threads for excess plastic. If you hit resistance, try screwing them in from the other side first to clear any obstruction. Screw them most of the way in, but leave some room for adjustment.
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_07.jpeg
@@ -800,7 +799,7 @@ Turn the PiFinder around and screw in the three thumbscrews as shown. Check for 
    :alt: Assembly Steps
 
 
-Next, position the camera module and use the longer M2.5 screw to secure it. Insert the screw through the center hole in the flat adapter back and thread it into the center hole in the camera cell. It should screw in 3-4mm and pull the camera cell against the ends of the three thumbscrews. If it's not secure, extend the thumbscrews until it's supported. No need to tighten anything too much here; you'll adjust again to align the PiFinder with your telescope's optical axis.
+Next, position the camera module and secure it with the longer M2.5 screw. Insert the screw through the center hole in the back of the flat adapter and thread it into the center hole in the camera cell. It should screw in 3-4mm and pull the camera cell against the ends of the three thumbscrews. If the cell isn't secure, extend the thumbscrews until they support it. No need to tighten anything too much here. You adjust it again later to align the PiFinder with the optical axis of your telescope.
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_09.jpeg
@@ -808,7 +807,7 @@ Next, position the camera module and use the longer M2.5 screw to secure it. Ins
    :alt: Assembly Steps
 
 
-Gently plug in the UI Module, tucking the cable underneath it. Take your time and make sure the camera cable isn't pinched between the stand-offs and the UI Module.
+Gently plug in the UI Hat and tuck the cable underneath it. Take your time and make sure the camera cable isn't pinched between the stand-offs and the UI Hat.
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_10.jpeg
@@ -826,9 +825,12 @@ Gently plug in the UI Module, tucking the cable underneath it. Take your time an
    :alt: Assembly Steps
 
 
-Once the UI Module is plugged in all the way and the cable is tidy, gather the remaining parts to wrap up the build. The shroud slips over the UI Module first, then the bezel slots on top, and finally the top PCB. Use three of the long screws to secure everything together, per the photos below.
+Once the UI Hat is plugged in all the way and the cable is tidy, gather the remaining parts to finish the build. The shroud slips over the UI Hat first, then the bezel slots on top, and finally the top PCB. Secure everything together with three of the long screws, as shown in the photos below.
 
-NOTE: If you haven't already flashed and inserted the SD card into the Raspberry Pi, now's a good time, as it's harder to reach after the shroud is installed. Also check that the PiSugar power switch access is cut and punched out of the shroud if you're using a PiSugar.
+.. note::
+   If you haven't already flashed the SD card and inserted it into the Raspberry Pi, do it
+   now. The card is harder to reach once the shroud is installed. If you use a PiSugar,
+   also check that you have cut and punched the power switch opening out of the shroud.
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_13.jpeg
@@ -857,7 +859,7 @@ NOTE: If you haven't already flashed and inserted the SD card into the Raspberry
    :alt: Assembly Steps
 
 
-The only thing left is to affix the camera lens. Unscrew the cap from the camera module, but leave the knurled adapter in place, as it's required to get the focus distance correct. Remove the cap from the silver end of the lens and gently screw them together.
+One task remains: fit the camera lens. Unscrew the cap from the camera module, but leave the knurled adapter in place. The adapter sets the correct focus distance. Remove the cap from the silver end of the lens and gently screw the two together.
 
 
 .. image:: ../../images/build_guide/v1.6/flat/flat_build_guide_19.jpeg
@@ -865,4 +867,4 @@ The only thing left is to affix the camera lens. Unscrew the cap from the camera
    :alt: Assembly Steps
 
 
-Congratulations, you have a PiFinder! See the :doc:`Software Setup<software>` guide for next steps.
+Congratulations, you have a PiFinder! See the :doc:`Software Setup <software>` guide for next steps.

--- a/docs/source/build_guide.rst
+++ b/docs/source/build_guide.rst
@@ -498,7 +498,7 @@ Orient the battery pack so the connector sits in the notch, as shown below.
    :target: _images/common_1b.jpeg
 
 
-Snip the zip ties off, then move on.
+Snip off the loose ends of the zip ties, then move on.
 
 
 .. image:: images/build_guide/common_1c.jpeg

--- a/docs/source/build_guide.rst
+++ b/docs/source/build_guide.rst
@@ -401,11 +401,11 @@ You need the following for a Rigel Quikfinder adapter:
      - Notes
    * - 1
      - PiToQuikfinder v2 - Part 1.stl
-     - `git repo quikfinder <https://github.com/brickbots/PiFinder/tree/release/case/adapter/quikfinder>`_
+     - `git repo quikfinder <https://github.com/brickbots/PiFinder/tree/release/case/adapters/quikfinder>`_
      - You need both this and the next item
    * - 1
      - PiToQuikfinder v2 - Part 2.stl
-     - `git repo quikfinder <https://github.com/brickbots/PiFinder/tree/release/case/adapter/quikfinder>`_
+     - `git repo quikfinder <https://github.com/brickbots/PiFinder/tree/release/case/adapters/quikfinder>`_
      - You need both this and the previous item
    * - 2
      - heat-set insert M2.5 x 4 mm
@@ -439,7 +439,7 @@ To adjust the orientation of your PiFinder so it stands vertical on your telesco
      - Notes
    * - 1
      - Pi2Q2Dovetail.stl
-     - `git repo quikfinder <https://github.com/brickbots/PiFinder/tree/release/case/adapter/quikfinder>`_
+     - `git repo quikfinder <https://github.com/brickbots/PiFinder/tree/release/case/adapters/quikfinder>`_
      - You need at least this and the next item
    * - 1
      - dovetail_top.stl

--- a/docs/source/build_guide.rst
+++ b/docs/source/build_guide.rst
@@ -387,10 +387,10 @@ If you need more flexibility, a go-pro compatible plate also bolts into the bott
 
 Once all the parts are printed and the inserts are seated, you're ready to :ref:`assemble <build_guide:assembly>`.
 
-Rigel Quickfinder Assembly
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Rigel Quikfinder Assembly
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You need the following for a Rigel Quickfinder adapter:
+You need the following for a Rigel Quikfinder adapter:
 
 .. list-table::
    :header-rows: 1
@@ -400,11 +400,11 @@ You need the following for a Rigel Quickfinder adapter:
      - URL
      - Notes
    * - 1
-     - PiToQuickfinder v2 - Part 1.stl
+     - PiToQuikfinder v2 - Part 1.stl
      - `git repo quikfinder <https://github.com/brickbots/PiFinder/tree/release/case/adapter/quikfinder>`_
      - You need both this and the next item
    * - 1
-     - PiToQuickfinder v2 - Part 2.stl
+     - PiToQuikfinder v2 - Part 2.stl
      - `git repo quikfinder <https://github.com/brickbots/PiFinder/tree/release/case/adapter/quikfinder>`_
      - You need both this and the previous item
    * - 2
@@ -418,7 +418,7 @@ Print "Part 2" to maximize the strength of the "hook". Print it with supports, a
 
 If you print your own parts, add heat-set inserts as pictured below. Space is limited, so fix it to the PiFinder first and then insert the second part. Tighten the screws just a little to hold the second part so it can't fall off.
 
-After you put it on a Rigel Quickfinder base, tighten the screws fully. The double-sided foam adhesive supplied with the Rigel Quikfinder may compress under the weight of the PiFinder, which is about 6 times the weight of a Quikfinder. You may need to fix the base plate to your telescope another way.
+After you put it on a Rigel Quikfinder base, tighten the screws fully. The double-sided foam adhesive supplied with the Rigel Quikfinder may compress under the weight of the PiFinder, which is about 6 times the weight of a Quikfinder. You may need to fix the base plate to your telescope another way.
 
 
 .. image:: images/build_guide/quickfinder_base_1.jpeg


### PR DESCRIPTION
Full simplified technical English pass over `docs/source/build_guide.rst`, using the `docs` skill's seven rules and approved-term table. Part of the manual-wide conversion, one PR per file.

## Measured change

```
  PASS  docs/source/build_guide.rst
     em-dash 0->0 | semicolon 13->0 | banned 52->44 | words 5211->5213 (+0%)
     terms: the display 3->0, the unit 3->0, navigate 2->0
OVERALL: PASS
```

## What the converting agent reported

```
EM_DASHES: 0 -> 0
SEMICOLONS: 13 -> 0  (all were rule-1 clause welds)
TERMS: the big win here is hardware-name unification.
  UI Hat / UI Board / UI Module / "the hat" / "PiFinder hat" / "custom 'Hat'"
    -> UI Hat everywhere (matching the locked heading "PiFinder UI Hat")
  Pi Mount / PiMount / PI Mount / RPI Mount / RPI Holder / "the mount plate"
    -> Pi Mount (matching the locked heading "Pi Mount")
  GPS unit->GPS module; display->the screen; scope->telescope;
  "dobsonians"->"Dobsonians"; unit->the PiFinder or build; keyboard->keypad;
  "inertial motion sensor"->IMU; navigate/go to->scroll/select;
  the glyph paths "Tools > Status" and "Objects > Name Search" replaced with
  prose chains; "power it up"->"turn the PiFinder on"; zip-ties->zip ties
STRUCTURAL: ~40 two-clause sentences split; ~25 procedural sentences reordered
  to lead with the command verb ("Switches go next"->"Fit the switches next").
  Passives made active ("is soldered from the top"->"Solder it from the top").
  Rule 6 noun stacks unpacked ("bottom plate mounting footprint"->"the mounting
  footprint on the bottom plate"). One inline "NOTE:" paragraph converted to a
  real .. note:: admonition.
LEFT_ALONE: every heading, underline and level verified byte-identical; all
  image/:target:/:alt: lines; both .. include:: lines; all tables. The heading
  "Display" kept although the body now says "screen", because headings are
  :ref: targets. First-person author voice in Printing/Inserts ("I use 3
  perimeter layers") and the closing "Congratulations, you have a PiFinder!"
  kept as genuinely delightful moments. No rev4 content or scoping added.
FACT_CONCERNS:
  1. Camera version drift: the Camera Prep lead-in says "The new v3 camera",
     but the page's top note scopes the whole guide to v2.5 hardware and a
     later note says "the v2.5 camera". Same part, two names.
  2. "Rigel Quickfinder" (heading + 2 mentions) vs "Rigel Quikfinder" (2
     mentions). The real product is "Quikfinder"; the heading is locked, so
     both spellings survive.
  3. common_1b.jpeg uses ":target: _images/common_1b.jpeg" while every other
     image targets its source path - looks like a stale build-output path.
  4. "Snip the zip ties off, then move on." follows the step that secures the
     battery WITH zip ties. It most likely means trim the tails, but the verb
     is ambiguous, so it was preserved.
```

## Content changes (added after review)

Four follow-up commits. One of them renames a heading, which this conversion
otherwise never did -- see the note below.

- **The Rigel Quikfinder is spelled correctly.** Rigel's product is the
  *Quikfinder*. The guide used "Quickfinder" in the section heading, its lead-in
  sentence and the base-plate paragraph, while that same paragraph spelled it
  "Quikfinder" twice. The two STL names were wrong as *filenames*, not just as
  prose: the files in `case/adapters/quikfinder/` are
  `PiToQuikfinder v2 - Part 1.stl` and `... Part 2.stl`, so a reader searching
  the repo for the documented name finds nothing. The `quickfinder_base_*.jpeg`
  image paths keep their spelling -- those are real filenames on disk.
- **Three links to the adapter parts were 404s.** All three "git repo
  quikfinder" links pointed at `case/adapter/quikfinder`. That directory has
  never existed; the parts live in `case/adapters/quikfinder` (plural) on both
  `main` and `release`. It is the only broken `case/` link in the manual.
- **The photo caveat names the v3 camera.** Line 512 calls the part "the new v3
  camera"; the note called the same part "the v2.5 camera". The v2.5 build uses
  the v3 camera, as `v25_upgrade.rst` says.
- **"Snip the zip ties off" says which part to snip.** It could mean trim the
  tails or remove the ties. The step above installs those ties to hold the
  battery, so removing them would undo it. Now "Snip off the loose ends of the
  zip ties".

### About the heading rename

`Rigel Quickfinder Assembly` -> `Rigel Quikfinder Assembly`. Checked before
making it: no `:ref:` or `:doc:` in the manual targets
`build_guide:rigel quickfinder assembly` -- not on `main`, and not on any of the
14 `docs-ste` branches. The only occurrence anywhere is the heading definition
itself. A nitpicky Sphinx build of this branch, and a full integration build of
all 14 branches merged together, are both clean.

`verify_ste.py` therefore reports two expected failures for this PR:
`HEADINGS CHANGED` for the rename, and `url LOST` / `url added` for the three
corrected links. Both are deliberate.

- **43 of the 44 click-to-enlarge links were dead.** Every image on this page
  links to itself so a reader can click for a full-size view. Sphinx copies
  image sources into `_images/` and rewrites the `<img src>` to match, but it
  emits a `:target:` value *verbatim* as an href -- so targets written as
  source-tree paths (`images/build_guide/x.jpeg`,
  `../../images/build_guide/x.jpeg`) resolve against the built page and 404.
  Audited the built HTML: **1 of 44 targets resolved before, 44 of 44 after.**
  The one that worked was `:target: _images/common_1b.jpeg`, which the review
  flagged as the odd one out -- it was in fact the only correct one, and every
  other page in the manual already uses that form. Checked for basename
  collisions first, since Sphinx renames on collision and `_images/<basename>`
  would then be wrong; there are none on this page.

## Safety

Every other change in this PR is style only. No numbers, procedures or step order were changed.

Verified mechanically against `origin/main` that every heading (text *and* underline character), every `:ref:`, `:doc:`, image path, substitution, `include::` and external URL is unchanged. Headings matter because `autosectionlabel` turns each one into a cross-reference target that other pages depend on, and a rename would break them silently.

Sphinx builds clean under `-n` (nitpicky).

Any `FACT_CONCERNS` above that are not listed under **Content changes** were deliberately **not** fixed. They are reported for a maintainer decision, since changing them would be a content edit rather than a style one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqTCarGCgTRWBQ1ysG8XFD

