### PR TITLE
docs: finish the scope → telescope normalisation

### DIFF
--- a/docs/source/dev_guide.rst
+++ b/docs/source/dev_guide.rst
@@ -688,7 +688,7 @@ Finally, you can start straight into this mode from the command line — see the
 
 .. note::
 
-  If you are using the demo-mode and move the PiFinder and scope around, you will notice, that the picture alway starts at the same "standard demo picture". And it always switch back to the same picture, once you stopped. Do not expect to move through the sky, like you normally would do and get a solve to the newly reached location. You will always be brought back to the same position in the sky.
+  If you are using the demo-mode and move the PiFinder and telescope around, you will notice, that the picture alway starts at the same "standard demo picture". And it always switch back to the same picture, once you stopped. Do not expect to move through the sky, like you normally would do and get a solve to the newly reached location. You will always be brought back to the same position in the sky.
 
 
 .. image:: images/user_guide/DEMO_MODE_001_docs.png

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,11 +42,11 @@ Features
 --------
 
 * Zero setup: Just turn it on and point it at the sky!  
-* Accurate pointing: Onboard GPS determines location and time while the camera determines where the scope is pointing.  Inertial Measurement Unit tracks scope motion and updates sky position between camera solves
+* Accurate pointing: Onboard GPS determines location and time while the camera determines where the telescope is pointing.  Inertial Measurement Unit tracks telescope motion and updates sky position between camera solves
 * Self-contained:  Includes catalog search/filtering, sky/object charting, push-to guidance and logging all via the screen and keypad on the unit.
 * Dark site friendly:  Red OLED screen and soft backlit keys have wide brightness adjustment, right down to 'off'. No need for bright cell phones or tablets
 * Easy access: Can be mounted by the eyepiece just like a finder.
-* Wifi Access Point / SkySafari Integration:  The PiFinder can act as a WIFI access point to connect your tablet or phone to sync SkySafari or other planetarium software with your scope.
+* Wifi Access Point / SkySafari Integration:  The PiFinder can act as a WIFI access point to connect your tablet or phone to sync SkySafari or other planetarium software with your telescope.
 
 Build Your Own
 --------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,7 +31,7 @@ About
 
 The PiFinder is my attempt to improve my time at my telescope.  I don't get nearly enough of it and I want to enjoy it as much as possible.  So after years of observing with paper charts and, later, a Nexus DSC here is what I felt I was missing:
 
-* **Reliable telescope positioning:**  The Nexus DSC is great, but my scope just isn't built for solid encoder integration.  The slop in the way I have to couple the encoders means poor pointing accuracy.
+* **Reliable telescope positioning:**  The Nexus DSC is great, but my telescope just isn't built for solid encoder integration.  The slop in the way I have to couple the encoders means poor pointing accuracy.
 * **Easy setup:**  The Nexus DSC needs multi-star alignment to understand how the encoders map to the sky.  The process is not terrible, but I'd like to avoid it.
 * **Good push-to functionality**:  This is one place the Nexus DSC shines... if it's well aligned.  The catalog system is okay, and once you select and object the screen is clear and helpful to get the telescope pointed correctly.
 * **Observation logging**:  I like to keep track of what I see each night.  I don't often sketch, just record what I saw when, with what eyepiece and some basic info about the experience.  If I could do this right at the eyepiece, that'd save time.


### PR DESCRIPTION
Finishes applying the approved term **telescope** across the manual, per the maintainer's decision.

The 13 conversion PRs (#586–#598) already normalised every page they touched. Two files sat outside that pass and still said "scope":

- **`index.rst`** (4) — the landing page. `where the telescope is pointing`, `tracks telescope motion`, `sync … with your telescope`, and `my telescope just isn't built for solid encoder integration`. That last one sat in a paragraph whose neighbouring sentences already said "my telescope" and "the telescope".
- **`dev_guide.rst`** (1) — one word in the demo-mode note. This is *not* a style pass over the contributor docs, just the single term.

## Deliberately not changed

These name different equipment, not the reader's telescope. Renaming them would introduce factual errors:

| Kept | Where | Why |
|---|---|---|
| `polar scope` ×4 | `user_guide.rst` | The sighting device inside an equatorial mount. "Polar telescope" is not a term anyone uses, and the surrounding text is about aligning *without* one. |
| `finder scope` | `troubleshooting.rst` | A separate optical finder. The sentence exists to contrast it with the PiFinder. |
| `scope type` | `skysafari.rst` | SkySafari's own field label, confirmed against `images/SkySafari/IMG_4796.jpeg`. Excluded by the maintainer explicitly. |

## Verification

With this branch and all 13 conversion PRs merged together, the only standalone occurrences of "scope" left in `docs/source/*.rst` are exactly those six. Combined build is clean under `-n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqTCarGCgTRWBQ1ysG8XFD
