### PR TITLE
fix(focus): drop the Quick Menu exposure jump, add a standing status bar

### DIFF
--- a/docs/ax/camera.md
+++ b/docs/ax/camera.md
@@ -71,6 +71,19 @@ Transitions worth knowing:
   than wrap. SQM calibration (`ui/sqm_calibration.py`) holds the same way.
   `inactive()` is idempotent: `MenuManager` calls it twice on a LEFT
   back-out.
+- **A hold survives only a clean exit.** The hand-back lives in
+  `inactive()`, and `add_to_stack` skips `inactive()` for non-stateful
+  modules, so *burying* the Focus screen strands the hold: the camera stays
+  pinned at the held manual exposure with `_auto_exposure_enabled` cleared
+  (only `set_exp:auto` sets it back, so zero-match recovery is dead too),
+  while Camera Exp still reads Auto. The Focus screen's marking menu used to
+  carry a `menu_jump` to `camera_exposure`, which was the likeliest route
+  into this, so it was removed — UP / DOWN already did the same job faster.
+  Its marking menu is now HELP only (`up` defaults to it, and the screen has
+  help pages), and a standing status bar along the bottom of the panel
+  advertises the UP / DOWN keys in its place. Long-RIGHT, the power button
+  and an object push from SkySafari can still bury the screen, so removing
+  the jump narrows this failure rather than closing it.
 - **Any manual nudge wins**: `exp_up` / `exp_dn` silently drop both
   auto-exposure regimes. The new value is *not* persisted until
   `exp_save`, which also writes `camera_gain`.

--- a/docs/ax/ui/CONTEXT.md
+++ b/docs/ax/ui/CONTEXT.md
@@ -200,6 +200,10 @@ _Avoid_: processed preview, enhanced stars, focus strip.
 One of the four Focus-screen views cycled with short `square`, following the normal **display mode** convention: **Stars** (the four focus tiles and HFD history), **Single** (the brightest tracked star at twice the Stars magnification, with HFD and history on a translucent lower-third overlay), **Image** (the complete frame with the original per-frame autocontrast applied for display only), and **Stats** (HFD, supplementary area-equivalent FWHM, detected-star count, exposure mode/value, gain, and a log-scaled raw histogram). HFD, centroids, and the Stats histogram always use the unstretched raw frame. Every unavailable HFD readout is shown as `?.?`; no upper-limit sentinel is displayed.
 _Avoid_: tab, page, focus-strip mode.
 
+**Focus status bar**:
+The standing bar along the bottom of the Focus screen in the **Stars**, **Single** and **Image** display modes: the held exposure on the left, the keys that change it on the right. Zoom keys are advertised only where `+`/`-` do something, so **Image** lists the exposure keys alone. Its rows are *reserved* out of the camera area rather than drawn over it — the tiles and crops are raw sensor pixels, and none of them is hidden behind the bar. **Stats** has no bar: it already reports exposure mode and value, and its histogram owns the bottom of the panel. It replaced a transient top-left exposure readout when the Focus marking menu lost its jump to Camera Exp, so it is also the only advertisement of the UP / DOWN exposure keys.
+_Avoid_: exposure flash, title bar (that is the shared `titlebar`), legend.
+
 **Focus FWHM estimate**:
 The median area-equivalent diameter of the pixels above half local maximum for the same four brightest measurable stars. It is supplementary diagnostics on the Stats display mode, not the focus-quality metric; HFD remains primary because it behaves better on saturated, broad, and donut-shaped stars.
 _Avoid_: focus FWHM (when used as a replacement for HFD), fitted FWHM (there is no Gaussian fit).

--- a/docs/source/menu_map.rst
+++ b/docs/source/menu_map.rst
@@ -52,9 +52,10 @@ Focus
    as it will go.  Sharp stars let the PiFinder solve.  Press **SQUARE** to
    cycle the Stars, Single, Image, and Stats views.  The screen holds the camera
    exposure steady while it is open, so only the lens changes what you see.
-   Press **UP** and **DOWN** to step the exposure.  Your previous exposure
-   setting returns when you leave.  The Quick Menu here adjusts the camera
-   Exposure, and a value selected there is saved.
+   Press **UP** and **DOWN** to step the exposure.  A bar along the bottom
+   shows the held exposure and the keys that change it.  Nothing you set here
+   is saved.  Your previous exposure setting returns when you leave.  To set an
+   exposure the PiFinder keeps, select Camera Exp in the Settings menu.
 Align
    Align the PiFinder to your eyepiece.  Center a known star and confirm.  Your
    Push-To distances then account for any offset between the camera and where

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -407,9 +407,11 @@ HFD readout and changing which stars you see.  Holding it steady means every cha
 comes from the lens.
 
 Press **UP** for a longer exposure and **DOWN** for a shorter one.  These step through the
-same values as the Camera Exp setting, from 0.025s to 1s.  The exposure appears briefly in
-the top left when you open the screen and each time you change it.  Nothing you set here is
-saved.  The PiFinder restores your previous exposure setting when you leave.
+same values as the Camera Exp setting, from 0.025s to 1s.  A bar along the bottom of the
+screen shows the held exposure on the left and the keys that change it on the right.  The bar
+stays on screen while you work.  Nothing you set here is saved.  The PiFinder restores your
+previous exposure setting when you leave.  To set an exposure the PiFinder keeps, select
+Settings from the main menu, then select Camera Exp.
 
 At the center of the screen is the **HFD** readout.  This is the Half-Flux Diameter of the
 detected stars, in camera pixels, and it measures how spread out the starlight is.  A
@@ -436,16 +438,16 @@ Press **SQUARE** to cycle through four views:
   and trace along the bottom.
 * **Image**: the full camera frame, brightened for the screen.
 * **Stats**: the HFD alongside an FWHM estimate, the detected-star count, the held exposure
-  marked ``HOLD``, gain, and a histogram of the raw image.
+  marked ``HOLD``, gain, and a histogram of the raw image.  This view reports the exposure
+  itself, so it has no bar along the bottom.
 
 .. image:: images/quick_start/focus_single_docs.png
    :width: 45%
 .. image:: images/quick_start/focus_stats_docs.png
    :width: 45%
 
-Press and hold **SQUARE** in any view to open the :ref:`user_guide:quick menu`, which offers
-the camera exposure setting.  A value you select there is saved, unlike the **UP** and
-**DOWN** steps on this screen.  With dark enough skies and good focus, the camera icon appears
+Press and hold **SQUARE** in any view to open the :ref:`user_guide:quick menu`.  It offers
+HELP for this screen.  With dark enough skies and good focus, the camera icon appears
 in the top right and the current constellation shows in the title bar.  Congratulations, the
 PiFinder knows where it's pointing!
 

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -127,9 +127,11 @@ Work through these in order:
 - **Lens cap off, and hold still.**  The PiFinder can only solve a sharp, stationary
   image.
 - **Exposure.**  The PiFinder defaults to **AUTO** and sets the exposure itself from each
-  solve.  Leave it there unless you have a reason not to.  To set it by hand, 0.2 s suits most
-  skies, bright urban skies want 0.4 s, and dark skies solve well at 0.1 s.  The Focus screen
-  holds the exposure steady while it is open, so it reads ``HOLD`` there even on **AUTO**.
+  solve.  Leave it there unless you have a reason not to.  To set it by hand, select Settings
+  from the main menu, then select Camera Exp.  0.2 s suits most skies, bright urban skies want
+  0.4 s, and dark skies solve well at 0.1 s.  The Focus screen holds the exposure steady while
+  it is open, so it reads ``HOLD`` there even on **AUTO**.  The **UP** and **DOWN** steps on
+  that screen change the exposure for the visit only, and the PiFinder does not save them.
   Software older than 2.2 has no AUTO option, which is another reason to update.
 - **High, thin cloud.**  An invisible drifting cloudbank stops solves at an otherwise perfect
   site.  If solves come and go while the telescope is dead still, suspect the sky before the

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -132,8 +132,7 @@ Press and hold **SQUARE** to open the Quick Menu.
 
 This menu presents up to four options, one per arrow button.  Press an arrow to select its
 item.  The menu changes with the screen you're on, but it often has
-:ref:`HELP<user_guide:help system>` at the UP option.  The Focus screen above offers HELP
-and Exposure.
+:ref:`HELP<user_guide:help system>` at the UP option.
 
 Some Quick Menus have a second layer.  The Object List's Quick Menu, for example, offers
 Sort and Filter.  Press **LEFT** for Sort to open a ring of sort orders, with subtle

--- a/python/PiFinder/ui/preview.py
+++ b/python/PiFinder/ui/preview.py
@@ -51,8 +51,15 @@ FOCUS_EXPOSURE_LADDER = (
 # Exposure to hold when no exposure is known yet. Matches the starting point
 # the camera processes use for auto-exposure.
 FOCUS_DEFAULT_EXPOSURE = 400_000
-# How long the exposure readout stays up after entering the screen or nudging.
-FOCUS_EXPOSURE_LABEL_S = 2.5
+# Height of the bottom status bar at 128px, scaled with the panel. Derived from
+# the resolution rather than the small font so that tile geometry stays
+# independent of font metrics; tests/test_focus_preview.py pins that this is
+# still tall enough for the small font on every shipped layout.
+#
+# The bar is reserved out of the camera area rather than drawn over it, so no
+# raw pixel is ever hidden by it -- the whole point of the star tiles is that
+# what you see is the sensor.
+FOCUS_STATUS_BAR_H_128 = 13
 
 
 def step_exposure(
@@ -129,13 +136,26 @@ class UIPreview(UIModule):
         self._exposure_hold_active = False
         self._saved_camera_exp: Optional[object] = None
         self._held_exposure_us: Optional[int] = None
-        self._exposure_label_until = 0.0
 
-        self.marking_menu = MarkingMenu(
-            left=MarkingMenuOption(
-                label=_("Exposure"),
-                menu_jump="camera_exposure",
-            ),
+        self.marking_menu = self._build_marking_menu()
+
+    @staticmethod
+    def _build_marking_menu() -> MarkingMenu:
+        """The Quick Menu for this screen: help only, no Exposure jump.
+
+        UP/DOWN adjust the exposure directly here, so the jump was a second,
+        slower route to the same thing -- and taking it buried this screen
+        without ``inactive()``, stranding the exposure hold and with it
+        auto-exposure for the rest of the session. The status bar advertises
+        the keys that replaced it.
+
+        The menu itself stays rather than becoming None: ``MarkingMenu.up``
+        defaults to HELP and this screen has help pages
+        (``__help_name__ = "camera"``), so dropping the menu would take the
+        help with it.
+        """
+        return MarkingMenu(
+            left=MarkingMenuOption(),
             down=MarkingMenuOption(),
             right=MarkingMenuOption(),
         )
@@ -211,10 +231,9 @@ class UIPreview(UIModule):
         return FOCUS_DEFAULT_EXPOSURE
 
     def _apply_hold_exposure(self, exposure_us: int) -> None:
-        """Hold the camera at one exposure and flash the value on screen."""
+        """Hold the camera at one exposure and show the value on screen."""
         self._held_exposure_us = int(exposure_us)
         self._exposure_hold_active = True
-        self._exposure_label_until = time.time() + FOCUS_EXPOSURE_LABEL_S
         self.command_queues["camera"].put(f"set_exp_transient:{self._held_exposure_us}")
 
     def _nudge_exposure(self, direction: int) -> None:
@@ -222,12 +241,11 @@ class UIPreview(UIModule):
         if not self._exposure_hold_active or self._held_exposure_us is None:
             return
         new_exposure = step_exposure(self._held_exposure_us, direction)
-        if new_exposure == self._held_exposure_us:
-            # Already at the end of the ladder; still flash the value so the
-            # key press doesn't read as the screen having missed it.
-            self._exposure_label_until = time.time() + FOCUS_EXPOSURE_LABEL_S
-        else:
+        if new_exposure != self._held_exposure_us:
             self._apply_hold_exposure(new_exposure)
+        # Redraw either way. At the end of the ladder the value is unchanged,
+        # but the status bar is standing so there is nothing to re-flash --
+        # the repaint just keeps the screen current with the key press.
         self.update(force=True)
 
     def _measure_focus(
@@ -336,23 +354,41 @@ class UIPreview(UIModule):
             return ()
         return tuple(self.last_focus_result.blobs[:FOCUS_TILE_COUNT])
 
+    def _status_bar_height(self) -> int:
+        """Rows reserved at the bottom for the exposure and key readout."""
+        res_y = self.display_class.resolution[1]
+        return max(FOCUS_STATUS_BAR_H_128, round(res_y * FOCUS_STATUS_BAR_H_128 / 128))
+
+    def _content_bottom(self) -> int:
+        """First row belonging to the status bar rather than the camera.
+
+        Every camera-area layout measures down to this instead of the panel
+        height, so the bar takes its space from the render rather than
+        covering it.
+        """
+        res_y = self.display_class.resolution[1]
+        content_top = min(self.display_class.titlebar_height + 1, res_y)
+        return max(content_top + 1, res_y - self._status_bar_height())
+
     def _focus_center(self) -> tuple[int, int]:
         """Return the center of the visible area below the title bar."""
         res_x, res_y = self.display_class.resolution
         content_top = min(self.display_class.titlebar_height + 1, res_y)
-        return res_x // 2, content_top + (res_y - content_top) // 2
+        content_bottom = self._content_bottom()
+        return res_x // 2, content_top + (content_bottom - content_top) // 2
 
     def _tile_boxes(self) -> tuple[tuple[int, int, int, int], ...]:
         """Split the visible camera area into four equally sized quadrants."""
         res_x, res_y = self.display_class.resolution
         content_top = min(self.display_class.titlebar_height + 1, res_y)
+        content_bottom = self._content_bottom()
         mid_x = res_x // 2
         mid_y = self._focus_center()[1]
         return (
             (0, content_top, mid_x, mid_y),
             (mid_x, content_top, res_x, mid_y),
-            (0, mid_y, mid_x, res_y),
-            (mid_x, mid_y, res_x, res_y),
+            (0, mid_y, mid_x, content_bottom),
+            (mid_x, mid_y, res_x, content_bottom),
         )
 
     def _render_focus_tiles(self, raw_image: Image.Image) -> Image.Image:
@@ -392,7 +428,9 @@ class UIPreview(UIModule):
     def _render_brightest_star(self, raw_image: Image.Image) -> Image.Image:
         """Fill the panel with the brightest detected star's raw crop."""
         raw_l = raw_image.convert("L")
-        target_size = self.display_class.resolution
+        # Stops above the status bar for the same reason the tiles do: these
+        # are raw sensor pixels and the bar must not sit on any of them.
+        target_size = (self.display_class.resolution[0], self._content_bottom())
         rendered = Image.new("L", target_size, 0)
         blobs = self._display_blobs()
         if blobs:
@@ -417,7 +455,8 @@ class UIPreview(UIModule):
     def _render_image_frame(self, raw_image: Image.Image) -> Image.Image:
         """Fit and autocontrast the full camera image for display only."""
         resized = raw_image.convert("L").resize(
-            self.display_class.resolution, resample=Image.Resampling.NEAREST
+            (self.display_class.resolution[0], self._content_bottom()),
+            resample=Image.Resampling.NEAREST,
         )
         red = ImageChops.multiply(resized.convert("RGB"), self.colors.red_image)
         return ImageOps.autocontrast(red)
@@ -455,10 +494,11 @@ class UIPreview(UIModule):
         """Draw quadrant separators, HFD history, and the current HFD."""
         res_x, res_y = self.display_class.resolution
         content_top = min(self.display_class.titlebar_height + 1, res_y)
+        content_bottom = self._content_bottom()
         center = self._focus_center()
         separator = self.colors.get(64)
         self.draw.line(
-            [(center[0], content_top), (center[0], res_y - 1)], fill=separator
+            [(center[0], content_top), (center[0], content_bottom - 1)], fill=separator
         )
         self.draw.line([(0, center[1]), (res_x - 1, center[1])], fill=separator)
 
@@ -479,10 +519,16 @@ class UIPreview(UIModule):
 
     def _draw_single_focus_overlay(self) -> None:
         """Draw HFD and history over a translucent lower-third panel."""
-        res_x, res_y = self.display_class.resolution
-        overlay_top = math.ceil(res_y * 2 / 3)
-        center = (res_x // 2, overlay_top + (res_y - overlay_top) // 2)
-        self.draw.rectangle((0, overlay_top, res_x, res_y), fill=(0, 0, 0, 128))
+        res_x = self.display_class.resolution[0]
+        content_bottom = self._content_bottom()
+        overlay_top = math.ceil(content_bottom * 2 / 3)
+        center = (res_x // 2, overlay_top + (content_bottom - overlay_top) // 2)
+        self.draw.rectangle(
+            # rectangle() includes its far corner, so stop one row short of the
+            # reserved status bar rather than shading its first row.
+            (0, overlay_top, res_x, content_bottom - 1),
+            fill=(0, 0, 0, 128),
+        )
 
         text = self._focus_readout_text()
 
@@ -589,30 +635,66 @@ class UIPreview(UIModule):
                 draw_isolated_sample(current[0], right_side)
             previous = current
 
-    def _draw_exposure_label(self) -> None:
-        """Flash the held exposure after entering the screen or nudging it.
+    def _status_bar_hint(self) -> str:
+        """Keys worth advertising in the view currently showing.
 
-        Stats carries a standing exposure readout, so the flash is only for
-        the views with no room for one. It clears itself: every new camera
-        frame repaints the view underneath, and past the deadline the label
-        simply isn't drawn again.
+        Only keys that do something here. ``+``/``-`` return early outside the
+        magnified views, so offering zoom on the full-frame Image view would
+        teach a key that does nothing.
+        """
+        hint = f"{self._UP_ARROW}{self._DOWN_ARROW}EXP"
+        if self.display_mode in (DISPLAY_STARS, DISPLAY_SINGLE):
+            hint = f"{hint} +/-ZOOM"
+        return hint
+
+    def _draw_status_bar(self) -> None:
+        """Draw the standing exposure and key readout along the bottom.
+
+        Persistent rather than a flash, and one bar rather than a value in one
+        corner and a legend in another: the exposure is worth watching for as
+        long as the screen is open, and the keys that change it are not
+        discoverable any other way now that the Quick Menu jump is gone.
+
+        Stats is excluded because it already reports the exposure and its
+        regime in full, and its histogram owns the bottom of the panel.
         """
         if self.display_mode == DISPLAY_STATS:
             return
-        if self._held_exposure_us is None:
-            return
-        if time.time() >= self._exposure_label_until:
-            return
-        res_y = self.display_class.resolution[1]
-        top = min(self.display_class.titlebar_height + 2, res_y)
-        self.draw.text(
-            (2, top),
-            self._format_exposure(self._held_exposure_us),
-            font=self.fonts.small.font,
-            fill=self.colors.get(255),
-            stroke_width=1,
-            stroke_fill=self.colors.get(0),
+        res_x, res_y = self.display_class.resolution
+        bar_top = self._content_bottom()
+        font = self.fonts.small.font
+        # Opaque, so the bar stays legible whatever the view under it renders.
+        self.draw.rectangle((0, bar_top, res_x, res_y), fill=self.colors.get(0))
+
+        text_y = bar_top + max(
+            0, (self._status_bar_height() - self.fonts.small.height) // 2
         )
+        exposure = (
+            self._format_exposure(self._held_exposure_us)
+            if self._held_exposure_us is not None
+            else ""
+        )
+        hint = self._status_bar_hint()
+
+        # The exposure changes width as it changes value, so it is pinned left
+        # and the hint pinned right rather than laid out as one string. If a
+        # long off-ladder exposure would collide with the hint on a narrow
+        # panel, the hint gives way -- the measurement outranks the legend.
+        exposure_w = self.draw.textlength(exposure, font=font) if exposure else 0
+        hint_w = self.draw.textlength(hint, font=font)
+        if exposure_w + hint_w + 6 > res_x:
+            hint = f"{self._UP_ARROW}{self._DOWN_ARROW}EXP"
+            hint_w = self.draw.textlength(hint, font=font)
+        if exposure:
+            self.draw.text((2, text_y), exposure, font=font, fill=self.colors.get(255))
+        if exposure_w + hint_w + 6 <= res_x:
+            self.draw.text(
+                (res_x - 2, text_y),
+                hint,
+                font=font,
+                fill=self.colors.get(128),
+                anchor="ra",
+            )
 
     @staticmethod
     def _format_exposure(exposure_us) -> str:
@@ -746,7 +828,7 @@ class UIPreview(UIModule):
             self._draw_single_focus_overlay()
 
         if image_updated or force:
-            self._draw_exposure_label()
+            self._draw_status_bar()
 
         return self.screen_update()
 

--- a/python/tests/test_focus_preview.py
+++ b/python/tests/test_focus_preview.py
@@ -10,7 +10,14 @@ import pytest
 from PIL import Image, ImageDraw
 
 from PiFinder.ui import preview as preview_module
-from PiFinder.displays import DisplayBase, Layout176, Layout320
+from PiFinder.displays import (
+    DisplayBase,
+    DisplayHeadless,
+    DisplayHeadless176,
+    DisplayHeadless320,
+    Layout176,
+    Layout320,
+)
 from PiFinder.focus import Blob, FocusResult
 from PiFinder.ui.preview import (
     DISPLAY_IMAGE,
@@ -154,9 +161,11 @@ def test_quadrants_are_centered_below_title_bar_on_every_layout(layout):
 
     assert boxes[0][1] == content_top
     assert abs(top_height - bottom_height) <= 1
+    # The status bar is reserved out of the camera area, so the quadrants
+    # centre on what is left rather than on the full panel height.
     assert (
         preview._focus_center()[1]
-        == content_top + (preview.display_class.resY - content_top) // 2
+        == content_top + (preview._content_bottom() - content_top) // 2
     )
 
 
@@ -218,15 +227,18 @@ def test_edge_star_crop_contains_only_source_frame_pixels():
     )
 
     content_top = preview.display_class.titlebar_height + 1
+    content_bottom = preview._content_bottom()
     assert np.all(rendered[:content_top, :, 0] == 0)
-    assert np.all(rendered[content_top:, :, 0] == 73)
+    assert np.all(rendered[content_top:content_bottom, :, 0] == 73)
+    # Reserved for the status bar, so no camera pixel lands here.
+    assert np.all(rendered[content_bottom:, :, 0] == 0)
     assert np.all(rendered[:, :, 1:] == 0)
 
 
 @pytest.mark.unit
 def test_image_renderer_uses_original_display_autocontrast():
     preview = object.__new__(UIPreview)
-    preview.display_class = SimpleNamespace(resolution=(128, 128))
+    preview.display_class = SimpleNamespace(resolution=(128, 128), titlebar_height=17)
     preview.colors = SimpleNamespace(
         red_image=Image.new("RGB", (128, 128), (255, 0, 0))
     )
@@ -242,7 +254,7 @@ def test_image_renderer_uses_original_display_autocontrast():
 def test_single_star_renderer_preserves_brightest_raw_crop(monkeypatch):
     preview = object.__new__(UIPreview)
     preview.focus_zoom = FOCUS_NOMINAL_ZOOM
-    preview.display_class = SimpleNamespace(resolution=(128, 128))
+    preview.display_class = SimpleNamespace(resolution=(128, 128), titlebar_height=17)
     preview.colors = SimpleNamespace(
         red_image=Image.new("RGB", (128, 128), (255, 0, 0))
     )
@@ -342,9 +354,14 @@ def test_single_star_readout_stays_in_translucent_lower_third():
     preview._draw_single_focus_overlay()
 
     pixels = np.asarray(preview.screen)
-    overlay_top = int(np.ceil(preview.display_class.resY * 2 / 3))
+    # Lower third of the camera area, which now stops above the status bar.
+    content_bottom = preview._content_bottom()
+    overlay_top = int(np.ceil(content_bottom * 2 / 3))
     assert np.all(pixels[:overlay_top, :, 0] == 100)
-    assert np.any((pixels[overlay_top:, :, 0] > 0) & (pixels[overlay_top:, :, 0] < 100))
+    band = pixels[overlay_top:content_bottom, :, 0]
+    assert np.any((band > 0) & (band < 100))
+    # The overlay must not reach into the reserved status bar.
+    assert np.all(pixels[content_bottom:, :, 0] == 100)
 
 
 @pytest.mark.unit
@@ -604,7 +621,6 @@ def _hold_preview(*, camera_exp="auto", exposure_time=437_000):
     preview._exposure_hold_active = False
     preview._saved_camera_exp = None
     preview._held_exposure_us = None
-    preview._exposure_label_until = 0.0
     preview.config_object = SimpleNamespace(get_option=lambda _name: camera_exp)
     preview.shared_state = SimpleNamespace(
         last_image_metadata=lambda: {"exposure_time": exposure_time}
@@ -799,40 +815,118 @@ def test_stats_reports_a_held_exposure_as_hold_not_the_saved_setting(monkeypatch
     assert not any("AUTO" in text for text in drawn_text)
 
 
-@pytest.mark.unit
-def test_exposure_label_flashes_on_the_star_views_then_clears(monkeypatch):
-    preview = _hold_preview(camera_exp=400_000)
-    preview.display_class = DisplayBase()
-    preview.colors = preview.display_class.colors
-    preview.fonts = preview.display_class.fonts
-    preview.display_mode = DISPLAY_STARS
+def _bar_preview(display_class, display_mode, camera_exp=400_000):
+    preview = _hold_preview(camera_exp=camera_exp)
+    preview.display_class = display_class
+    preview.colors = display_class.colors
+    preview.fonts = display_class.fonts
+    preview.display_mode = display_mode
+    preview.screen = Image.new("RGB", display_class.resolution)
+    preview.draw = ImageDraw.Draw(preview.screen, mode="RGBA")
+    return preview
 
-    def rendered_label(now: float) -> int:
+
+@pytest.mark.unit
+def test_status_bar_persists_on_the_star_views(monkeypatch):
+    """The bar is standing, not a flash: it must not time out."""
+    preview = _bar_preview(DisplayBase(), DISPLAY_STARS)
+    monkeypatch.setattr(preview_module.time, "time", lambda: 100.0)
+    preview._begin_exposure_hold()
+
+    def rendered(now: float) -> int:
         monkeypatch.setattr(preview_module.time, "time", lambda: now)
         preview.screen = Image.new("RGB", preview.display_class.resolution)
         preview.draw = ImageDraw.Draw(preview.screen, mode="RGBA")
-        preview._draw_exposure_label()
+        preview._draw_status_bar()
         return int(np.count_nonzero(np.asarray(preview.screen)))
 
-    monkeypatch.setattr(preview_module.time, "time", lambda: 100.0)
-    preview._begin_exposure_hold()
-
-    assert rendered_label(100.5) > 0
-    assert rendered_label(100.0 + preview_module.FOCUS_EXPOSURE_LABEL_S + 0.1) == 0
+    assert rendered(100.5) > 0
+    # Far past any old flash deadline, and still drawn.
+    assert rendered(100.0 + 3600.0) > 0
 
 
 @pytest.mark.unit
-def test_exposure_label_stays_off_the_stats_view_which_already_shows_it(monkeypatch):
-    preview = _hold_preview(camera_exp=400_000)
-    preview.display_class = DisplayBase()
-    preview.colors = preview.display_class.colors
-    preview.fonts = preview.display_class.fonts
-    preview.display_mode = DISPLAY_STATS
-    preview.screen = Image.new("RGB", preview.display_class.resolution)
-    preview.draw = ImageDraw.Draw(preview.screen, mode="RGBA")
+def test_status_bar_carries_the_held_exposure_and_the_keys(monkeypatch):
+    preview = _bar_preview(DisplayBase(), DISPLAY_STARS)
     monkeypatch.setattr(preview_module.time, "time", lambda: 100.0)
     preview._begin_exposure_hold()
 
-    preview._draw_exposure_label()
+    drawn = []
+    original = preview.draw.text
+    preview.draw.text = lambda xy, text, **kw: (
+        drawn.append(text),
+        original(xy, text, **kw),
+    )[1]
+    preview._draw_status_bar()
+
+    assert any("0.4s" in text for text in drawn)
+    assert any(preview._UP_ARROW in text and "EXP" in text for text in drawn)
+    assert any("ZOOM" in text for text in drawn)
+
+
+@pytest.mark.unit
+def test_status_bar_drops_zoom_on_the_image_view_where_it_does_nothing():
+    """+/- return early outside the magnified views, so do not advertise them."""
+    preview = _bar_preview(DisplayBase(), DISPLAY_IMAGE)
+
+    assert "ZOOM" not in preview._status_bar_hint()
+    assert "EXP" in preview._status_bar_hint()
+
+
+@pytest.mark.unit
+def test_status_bar_stays_off_the_stats_view_which_already_shows_it(monkeypatch):
+    preview = _bar_preview(DisplayBase(), DISPLAY_STATS)
+    monkeypatch.setattr(preview_module.time, "time", lambda: 100.0)
+    preview._begin_exposure_hold()
+
+    preview._draw_status_bar()
 
     assert preview.screen.getbbox() is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "display_cls",
+    (DisplayHeadless, DisplayHeadless176, DisplayHeadless320),
+    ids=lambda cls: cls.__name__,
+)
+def test_status_bar_is_tall_enough_for_the_small_font(display_cls):
+    """The bar height is derived from resolution, not font metrics.
+
+    That keeps tile geometry independent of fonts, but it is only safe while
+    the derived height still clears the small font on every shipped panel.
+    """
+    display_class = display_cls()
+    preview = _bar_preview(display_class, DISPLAY_STARS)
+
+    assert preview._status_bar_height() >= display_class.fonts.small.height
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("layout", (DisplayBase, Layout176, Layout320))
+def test_status_bar_never_covers_camera_pixels(layout):
+    """The bar is reserved out of the camera area, not drawn over it."""
+    preview = object.__new__(UIPreview)
+    preview.display_class = SimpleNamespace(
+        resolution=layout.resolution,
+        titlebar_height=layout.titlebar_height,
+        resY=layout.resolution[1],
+    )
+    bar_top = preview._content_bottom()
+
+    # No tile, and no part of the focus overlay, may reach into the bar.
+    assert bar_top < layout.resolution[1]
+    assert all(box[3] <= bar_top for box in preview._tile_boxes())
+    assert preview._focus_center()[1] < bar_top
+
+
+@pytest.mark.unit
+def test_focus_screen_offers_no_exposure_jump_but_keeps_its_help():
+    """Leaving via the jump stranded the hold; HELP rides the same menu."""
+    menu = UIPreview._build_marking_menu()
+
+    jumps = [option.menu_jump for option in (menu.left, menu.down, menu.right, menu.up)]
+    assert jumps == [None, None, None, None]
+    # up defaults to HELP, and this screen has help pages to show.
+    assert menu.up.label == "HELP"
+    assert UIPreview.__help_name__ == "camera"


### PR DESCRIPTION
Narrows the Focus-screen exposure-hold leak found while reviewing 2.6.2 (see #619, review finding 2), and replaces the removed route with a discoverable one.

## The bug

`_begin_exposure_hold()` sends `set_exp_transient`, which clears `_auto_exposure_enabled` in the camera process. Only `set_exp:auto` ever sets it back, and that is sent from `inactive()`. But `MenuManager.add_to_stack` calls `inactive()` on the outgoing screen **only when the incoming item carries a preloaded `state`**, and `key_long_left` deactivates just the top of the stack before truncating. So anything pushed over the Focus screen buries it, and a following long-LEFT discards it with the hold still engaged.

The result is not subtle: the camera stays pinned at a manual exposure and **zero-match recovery stops running for the rest of the session**, while `Settings → Camera Exp` still reads `Auto`. Recovery means re-selecting Auto, or a reboot.

PR #614 characterised this as an exotic exit. It is not — the Focus screen's *own* Quick Menu carried an `Exposure` jump (`menu_jump="camera_exposure"`), and adjusting exposure while focusing is an ordinary thing to do.

## What changed

**The Quick Menu Exposure jump is gone.** UP/DOWN already adjust the exposure directly on this screen, so the jump was a second, slower route to the same thing.

The marking menu itself **stays** rather than becoming `None`. `MarkingMenu.up` defaults to `MarkingMenuOption(label="HELP")` and `UIPreview.__help_name__ = "camera"` with real pages in `help/camera/`, so nulling the menu would have silently taken the screen's help with it. Menu construction moved into `_build_marking_menu()` so the behaviour is pinnable by test.

**The transient top-left exposure flash became a standing bar along the bottom**, carrying the held exposure on the left and the keys on the right. Removing the jump removes a discoverable path, so the keys that replaced it have to be visible.

- Zoom is advertised only in **Stars** and **Single**; `+`/`-` return early elsewhere, so **Image** lists the exposure keys alone.
- **Stats** has no bar. It already reports the exposure and its `HOLD` regime, and its histogram owns the bottom of the panel.
- The bar's rows are **reserved out of the camera area, not drawn over it**. Tile boxes, the Single and Image renders, and both overlays now measure to a `_content_bottom()` line. The star tiles are raw sensor pixels and the whole point of the screen is that what you see is the sensor.

## Three things worth knowing

**This narrows the leak, it does not close it.** Long-RIGHT to object details, the power button, and an object push from SkySafari (`main.py` → `jump_to_label("recent")`, which the user does not initiate) all still bury the screen, and each still needs a following long-LEFT. Severity goes HIGH → MEDIUM: much less likely, same silent impact. The real cure is a self-expiring lease on the transient exposure, renewed each frame by the Focus screen and dropped by the camera process on expiry — the black-level lease is the in-repo precedent. Recorded in `docs/ax/camera.md` so it is not lost.

**Unicode arrows silently render nothing in this font.** `↑↓` and `▲▼` return a plausible `textlength` but produce an empty bbox, so a width-based fit check passes and the hint ships invisible. The bar uses the base class's `_UP_ARROW` / `_DOWN_ARROW` icon-font constants.

**The bar height is derived from panel resolution, not font metrics.** Font-derived was the obvious approach but made `_tile_boxes()` depend on `self.fonts`, coupling geometry to fonts. Resolution-derived matches this file's existing idiom (`plot_half_height = max(8, round(res_y * 10 / 128))`), and a test pins that the derived height still clears the small font on all three shipped layouts.

## Found while writing the tests

The Single view's translucent lower-third panel used an inclusive `ImageDraw.rectangle`, so it shaded the first reserved row. Fixed in the source rather than by relaxing the test.

## Behaviour change to be aware of

The Focus screen now has **no way to persist an exposure**. #614 designed the Quick Menu jump as "the one deliberate way to save a value" from this screen. Saving now means `Settings → Camera Exp`, and the docs redirect readers there.

## Docs

`quick_start`, `menu_map` and `troubleshooting` describe the bar and the new saved-exposure route. `user_guide` no longer enumerates this screen's Quick Menu options, because the screenshot beside it still shows the EXPOSURE slice and would contradict the text until re-taken. `docs/ax/camera.md` records the lifecycle trap and what remains open; `docs/ax/ui/CONTEXT.md` gains a **Focus status bar** entry. `docs/ax/camera/CONTEXT.md` needed no change — **exposure hold** and **saved exposure** both still describe reality.

### Screenshots now stale, not re-taken here

Re-taking needs the real multi-process app, so it is out of scope for this PR:

- `images/user_guide/quick_menu_00.png` — the worst one. A Focus-screen Quick Menu shot showing an **EXPOSURE** slice that no longer exists, used twice in `user_guide.rst`.
- `images/quick_start/focus_stars_docs.png` and `focus_single_docs.png` — no bottom bar, tiles drawn to the panel edge.

`focus_stats_docs.png` is **not** stale: `_draw_status_bar` returns early on `DISPLAY_STATS`, and the Stats branch never consults `_content_bottom`.

Also noticed and not addressed: `help/camera/1.png` and `2.png` predate the #531 focus rework entirely (they say "SQUARE Align" and "a live preview with zoom and align features"). They are now more prominent, since HELP is the Quick Menu's only remaining option here.

## Verification

- `pytest -m "smoke or unit"` — **1238 passed, 0 failures** (baseline on `main` is 1229).
- `ruff check` / `ruff format` clean; `mypy PiFinder/ui/preview.py` clean.
- `python -m sphinx -b html -nW` — exit 0, zero warnings.
- Rendered all four views at 128×128 and 320×240 and inspected them, to confirm the bar reads correctly, the arrows actually draw, and no tile is clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
