### PR TITLE
ci(nixos): retire the preview label from the testable PR build

### DIFF
--- a/.github/workflows/nixos-pr-build.yml
+++ b/.github/workflows/nixos-pr-build.yml
@@ -6,10 +6,10 @@ name: Build PiFinder NixOS (testable PRs)
 # `pull_request_target` runs in the BASE repo's trusted context, so the job has
 # the real ATTIC_TOKEN and a read-write GITHUB_TOKEN even for fork PRs. The
 # contributor's code is checked out explicitly (head SHA) and built. This is
-# only reached after a maintainer applies the `testable` (or `preview`) label —
-# that label is the security boundary: it runs contributor code with the cache
-# push token, so review the diff before labeling, and re-review on each new push
-# to a labeled PR.
+# only reached after a maintainer applies the `testable` label — that label is
+# the security boundary: it runs contributor code with the cache push token, so
+# review the diff before labeling, and re-review on each new push to a labeled
+# PR.
 #
 # Build strategy: the free GitHub-hosted ubuntu-24.04-arm runner builds first.
 # Its cores are faster than the Pi5, and the Attic cache (cache.pifinder.eu) is
@@ -33,9 +33,7 @@ permissions:
 jobs:
   # Primary: free GitHub-hosted arm64 runner (native aarch64, no QEMU).
   build-hosted:
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'preview') ||
-      contains(github.event.pull_request.labels.*.name, 'testable')
+    if: contains(github.event.pull_request.labels.*.name, 'testable')
     runs-on: ubuntu-24.04-arm
     # Generous: only a kernel/source change compiles from scratch (~1 h on this
     # 4-core runner); everything else substitutes from Attic in minutes.
@@ -52,8 +50,8 @@ jobs:
           persist-credentials: false
           # Fork PRs: pull_request_target checkout of the head requires opt-in
           # since actions/checkout began refusing it. The head SHA is pinned
-          # explicitly and only reached after the `testable`/`preview` label,
-          # which is the review gate for running contributor code.
+          # explicitly and only reached after the `testable` label, which is the
+          # review gate for running contributor code.
           allow-unsafe-pr-checkout: true
 
       - uses: DeterminateSystems/nix-installer-action@main
@@ -106,8 +104,7 @@ jobs:
     needs: build-hosted
     if: |
       always() &&
-      (contains(github.event.pull_request.labels.*.name, 'preview') ||
-       contains(github.event.pull_request.labels.*.name, 'testable')) &&
+      contains(github.event.pull_request.labels.*.name, 'testable') &&
       needs.build-hosted.result == 'failure'
     runs-on: [self-hosted, aarch64]
     timeout-minutes: 240
@@ -121,8 +118,8 @@ jobs:
           persist-credentials: false
           # Fork PRs: pull_request_target checkout of the head requires opt-in
           # since actions/checkout began refusing it. The head SHA is pinned
-          # explicitly and only reached after the `testable`/`preview` label,
-          # which is the review gate for running contributor code.
+          # explicitly and only reached after the `testable` label, which is the
+          # review gate for running contributor code.
           allow-unsafe-pr-checkout: true
 
       - name: Ensure nix is on PATH (self-hosted runner)


### PR DESCRIPTION
`preview` did nothing `testable` did not.

Both job conditions in `nixos-pr-build.yml` accepted either label, and nothing downstream inspected which one was applied — `update_manifest.py` never receives a label and writes every PR build into `channels["unstable"]`. So the two were exact synonyms.

This repo has no `preview` label at all, so the condition was dead code here. The label existed only on the `mrosseel` fork, where it has now been deleted; `testable`'s description there was also corrected — it claimed "Triggers CI build for testing (no channel publish)", which was never true.

Four mention sites removed: the header comment, both job `if:` conditions, and the two `allow-unsafe-pr-checkout` comments. Both `allow-unsafe-pr-checkout: true` opt-ins themselves are untouched, and the workflow still parses with both remaining conditions gating on `testable` alone.

Branched off `main` so the diff is this one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
