### PR TITLE
PR #609 follow-ups: sweep lens, unknown-sensor fallback, explicit frustum

### DIFF
--- a/docs/ax/camera/CONTEXT.md
+++ b/docs/ax/camera/CONTEXT.md
@@ -148,6 +148,20 @@ downscale factor and confusing them silently rescales any angle computed
 from it.
 _Avoid_: arcsec per pixel (unqualified — say which grid), resolution.
 
+**Frustum**:
+The box drawn on a chart marking the part of it the camera images — the
+**field of view** of the current optical train, inside the chart's own zoom
+level. It does two jobs at once: the chart outside it can be dimmed, and it
+selects the stars the chart reports back, which is why the align screen only
+offers alignment stars the camera can actually see. A chart is rendered with
+a frustum only when the caller states a camera field of view; **no frustum**
+is a real state (`plot.frustum_box` returns None), not a default box, because
+there is no stand-in for a number that is a property of the hardware fitted
+to that particular device.
+_Avoid_: camera box, FOV box, "the frustrum" in prose (the misspelling
+survives only in the `shade_frustrum` argument name); "visible stars" meaning
+*stars on the chart* — with a frustum they are the stars inside it.
+
 ### Cross-context terms
 
 - **`Matches`** — defined in [Positioning](../positioning/CONTEXT.md): count of stars tetra3 matched in the most recent solve attempt, published on every attempt (success or failure) because auto-exposure depends on it. The feedback signal for solver-driven auto-exposure.

--- a/python/PiFinder/api_extensions.py
+++ b/python/PiFinder/api_extensions.py
@@ -463,14 +463,14 @@ def register_api_routes(app, server_instance, require_auth=False):
             )
 
             # The frustum marks what the camera images, so it follows the
-            # fitted optical train. Set per request rather than baked into the
-            # cache key: the Starfield is expensive to build and is reused
-            # across requests, while the lens can change under it.
-            starfield.set_camera_fov(
-                _API_OPTICAL_TRAIN.resolve(
-                    ss.camera_type(), ss.camera_lens()
-                ).fov_degrees
-            )
+            # fitted optical train. Passed per render rather than held on the
+            # Starfield: that object is cached and shared across requests, and
+            # waitress serves them on several threads, so anything set on it
+            # between one request's resolve and its render belongs to whoever
+            # got there last.
+            camera_fov = _API_OPTICAL_TRAIN.resolve(
+                ss.camera_type(), ss.camera_lens()
+            ).fov_degrees
 
             # --------------------------------------------------
             # 5. Call PiFinder's native star chart rendering logic
@@ -481,6 +481,7 @@ def register_api_routes(app, server_instance, require_auth=False):
                 roll,
                 constellation_brightness,
                 shade_frustrum=shade_frustrum,
+                camera_fov=camera_fov,
             )
 
             # --------------------------------------------------

--- a/python/PiFinder/camera_interface.py
+++ b/python/PiFinder/camera_interface.py
@@ -940,6 +940,7 @@ class CameraInterface:
                                     altitude_deg=altitude_deg,
                                     azimuth_deg=azimuth_deg,
                                     camera_type=shared_state.camera_type(),
+                                    lens_key=shared_state.camera_lens(),
                                     notes=f"Exposure sweep: {num_images} images, {min_exp / 1000:.1f}-{max_exp / 1000:.1f}ms",
                                 )
                                 logger.info(

--- a/python/PiFinder/optics.py
+++ b/python/PiFinder/optics.py
@@ -20,11 +20,14 @@ is what the lens behaves as; only the second is correct to compute with.
 
 from __future__ import annotations
 
+import logging
 import math
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
 from PiFinder.camera_profiles import CameraProfile, get_camera_profile
+
+logger = logging.getLogger("Optics")
 
 # Half-width of the solver's FOV gate, as a fraction of the derived field of
 # view. Proportional rather than absolute: a fixed number of degrees is four
@@ -38,6 +41,13 @@ FOV_GATE_MARGIN = 0.15
 # Pixels per side of the image handed to tetra3. Centroids are reported in
 # this grid, so it is the grid the solver's plate scale is stated against.
 SOLVER_IMAGE_PIXELS = 512
+
+# Sensor to derive angles from when the camera type is one we have no profile
+# for. It matches SharedStateObj's pre-camera default, so an unrecognised
+# sensor behaves exactly like the window before the camera process reports in
+# -- which every consumer here already survives, because it happens on every
+# boot.
+FALLBACK_CAMERA_TYPE = "imx296"
 
 
 @dataclass(frozen=True)
@@ -128,6 +138,33 @@ def get_lens(lens_key: str) -> Lens:
     if lens_key not in LENSES:
         raise ValueError(f"Unknown lens: {lens_key}. Available: {list(LENSES.keys())}")
     return LENSES[lens_key]
+
+
+def resolve_camera_profile(camera_type: str) -> CameraProfile:
+    """The profile to derive angles from, tolerating an unrecognised sensor.
+
+    The sensor half of the train has the same problem the lens half has: the
+    live consumers read it from state that a wrong value can reach --
+    ``camera_type`` is whatever the camera process published, and it is a
+    plain string. Raising there is worse than being approximately right: the
+    solver resolves per frame inside a loop whose outer handler restarts the
+    whole solver, tetra3 database load included, and the lens menu resolves
+    while it is being built. An unknown sensor would be a crash-reload loop
+    and an unopenable menu rather than a diagnosis.
+
+    So this is the one place the fallback policy lives -- the counterpart of
+    ``resolve_lens`` for the other half. ``get_camera_profile`` stays strict:
+    offline scripts and tests naming a sensor should still hear about a typo.
+    """
+    try:
+        return get_camera_profile(camera_type)
+    except ValueError:
+        logger.warning(
+            "Unknown camera type %r; deriving optics from %s instead",
+            camera_type,
+            FALLBACK_CAMERA_TYPE,
+        )
+        return get_camera_profile(FALLBACK_CAMERA_TYPE)
 
 
 def resolve_lens(profile: CameraProfile, lens_key: Optional[str] = None) -> Lens:
@@ -232,6 +269,12 @@ class OpticalTrainResolver:
     rebuilding a train per frame would re-copy a profile for no reason. Keyed
     on both halves because the camera type is also not final at startup: it
     still holds the pre-camera default until the camera process reports.
+
+    Neither half raises on an unrecognised value: both resolve through the
+    fallbacks above. Caching under the *stated* key rather than the resolved
+    one is what keeps an unknown sensor from logging once per frame, and it
+    keeps the identity of the returned train stable so callers can compare
+    trains with ``is`` to detect a real change.
     """
 
     def __init__(self) -> None:
@@ -241,6 +284,8 @@ class OpticalTrainResolver:
     def resolve(self, camera_type: str, lens_key: Optional[str] = None) -> OpticalTrain:
         key = (camera_type, lens_key)
         if key != self._key or self._train is None:
-            self._train = build_optical_train(camera_type, lens_key)
+            self._train = optical_train_for_profile(
+                resolve_camera_profile(camera_type), lens_key
+            )
             self._key = key
         return self._train

--- a/python/PiFinder/plot.py
+++ b/python/PiFinder/plot.py
@@ -10,6 +10,7 @@ import os
 import numpy as np
 import pandas
 from pathlib import Path
+from typing import Optional, Tuple
 from PiFinder import utils
 from PiFinder import timez
 from PIL import Image, ImageDraw, ImageChops
@@ -18,17 +19,45 @@ from skyfield.api import Star, load, Angle
 from skyfield.data import hipparcos, stellarium
 from skyfield.projections import build_stereographic_projection
 from PiFinder.calc_utils import sf_utils
-from PiFinder.optics import build_optical_train
 
 
 logger = logging.getLogger("Plot")
 
-# Frustum shading needs a camera field of view before anyone has told it which
-# optical train is fitted. Derive the stand-in rather than writing a number
-# down, so it stays consistent with the trains callers will actually pass.
-DEFAULT_CAMERA_FOV_DEGREES = build_optical_train("imx296").fov_degrees
+# Below this ratio of camera field to chart field there is no frustum worth
+# drawing: the box would be within a pixel or two of the chart edge, so it
+# would shade nothing and exclude nothing.
+_FRUSTUM_MIN_RATIO = 0.99
 
 _RAW_STARS_DF = None
+
+
+def frustum_box(
+    render_size: Tuple[int, int], fov: float, camera_fov: Optional[float]
+) -> Optional[Tuple[float, float, float, float]]:
+    """Screen-space box the camera images, or None when there is no frustum.
+
+    Two different angles meet here and they are easy to confuse: ``fov`` is
+    the chart's zoom level, which the user changes, and ``camera_fov`` is the
+    angular width the camera images, which follows the fitted optical train.
+    The frustum is the second drawn inside the first.
+
+    ``camera_fov`` is None when the caller has not said what the camera
+    images. That is *no frustum*, not a default one -- there is no honest
+    stand-in, because the answer is a property of the hardware in front of
+    this particular device (an imx296 on the shipped lens images 13.71
+    degrees, an imx462 10.40, an HQ 10.33). A caller that wants a frustum
+    states one; a caller that does not gets the whole chart.
+    """
+    if camera_fov is None:
+        return None
+
+    ratio = camera_fov / fov
+    if ratio >= _FRUSTUM_MIN_RATIO:
+        return None
+
+    width, height = render_size
+    offset = (width - ratio * width) / 2
+    return (offset, offset, width - offset, height - offset)
 
 
 def _load_raw_stars():
@@ -75,17 +104,9 @@ class Starfield:
     specified RA/DEC + roll
     """
 
-    def __init__(self, colors, resolution, mag_limit=7, fov=10.2, camera_fov=None):
+    def __init__(self, colors, resolution, mag_limit=7, fov=10.2):
         self.colors = colors
         self.resolution = resolution
-        # Angular width the camera actually images, used to shade the part of
-        # the chart the camera cannot see. Distinct from self.fov, which is
-        # the chart's own zoom level. Every caller that shades a frustum
-        # resolves the live optical train and calls set_camera_fov(); this
-        # default only covers a caller that has not.
-        self.camera_fov = (
-            camera_fov if camera_fov is not None else DEFAULT_CAMERA_FOV_DEGREES
-        )
         utctime = timez.utc(2023, 1, 1, 2, 0, 0)
         ts = sf_utils.ts
         self.t = ts.from_datetime(utctime)
@@ -173,10 +194,6 @@ class Starfield:
 
     def set_mag_limit(self, mag_limit):
         self.mag_limit = mag_limit
-
-    def set_camera_fov(self, camera_fov: float):
-        """Set the angular width the camera images, for frustum shading."""
-        self.camera_fov = camera_fov
 
     def set_fov(self, fov):
         self.fov = fov
@@ -363,12 +380,26 @@ class Starfield:
         self.projection = build_stereographic_projection(center)
 
     def plot_starfield(
-        self, ra, dec, roll, constellation_brightness=32, shade_frustrum: bool = False
+        self,
+        ra,
+        dec,
+        roll,
+        constellation_brightness=32,
+        shade_frustrum: bool = False,
+        camera_fov: Optional[float] = None,
     ):
         """
         Returns an image of the starfield at the
         provided RA/DEC/ROLL with or without
         constellation lines
+
+        camera_fov: angular width the camera images, from the live optical
+            train. Omit it for a chart with no frustum: the returned stars are
+            then everything on the chart, not everything the camera can see.
+            Passed per call rather than held on the object -- a Starfield is
+            expensive enough to be cached and shared (the API caches one
+            across concurrent requests), and per-render state on a shared
+            object is one request's value away from being another's.
         """
         self.update_projection(ra, dec)
         self.roll = roll
@@ -383,16 +414,24 @@ class Starfield:
         self._const_ex, self._const_ey = self.projection(self.const_end_star_positions)
 
         pil_image, visible_stars = self.render_starfield_pil(
-            constellation_brightness, shade_frustrum
+            constellation_brightness, shade_frustrum, camera_fov
         )
         return pil_image, visible_stars
 
     def render_starfield_pil(
-        self, constellation_brightness: int, shade_frustrum: bool = False
+        self,
+        constellation_brightness: int,
+        shade_frustrum: bool = False,
+        camera_fov: Optional[float] = None,
     ):
         """
         constellation_brightness: intensity of constellation lines
-        shade_frustrum: Shade areas of the chart that are outside of the actual camera FOV
+        shade_frustrum: Dim the part of the chart the camera cannot see.
+            Needs a camera_fov; without one there is nothing to shade.
+        camera_fov: angular width the camera images. When given, the returned
+            visible_stars are restricted to that box -- they are the stars the
+            camera can see, which is what an alignment star has to be. When
+            omitted they are every star on the chart.
 
         returns (image, visible_stars)
         """
@@ -402,21 +441,10 @@ class Starfield:
         W, H = self.render_size
         cx, cy = self.render_center
 
-        frustrum_perc = self.camera_fov / self.fov
-        if shade_frustrum and frustrum_perc < 0.99:
+        frustum = frustum_box(self.render_size, self.fov, camera_fov)
+        if shade_frustrum and frustum is not None:
             idraw.rectangle([0, 0, W, H], fill=32)
-
-            # Calc square for in-frustrum
-            frustrum_offset = (W - frustrum_perc * W) / 2
-            idraw.rectangle(
-                [
-                    frustrum_offset,
-                    frustrum_offset,
-                    W - frustrum_offset,
-                    H - frustrum_offset,
-                ],
-                fill=0,
-            )
+            idraw.rectangle(list(frustum), fill=0)
 
         # prep rotate by roll....
         roll_rad = self.roll * (np.pi / 180.0)
@@ -493,18 +521,18 @@ class Starfield:
                     width=0,
                 )
 
-        # Frustrum filter for the returned visible_stars set.
-        if frustrum_perc < 0.99:
-            frustrum_offset = (W - frustrum_perc * W) / 2
-            in_frustrum = (
-                (x_pos > frustrum_offset)
-                & (x_pos < W - frustrum_offset)
-                & (y_pos > frustrum_offset)
-                & (y_pos < H - frustrum_offset)
+        # Frustum filter for the returned visible_stars set. Gated on the
+        # frustum existing, not on the shading: a caller can want the box
+        # marked or not, but if it stated a camera field of view it means the
+        # stars the camera can see. State no camera and this does not run.
+        if frustum is not None:
+            left, top, right, bottom = frustum
+            in_frustum = (
+                (x_pos > left) & (x_pos < right) & (y_pos > top) & (y_pos < bottom)
             )
-            visible_idx = visible_idx[in_frustrum]
-            x_pos = x_pos[in_frustrum]
-            y_pos = y_pos[in_frustrum]
+            visible_idx = visible_idx[in_frustum]
+            x_pos = x_pos[in_frustum]
+            y_pos = y_pos[in_frustum]
 
         # Rebuild visible_stars as a DataFrame for align.py compatibility:
         # it expects pandas semantics (.iloc, .sort_values, .assign) and

--- a/python/PiFinder/sqm/save_sweep_metadata.py
+++ b/python/PiFinder/sqm/save_sweep_metadata.py
@@ -53,8 +53,14 @@ def save_sweep_metadata(
             Contains: noise_floor_adu, dark_pixel_raw, dark_pixel_smoothed, theoretical_floor,
             temporal_noise, read_noise, dark_current_contribution, bias_offset, etc.
         camera_type: Camera type string (optional)
-        lens_key: Configured lens (optional). Omitted means the sensor's
-            shipped lens, which is what the device itself assumes.
+        lens_key: The lens the device is configured for. Pass what
+            ``shared_state.camera_lens()`` holds, even when that is None.
+            Omitting it falls back to the sensor's shipped lens, which is a
+            *different* field width from the one the sweep was taken through
+            unless the two happen to agree -- so an omission from a caller
+            that has the config in hand is a bug, not a default. The archive
+            is what the SQM constants are re-derived from, so a mislabelled
+            lens silently poisons the next calibration.
         notes: Any additional notes
     """
     metadata: Dict[str, Any] = {

--- a/python/PiFinder/ui/align.py
+++ b/python/PiFinder/ui/align.py
@@ -229,12 +229,14 @@ class UIAlign(UIModule):
                     dt=self.shared_state.datetime(),
                 )
                 chart_rot_angle = orientation.rot_deg if orientation else None
-                self.starfield.set_camera_fov(
-                    self._optical_train.resolve(
-                        self.shared_state.camera_type(),
-                        self.shared_state.camera_lens(),
-                    ).fov_degrees
-                )
+                # The frustum marks what the camera images, so it follows the
+                # fitted optical train. It also decides which stars come back
+                # as visible_stars, and an alignment star the camera cannot
+                # see is no use.
+                camera_fov = self._optical_train.resolve(
+                    self.shared_state.camera_type(),
+                    self.shared_state.camera_lens(),
+                ).fov_degrees
                 # This needs to be called first to set RA/DEC/chart_rot_angle
                 image_obj, self.visible_stars = self.starfield.plot_starfield(
                     chart_center.RA,
@@ -242,6 +244,7 @@ class UIAlign(UIModule):
                     chart_rot_angle,
                     constellation_brightness,
                     shade_frustrum=True,
+                    camera_fov=camera_fov,
                 )
 
                 image_obj = ImageChops.multiply(

--- a/python/PiFinder/ui/callbacks.py
+++ b/python/PiFinder/ui/callbacks.py
@@ -18,9 +18,8 @@ import pytz
 from typing import Any, TYPE_CHECKING
 from PiFinder import utils, calc_utils
 from PiFinder import timez
-from PiFinder.camera_profiles import get_camera_profile
 from PiFinder.locations import Location as SavedLocation
-from PiFinder.optics import resolve_lens
+from PiFinder.optics import resolve_camera_profile, resolve_lens
 from PiFinder.state import Location
 from PiFinder.ui.base import UIModule
 from PiFinder.ui.textentry import UITextEntry
@@ -217,10 +216,12 @@ def get_camera_lens(ui_module: UIModule) -> list[str]:
 
     Not simply the config value: an install that predates the setting has none
     stored, and which lens that means depends on the detected sensor. Resolve
-    it the same way the solver does so the menu shows what is actually in
-    force rather than an arbitrary first entry.
+    it the same way the solver does -- both halves through the tolerant
+    resolvers -- so the menu shows what is actually in force rather than an
+    arbitrary first entry, and so an unrecognised sensor leaves the lens menu
+    openable instead of raising while it is built.
     """
-    profile = get_camera_profile(ui_module.shared_state.camera_type())
+    profile = resolve_camera_profile(ui_module.shared_state.camera_type())
     return [
         resolve_lens(profile, ui_module.config_object.get_option("camera_lens")).key
     ]

--- a/python/tests/test_lens_menu_callback.py
+++ b/python/tests/test_lens_menu_callback.py
@@ -1,0 +1,41 @@
+"""The Lens menu's value callback, which resolves both halves of the train.
+
+``get_camera_lens`` is the one consumer that reaches the camera profile
+without going through ``OpticalTrainResolver``, so it needs the same tolerance
+the resolver has: it runs while the menu is being built, and raising there
+leaves the user with a menu that cannot be opened -- on exactly the screen
+they would go to in order to fix a camera problem.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+# Installs the ``_()`` gettext builtin that PiFinder.ui modules rely on.
+import PiFinder.i18n  # noqa: F401
+
+from PiFinder.ui import callbacks
+
+
+def _ui_module(camera_type, lens_key):
+    return SimpleNamespace(
+        shared_state=SimpleNamespace(camera_type=lambda: camera_type),
+        config_object=SimpleNamespace(get_option=lambda _key: lens_key),
+    )
+
+
+@pytest.mark.unit
+class TestGetCameraLens:
+    def test_shows_the_configured_lens(self):
+        assert callbacks.get_camera_lens(_ui_module("imx296", "12mm")) == ["12mm"]
+
+    def test_shows_the_shipped_lens_when_nothing_is_configured(self):
+        # An install predating the setting: which lens that means depends on
+        # the detected sensor, so the menu must resolve rather than guess.
+        assert callbacks.get_camera_lens(_ui_module("hq", None)) == ["25mm"]
+
+    def test_an_unknown_sensor_still_opens_the_menu(self):
+        assert callbacks.get_camera_lens(_ui_module("none", None)) == ["16mm"]
+
+    def test_an_unknown_sensor_still_honours_a_configured_lens(self):
+        assert callbacks.get_camera_lens(_ui_module("none", "12mm")) == ["12mm"]

--- a/python/tests/test_optics.py
+++ b/python/tests/test_optics.py
@@ -7,12 +7,14 @@ if it does not, this change silently moved everyone's SQM and everyone's FOV
 gate. See docs/adr/0027-fov-gate-derived-from-optical-train.md.
 """
 
+import logging
 import math
 
 import pytest
 
 from PiFinder.camera_profiles import CAMERA_PROFILES, get_camera_profile
 from PiFinder.optics import (
+    FALLBACK_CAMERA_TYPE,
     FOV_GATE_MARGIN,
     LENSES,
     SOLVER_IMAGE_PIXELS,
@@ -22,6 +24,7 @@ from PiFinder.optics import (
     build_optical_train,
     get_lens,
     optical_train_for_profile,
+    resolve_camera_profile,
     resolve_lens,
 )
 
@@ -287,6 +290,64 @@ class TestOpticalTrainResolver:
         # resolver must not treat None as already-resolved.
         assert stated is not unset
         assert stated.fov_degrees == pytest.approx(unset.fov_degrees)
+
+    def test_unknown_sensor_falls_back_rather_than_raising(self):
+        # The solver resolves inside a per-frame loop whose outer handler
+        # restarts the solver, tetra3 database load included. A ValueError
+        # here is a crash-reload loop once per frame, not a diagnosis.
+        resolver = OpticalTrainResolver()
+        train = resolver.resolve("none", None)
+        assert train.fov_degrees == pytest.approx(
+            build_optical_train(FALLBACK_CAMERA_TYPE).fov_degrees
+        )
+
+    def test_the_fallback_is_cached_so_it_logs_once(self, caplog):
+        # Cached under the *stated* key: that is what turns once-per-frame
+        # logging into once-per-change, and it keeps the returned train
+        # identical so callers comparing with `is` see no spurious change.
+        resolver = OpticalTrainResolver()
+        with caplog.at_level(logging.WARNING, logger="Optics"):
+            first = resolver.resolve("none", None)
+            again = resolver.resolve("none", None)
+        assert again is first
+        assert len(caplog.records) == 1
+
+    def test_a_real_sensor_still_rebuilds_after_a_fallback(self):
+        # The actual startup sequence: whatever the camera process publishes
+        # first must not be latched in place of the sensor it later reports.
+        resolver = OpticalTrainResolver()
+        fallback = resolver.resolve("none", None)
+        detected = resolver.resolve("hq", None)
+        assert detected is not fallback
+        assert detected.lens.key == "25mm"
+        assert detected.fov_degrees == pytest.approx(
+            build_optical_train("hq").fov_degrees
+        )
+
+
+@pytest.mark.unit
+class TestCameraProfileFallback:
+    """The sensor half of "resolve, don't raise", shared by every consumer."""
+
+    def test_known_sensors_resolve_to_themselves(self):
+        for camera_type in CAMERA_PROFILES:
+            assert resolve_camera_profile(camera_type) == get_camera_profile(
+                camera_type
+            )
+
+    def test_unknown_sensor_resolves_to_the_shared_state_default(self):
+        # Matching SharedStateObj's pre-camera default is the point: an
+        # unrecognised sensor then behaves like the window every boot already
+        # passes through, rather than like a new state nothing has handled.
+        assert resolve_camera_profile("none") == get_camera_profile(
+            FALLBACK_CAMERA_TYPE
+        )
+
+    def test_the_strict_lookup_stays_strict(self):
+        # Scripts and tests naming a sensor should still hear about a typo;
+        # only the live consumers want the fallback.
+        with pytest.raises(ValueError):
+            get_camera_profile("none")
 
 
 @pytest.mark.unit

--- a/python/tests/test_plot_frustum.py
+++ b/python/tests/test_plot_frustum.py
@@ -1,0 +1,70 @@
+"""Tests for the chart frustum: the box marking what the camera images.
+
+Two angles meet in ``plot``: the chart's zoom level, which the user changes,
+and the camera's field of view, which follows the fitted optical train. The
+frustum is the second drawn inside the first, and it decides two things at
+once -- what gets shaded, and which stars come back as ``visible_stars`` (the
+set the align screen picks an alignment star from). Both hang off
+``frustum_box`` returning None or not, which is what these pin.
+"""
+
+import pytest
+
+from PiFinder.optics import build_optical_train
+from PiFinder.plot import frustum_box
+
+
+RENDER_SIZE = (128, 128)
+
+
+@pytest.mark.unit
+class TestNoFrustum:
+    """No stated camera means no frustum -- not a default one."""
+
+    def test_absent_camera_fov_means_no_frustum(self):
+        # There is no honest stand-in: the answer is a property of the
+        # hardware in front of this device. A caller that has not said gets
+        # the whole chart, shaded nowhere and filtered nowhere.
+        assert frustum_box(RENDER_SIZE, 10.2, None) is None
+
+    def test_a_camera_wider_than_the_chart_has_no_frustum(self):
+        # Zoomed in past what the camera images: everything on the chart is
+        # inside the camera's field, so there is nothing to mark.
+        assert frustum_box(RENDER_SIZE, 10.2, 13.71) is None
+
+    def test_a_camera_matching_the_chart_has_no_frustum(self):
+        # A box within a pixel of the chart edge shades nothing and excludes
+        # nothing; drawing it would just be a border.
+        assert frustum_box(RENDER_SIZE, 10.2, 10.2) is None
+        assert frustum_box(RENDER_SIZE, 10.2, 10.15) is None
+
+
+@pytest.mark.unit
+class TestFrustumGeometry:
+    def test_the_box_is_centred_and_scales_with_the_camera_field(self):
+        left, top, right, bottom = frustum_box(RENDER_SIZE, 20.0, 10.0)
+
+        width, height = RENDER_SIZE
+        # Half the chart's field of view, so half its width, centred.
+        assert right - left == pytest.approx(width / 2)
+        assert bottom - top == pytest.approx(height / 2)
+        assert left == pytest.approx(width - right)
+        assert top == pytest.approx(height - bottom)
+
+    def test_a_narrower_camera_gives_a_smaller_box(self):
+        wide = frustum_box(RENDER_SIZE, 30.0, 13.71)
+        narrow = frustum_box(RENDER_SIZE, 30.0, 10.33)
+        assert narrow[2] - narrow[0] < wide[2] - wide[0]
+
+    def test_the_shipped_trains_all_produce_a_box_at_chart_zoom(self):
+        # Every sensor on its shipped lens images less than the 20 degree
+        # chart step, so each has a frustum to mark -- and a different one,
+        # which is the whole reason it cannot be a constant.
+        widths = set()
+        for camera_type in ("imx296", "imx462", "imx290", "hq"):
+            box = frustum_box(
+                RENDER_SIZE, 20.0, build_optical_train(camera_type).fov_degrees
+            )
+            assert box is not None, camera_type
+            widths.add(round(box[2] - box[0], 3))
+        assert len(widths) > 1

--- a/python/tests/test_sqm.py
+++ b/python/tests/test_sqm.py
@@ -11,6 +11,7 @@ from PiFinder.sqm.camera_profiles import (
     detect_camera_type,
 )
 from PiFinder.sqm.save_sweep_metadata import save_sweep_metadata
+from PiFinder.optics import build_optical_train
 from PiFinder.sqm.wings import WingEstimator
 
 
@@ -1386,6 +1387,60 @@ class TestSaveSweepMetadata:
             data = json.load(f)
 
         assert data["timestamp"] == gps_time
+
+    def test_lens_key_is_recorded_and_moves_the_field_width(self, tmp_path):
+        """A stated lens has to reach the archive, field width and all.
+
+        The sweep archive is what the SQM calibration constants get re-derived
+        from, so recording the shipped lens for a device that is not on it
+        makes the mislabelling self-reinforcing: the refit divides by a field
+        width the frames were never taken through.
+        """
+        sweep_dir = tmp_path / "sweep_lens"
+        sweep_dir.mkdir()
+
+        save_sweep_metadata(
+            sweep_dir=sweep_dir,
+            observer_lat=50.85,
+            observer_lon=4.35,
+            camera_type="imx296",
+            lens_key="12mm",
+        )
+
+        with open(sweep_dir / "sweep_metadata.json") as f:
+            data = json.load(f)
+
+        assert data["camera"]["lens"] == "12mm"
+        assert data["camera"]["lens_effective_focal_length_mm"] == pytest.approx(12.0)
+        # 12mm on an imx296 images ~17.8 degrees, not the shipped 16mm's 13.71.
+        assert data["camera"]["radiometric_fov_degrees"] == pytest.approx(
+            build_optical_train("imx296", "12mm").fov_degrees
+        )
+        assert data["camera"]["radiometric_fov_degrees"] > 15.0
+
+    def test_omitted_lens_key_records_the_shipped_lens(self, tmp_path):
+        """The fallback, so the assertion above is about the lens, not the call.
+
+        Only correct for a caller that genuinely has no lens config to pass;
+        a caller holding shared_state must pass what it holds.
+        """
+        sweep_dir = tmp_path / "sweep_no_lens"
+        sweep_dir.mkdir()
+
+        save_sweep_metadata(
+            sweep_dir=sweep_dir,
+            observer_lat=50.85,
+            observer_lon=4.35,
+            camera_type="imx296",
+        )
+
+        with open(sweep_dir / "sweep_metadata.json") as f:
+            data = json.load(f)
+
+        assert data["camera"]["lens"] == "16mm"
+        assert data["camera"]["radiometric_fov_degrees"] == pytest.approx(
+            13.71, abs=0.03
+        )
 
     def test_nonexistent_directory_raises_error(self, tmp_path):
         """Test that saving to nonexistent directory raises an error."""


### PR DESCRIPTION
Review follow-ups for #609, stacked on its branch (`worktree-lens-config-impl`) so #609 itself is untouched. Each commit is one of the three items Rich picked; nothing else from the review is in here.

If you would rather have these inside #609, this branch is a direct descendant of its tip, so `git push origin worktree-pr609-followups:worktree-lens-config-impl` is a clean fast-forward.

## 1. `save_sweep_metadata(lens_key=...)` was never passed

`camera_interface.py`'s sweep-completion block passed `camera_type` but not `lens_key`, so a sweep captured on a device with a non-default lens recorded the *shipped* lens's field width and a wrong `"lens"` string. Those archives are what `evaluate_radiometer_archive.py` re-derives the SQM constants from, so the mislabelling is self-reinforcing. Fixed, plus the now-false docstring ("omitted means the sensor's shipped lens, which is what the device itself assumes" — the device now assumes the *configured* lens) and a regression test that a stated lens moves `radiometric_fov_degrees` off the shipped value.

## 2. Unknown `camera_type` no longer raises

`get_camera_profile()` raises for anything outside `CAMERA_PROFILES`, and #609 put that lookup on three paths that were previously insensitive to `camera_type` — the solver's per-frame resolve, the align screen, and the Lens menu's value callback. In the solver a `ValueError` escapes the local handler and reaches the outer one that restarts the entire solver loop, tetra3 database load included: a crash-reload loop, once per frame.

`optics.resolve_camera_profile()` is now the single fallback policy for the sensor half — the counterpart of `resolve_lens` for the lens half. It logs and falls back to `imx296`, which is `SharedStateObj`'s pre-camera default, so an unknown sensor behaves like the window every boot already passes through. `get_camera_profile` stays strict so scripts and tests still hear about a typo. `ui/callbacks.get_camera_lens`, which bypasses the resolver, goes through the same helper.

**This is hardening, not a fix for an observed crash.** `camera_none` does publish `camera_type="none"`, but its `get_images` passes a `bias_image` argument `CameraInterface.get_image_loop` does not accept, so the camera process dies before `"none"` ever reaches shared state. That `TypeError` predates #609 and is unrelated — worth its own issue, not folded in here.

## 3. `plot.py` frustum / `camera_fov` default — Option A + C

Rich had not picked an approach; this implements the recommended **A** (delete the default, `None` means *no frustum*) together with **C** (pass it per render instead of holding it on the object), which the handoff called the honest end state.

- `DEFAULT_CAMERA_FOV_DEGREES` is gone. It was a hard-coded constant wearing a derived costume: it did not become correct, it moved from 9.5° to 13.71°, and spelling it as a derivation made it *harder* to notice it was a constant.
- `camera_fov=None` now means no frustum — no shading **and** no `visible_stars` filter. The filter used to run ungated on `shade_frustrum`, so a caller could have its stars silently restricted by a value it never set, with no way to ask for "chart, no frustum".
- `frustum_box()` holds the geometry, so the shading and the filter read the same box and "no frustum" is one testable state instead of two inequalities.
- Per-render also takes it off the shared object: `api_extensions` caches one `Starfield` across requests and waitress is multi-threaded, so `set_camera_fov()` between one request's resolve and its render belonged to whoever got there last.

`align.py` and the chart API set it as before → behaviour unchanged. `ui/chart.py`, which never set it, now gets unfiltered `visible_stars` that it already discards.

Vocabulary: `docs/ax/camera/CONTEXT.md` gains a **Frustum** entry, since "no frustum" is now a real state and `visible_stars` means *stars inside the frustum*, not *stars on the chart*.

## Verification

- `pytest -m "unit or smoke"` — 1209 passed (was 1205 + 4 new files' worth of cases), including the handoff's named suites: optics + optics_solving 44, sqm/radiometer/solver_sqm/sweep_frame_record 165, menu_struct/chart/align/api/camera_interface 51.
- `ruff check`, `ruff format --check`, `mypy` on the touched modules — clean.
- Driven on the running app (`pifinder-remote`, debug camera → `hq`): the Lens menu opens and shows 25mm ticked (item 2's callback path); the align screen draws **no** frustum at its default 10.2° zoom, because an hq device images 10.33° — same as before this change — and zooming to 20° draws the box at the computed offsets (42.6–133.4 px on a 176 px display) with the surround dimmed to 32 and the interior at 0.

## Not done (out of scope, per the handoff)

- The Lens menu offering combinations below the pattern database's `min_fov`; the existing `_warn_if_outside_solver_database` log stands.
- The `solver.py` double `camera_type()` read, the `.po`/offline-script nits, the hq non-square-crop rounding note.
- ADR 0027's consequences section could use one sentence noting that `--camera debug` now reports `"hq"` to *every* `camera_type()` consumer (SQM profile, API status, sweep metadata), not just the FOV gate — all dev-only, no impact. Left out as it is outside items 1–3; say the word and it is a one-line commit.
- Pre-existing and untouched: the cached API `Starfield` still carries per-render state (`projection`, `roll`) across concurrent requests. Only `camera_fov` moved off it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)