### PR TITLE
docs: call the ring menu "Quick Menu" in polar alignment

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -1137,10 +1137,10 @@ The top line summarises the measurement: the number of points used, the total sw
 for a three-point solve, a fit rating of ``ok``, ``mid``, or ``bad``.  A poor fit usually
 means something moved between captures that shouldn't have, so it's worth redoing.
 
-Press and hold **SQUARE** for the marking menu, which gathers the advanced actions.
-**STATS** opens a read-only detail view.  **REDO PT** drops just the last point so you can
-recapture it.  **Roll On/Off** switches between a full three-axis fit and an RA/Dec-only fit
-that ignores camera roll, which is useful after a camera flop.
+Press and hold **SQUARE** to open the :ref:`user_guide:quick menu`, which gathers the
+advanced actions.  **STATS** opens a read-only detail view.  **REDO PT** drops just the
+last point so you can recapture it.  **Roll On/Off** switches between a full three-axis
+fit and an RA/Dec-only fit that ignores camera roll, which is useful after a camera flop.
 :ref:`user_guide:getting a good measurement` covers which fit suits each mount.
 
 .. image:: images/user_guide/polar_align_marking_menu_docs.png
@@ -1169,7 +1169,7 @@ On an equatorial mount:
   Measure from wherever that axis points now, not from where the true pole is.
 - Sweep roughly 30–45° in right ascension: take the middle capture with the PiFinder's
   screen roughly vertical, and the first and last captures 15–22° either side of it.
-- Set Roll Off in the marking menu.  Flexure shows up most strongly in roll, so the fit is
+- Set Roll Off in the Quick Menu.  Flexure shows up most strongly in roll, so the fit is
   better without it.
 
 On an equatorial platform:


### PR DESCRIPTION
The polar alignment section of the user guide was the only place in the manual that called the ring-shaped shortcut menu the **marking menu**. That is the internal code term — the Python class is `MarkingMenu`. Everywhere else the manual and the UI itself call it the **Quick Menu**, which has its own dedicated section in `user_guide.rst` and 14 other mentions across the user guide, quick start and menu map.

House style rule 7 is *use one word per concept*. A reader who meets both names reasonably wonders whether they are two different things, which is exactly the kind of friction the manual can least afford at 2am in the dark.

## Changes

Two prose occurrences in `docs/source/user_guide.rst`:

- **~line 1140** — "Press and hold **SQUARE** for the marking menu" becomes "Press and hold **SQUARE** to open the Quick Menu". This now matches the phrasing used at the three other "press and hold SQUARE" sites in the guide. It also gains a cross-reference to the Quick Menu section, since a reader who lands directly in polar alignment is a long way from the section that explains what the Quick Menu is. The paragraph is rewrapped to keep the line width consistent, which is why the diff shows four lines rather than one.
- **~line 1172** — "Set Roll Off in the marking menu" becomes "Set Roll Off in the Quick Menu". Second mention within the same section, so it is plain text rather than a second link.

One link, not three: the first mention in the section is linked and the rest read as plain prose.

## Deliberate non-change

The screenshot `docs/source/images/user_guide/polar_align_marking_menu_docs.png` **keeps its filename**, and the `.. image::` directive that points at it is untouched. Filenames are not user-visible, and renaming a binary would add pointless churn to the diff for no reader benefit.

Also out of scope and intentionally untouched: `docs/ax/**` and `docs/adr/**`, where "marking menu" is the correct internal domain term, and all Python source, where `MarkingMenu` / `marking_menu` are correct identifiers.

## Verification

- `python -m sphinx -b html -n -q source /tmp/pifinder_mm_build` — clean build, **zero warnings**, exit 0. `-n` confirms the new `:ref:` target resolves.
- `grep -rn -i "marking menu" docs/source/` — no matches remain.

## Note on overlap

This branch is based on current `origin/main` and touches `user_guide.rst` only around lines 1137–1172. #606 also edits `user_guide.rst` but around line 350, so the two should not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)