### PR TITLE
fix(optics): measure the 12mm's effective focal length (13.04mm)

### DIFF
--- a/docs/adr/0029-fov-gate-width-follows-lens-confidence.md
+++ b/docs/adr/0029-fov-gate-width-follows-lens-confidence.md
@@ -39,6 +39,9 @@ re-centred (tetra3's window is symmetric — `fov_estimate ± fov_max_error`):
 | imx296 | 12 mm (17.78°), 16 mm (13.71°) | `16.05 ± 4.39` = [11.65, 20.44] | [11.65, 15.77] |
 | hq | 25 mm (10.33°) | [8.78, 11.88] — unchanged | n/a |
 
+**Every 12 mm figure in this table is superseded** — see the amendment at the
+foot of this document. The reasoning stands; the arithmetic moved.
+
 The imx462 assumed gate lands within a whisker of the pre-0027 constants it
 replaces, which is the behaviour these units are known to work under. The hq
 only ever shipped one lens, so nothing about it widens.
@@ -142,3 +145,58 @@ enough to have absorbed the swap. The general cure is to re-open the gate on
 sustained zero matches *with adequate centroids*, which is #611's scope and
 needs `Centroids` on `SolveDiagnostics` (#610). Until then it is a
 documentation path (#613).
+
+## Amendment (#627): the 12 mm's field of view was derived from a guess
+
+Every 12 mm number above — 13.51°, 17.78°, and the two assumed gates built on
+them — came from `LENSES["12mm"].effective_focal_length_mm = 12.0`, which was
+the nominal standing in for a measurement, flagged
+`effective_focal_length_measured=False` in the registry and called out in a
+comment as optimistic. It was.
+
+A rev4 imx462 on a 12 mm fitted **12.4366 ± 0.0025°** over six solves, giving
+an effective focal length of **13.04 mm** — the barrel runs 8.7% long. The same
+board, same night, same code, then took a 16 mm and fitted 10.4011°, which
+reproduces that lens's derived field to 0.02% and its 15.61 mm to 15.613. That
+control is what makes this a measurement of the 12 mm rather than of the crop
+geometry, which it independently confirms.
+
+| sensor | shipped lenses | assumed gate | stated-12mm gate |
+|---|---|---|---|
+| imx462 / imx290 | 12 mm (**12.44°**), 16 mm (10.40°) | **`11.57 ± 2.73` = [8.84, 14.30]** | [10.57, 14.30] |
+| imx296 | 12 mm (**16.38°**), 16 mm (13.71°) | **`15.25 ± 3.59` = [11.65, 18.84]** | [13.92, 18.84] |
+| hq | 25 mm (10.33°) | [8.78, 11.88] — still unchanged | n/a |
+
+What this does and does not disturb:
+
+**The decision is unaffected.** Gate width still follows lens confidence, the
+assumed gate still spans every lens its sensor shipped with, and the hq still
+has no union to take. Only the field of view the 12 mm implies has moved.
+
+**The regression this ADR exists to fix was real either way.** A rev4
+assuming the 16 mm gated `[8.84, 11.96]` against frames that are 12.44° wide,
+not 13.51° — still outside, still every frame, still forever.
+
+**The assumed gates narrowed rather than widened**, because the 12 mm's true
+field is closer to the 16 mm's than the nominal suggested. The imx462's upper
+bound moves 15.53° → 14.30°, so the mis-solve rejection argued for above gets
+slightly stronger, not weaker. The database floor note still holds: the
+effective imx462 assumed gate is now `[10.0, 14.30]`.
+
+**Self-heal could not identify the 12 mm until this was fixed.** A fitted
+12.44° sat 7.9% from the derived 13.51°, outside `LENS_IDENTIFY_TOLERANCE`
+(5%), so `identify_lens_from_fitted_fov` returned None on every frame and the
+affected units kept solving on the wide gate forever — the "matching no known
+lens writes nothing" consequence, firing on a lens we shipped. That is the
+symptom that surfaced this, and it is what #627 fixes.
+
+**SQM on 12 mm units was reading a field 8.6% too wide**, and its zero point
+with it. The f-number comment above still wants settling separately.
+
+**The 5% tolerance survives.** The imx462's two candidates are now 19.6% apart
+rather than ~30%, which is still far outside any plausible ambiguity.
+
+One caveat, recorded honestly: 13.04 mm rests on a **single 12 mm sample**. The
+16 mm earned its 15.61 by reproducing two independently calibrated field
+widths on two different sensors. A second 12 mm — ideally on an imx296, so the
+sensor half varies too — would put it on the same footing.

--- a/python/PiFinder/optics.py
+++ b/python/PiFinder/optics.py
@@ -47,7 +47,7 @@ FOV_GATE_MARGIN = 0.15
 # How close a fitted FOV must sit to a lens's derived field of view, as a
 # fraction of the latter, before that lens is taken as identified. tetra3 fits
 # the field of view to well under a percent, and the candidates on any one
-# sensor are ~30% apart (the imx462's are 13.51 and 10.40 degrees), so 5% is
+# sensor are ~20% apart (the imx462's are 12.44 and 10.40 degrees), so 5% is
 # generous without being ambiguous. Outside it, no lens is named: a third-party
 # lens must leave the assumption alone rather than be snapped to the nearest
 # thing we happen to sell. See docs/adr/0029.
@@ -105,7 +105,14 @@ LENSES: Dict[str, Lens] = {
     "12mm": Lens(
         key="12mm",
         nominal_focal_length_mm=12.0,
-        effective_focal_length_mm=12.0,
+        # 13.04 is what a rev4 imx462 measured on sky: six solves fitting
+        # 12.4366 +/- 0.0025 degrees against a 980px @ 2.9um crop. The same
+        # board on the 16mm then fitted 10.4011 degrees, reproducing that
+        # lens's derived field to 0.02% -- which is what makes this a
+        # measurement of the 12mm rather than of the sensor profile. The
+        # barrel runs 8.7% long, in the opposite direction from the 16mm's
+        # 2.4% short, so neither label predicts the other. See #627.
+        effective_focal_length_mm=13.04,
         # Front element measures 9.85mm, but that is not the entrance pupil:
         # M12 front elements are deliberately oversized to accept off-axis
         # rays (the advertised-f/2 16mm shows a 1.24x oversize). Applying the
@@ -115,10 +122,6 @@ LENSES: Dict[str, Lens] = {
         # is f/1.6-f/2.0; 2.0 never over-claims. Settle it by comparing
         # on-sky photometric zero points, not by measuring glass.
         f_number=2.0,
-        # Nominal standing in for a measurement. The 16mm measured 2.5% short
-        # of its label, so assuming this one is exact is optimistic; an on-sky
-        # sweep is needed, and the same sweep settles its SQM zero point.
-        effective_focal_length_measured=False,
     ),
     "16mm": Lens(
         key="16mm",

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -1181,9 +1181,24 @@ def solver(
                         solver_queue.put(solve_result)
                     else:
                         if solution:
+                            # Report the gate actually in force. This line
+                            # used to hardcode the pre-0027 constants
+                            # (12.0 +/- 4.0), which stopped being true when
+                            # the gate started coming from the optical train
+                            # -- so the one message a reader consults while
+                            # diagnosing "why is nothing solving" told them
+                            # about a window the solver had not used in two
+                            # releases. Saying stated vs assumed matters for
+                            # the same reason it does on the "Optical train:"
+                            # line above.
                             logger.warning(
-                                f"Solve FAILED - {len(centroids)} centroids detected but "
-                                f"pattern match failed (FOV est: 12.0°, max err: 4.0°)"
+                                "Solve FAILED - %d centroids detected but "
+                                "pattern match failed (%s %s lens, FOV gate "
+                                "[%.2f, %.2f] deg)",
+                                len(centroids),
+                                "stated" if train.lens_stated else "assumed",
+                                train.lens.menu_label,
+                                *_fov_gate_bounds(train),
                             )
                         solver_queue.put(
                             _build_failed_solve(

--- a/python/tests/test_optics.py
+++ b/python/tests/test_optics.py
@@ -74,12 +74,14 @@ class TestLensRegistry:
         assert lens.effective_focal_length_mm == pytest.approx(15.61)
         assert lens.nominal_focal_length_mm != lens.effective_focal_length_mm
 
-    def test_unmeasured_lengths_are_flagged_as_such(self):
-        # The 12mm's effective length is its nominal standing in for a
-        # measurement nobody has taken. That has to stay visible in the data,
-        # not just in a comment, or it gets quietly treated as calibrated.
-        assert LENSES["12mm"].effective_focal_length_measured is False
-        assert LENSES["16mm"].effective_focal_length_measured is True
+    def test_no_effective_length_is_standing_in_for_a_measurement(self):
+        # The 12mm carried its nominal 12.0 as a placeholder until a rev4
+        # imx462 measured it on sky at 13.04mm (#627), and it was 8.7% out.
+        # Nothing in the registry stands in for a measurement now; anything
+        # added that does has to say so in the data, not just in a comment,
+        # or it gets quietly treated as calibrated the same way.
+        for key, lens in LENSES.items():
+            assert lens.effective_focal_length_measured is True, key
 
     def test_unknown_lens_is_rejected(self):
         with pytest.raises(ValueError, match="Unknown lens"):
@@ -146,11 +148,13 @@ class TestDerivedFieldOfView:
         """The combination that motivated the whole change.
 
         The retired constants were fov_estimate=12.0, fov_max_error=4.0, i.e.
-        a [8.0, 16.0] window. A 12mm lens on an imx296 images ~17.8 degrees
-        and could not solve at all.
+        a [8.0, 16.0] window. A 12mm lens on an imx296 images ~16.4 degrees
+        and could not solve at all. The margin narrowed when the 12mm's
+        effective length was measured (#627) -- 17.8 degrees was derived from
+        the nominal -- but it did not close.
         """
         fov = build_optical_train("imx296", "12mm").fov_degrees
-        assert fov == pytest.approx(17.78, abs=0.05)
+        assert fov == pytest.approx(16.38, abs=0.05)
         assert fov > 16.0
 
     def test_field_of_view_is_the_crop_not_the_raw_sensor(self):
@@ -210,10 +214,16 @@ class TestFovGate:
 # specific windows were reasoned about, in particular that the imx462's lands
 # within a whisker of the pre-0027 [8.0, 16.0] these units are known to work
 # under, and that the hq's does not move at all.
+# Recomputed after the 12mm's effective focal length was measured at 13.04mm
+# (#627); the ADR's original table derived the 12mm's field from its nominal.
+# The upper bounds moved down with it, the hq is untouched because it never
+# shipped a 12mm, and every gate still spans both of its sensor's lenses --
+# which is the property test_the_assumed_gate_spans_every_lens_the_sensor
+# _shipped checks independently of these numbers.
 ADR_0029_ASSUMED_GATES = {
-    "imx296": (11.65, 20.44),
-    "imx462": (8.84, 15.53),
-    "imx290": (8.84, 15.53),
+    "imx296": (11.65, 18.84),
+    "imx462": (8.84, 14.30),
+    "imx290": (8.84, 14.30),
     "hq": (8.78, 11.88),
 }
 
@@ -313,11 +323,13 @@ class TestAssumedLensGate:
         """The regression, stated as a test.
 
         A rev4 that shipped with the 12mm and no config assumed the 16mm,
-        gated [8.84, 11.96], and rejected its own 13.51 degree frames -- every
-        one of them, having changed nothing.
+        gated [8.84, 11.96], and rejected its own 12.44 degree frames -- every
+        one of them, having changed nothing. (The ADR says 13.51 there: that
+        was derived from the 12mm's nominal length, before #627 measured it.
+        The frames were always 12.44 degrees wide, and always outside.)
         """
         fitted = build_optical_train("imx462", "12mm").fov_degrees
-        assert fitted == pytest.approx(13.51, abs=0.05)
+        assert fitted == pytest.approx(12.44, abs=0.05)
 
         estimate, max_error = build_optical_train("imx462", "16mm").solver_fov_params()
         assert fitted > estimate + max_error  # the bug

--- a/python/tests/test_sqm.py
+++ b/python/tests/test_sqm.py
@@ -1411,8 +1411,8 @@ class TestSaveSweepMetadata:
             data = json.load(f)
 
         assert data["camera"]["lens"] == "12mm"
-        assert data["camera"]["lens_effective_focal_length_mm"] == pytest.approx(12.0)
-        # 12mm on an imx296 images ~17.8 degrees, not the shipped 16mm's 13.71.
+        assert data["camera"]["lens_effective_focal_length_mm"] == pytest.approx(13.04)
+        # 12mm on an imx296 images ~16.4 degrees, not the shipped 16mm's 13.71.
         assert data["camera"]["radiometric_fov_degrees"] == pytest.approx(
             build_optical_train("imx296", "12mm").fov_degrees
         )

--- a/release_notes/2.6.2.md
+++ b/release_notes/2.6.2.md
@@ -34,15 +34,15 @@ All three now derive from one place, `PiFinder.optics`, which models the **optic
 - **`Settings → Advanced → Lens`**, beside Camera Type, offering 12 mm, 16 mm and 25 mm. The menu shows the lens actually in force rather than the first entry in the list, including on installs that have never stored the setting.
 - **Changing the lens restarts the PiFinder.** Everything that reads the lens live would follow it on the very next frame — the FOV gate, SQM's radiometric field width and the chart's frustum shading all re-resolve per frame. Tetra3's internal pattern cache would not: it stores results already filtered against whichever search window was in force when they were computed, under a key that does not mention the window, and nothing ever clears it. So a lens change could leave the solver holding stale work and appear not to have taken. Restarting is the reliable fix for a setting you change about once in the life of the device.
 - **The gate is ±15% of the derived field of view**, proportional rather than a fixed number of degrees, which is *tighter* than the old fixed pair (effectively ±33%) while being correct for every combination rather than three of four.
-- **Effective, not nominal, focal length drives the arithmetic.** The shipped "16 mm" measures 15.61 mm, and that single value reproduces both independently calibrated SQM field widths (imx296 13.71°, imx462 10.38°) to within 0.02°. Two different sensors agreeing on one lens is what makes it a measurement rather than a fudge factor. Deriving from the nominal 16.0 would have shifted every existing user's SQM by ~0.05 mag. The menu still shows the number printed on the barrel.
+- **Effective, not nominal, focal length drives the arithmetic.** The shipped "16 mm" measures 15.61 mm, and that single value reproduces both independently calibrated SQM field widths (imx296 13.71°, imx462 10.38°) to within 0.02°. Two different sensors agreeing on one lens is what makes it a measurement rather than a fudge factor. Deriving from the nominal 16.0 would have shifted every existing user's SQM by ~0.05 mag. The 12 mm has since been measured the same way and comes out at **13.04 mm** — 8.7% *long*, where the 16 mm runs 2.4% short, so no label predicts its own glass. The menu still shows the number printed on the barrel.
 
 The field of view each combination now derives:
 
 | Sensor | 12 mm | 16 mm | 25 mm |
 |---|---|---|---|
-| imx296 | 17.78° | **13.71°** | 8.26° ✗ |
-| imx462 / imx290 | 13.51° | **10.40°** | 6.26° ✗ |
-| HQ (imx477) | 22.16° | 17.12° | **10.33°** |
+| imx296 | 16.38° | **13.71°** | 8.26° ✗ |
+| imx462 / imx290 | 12.44° | **10.40°** | 6.26° ✗ |
+| HQ (imx477) | 20.43° | 17.12° | **10.33°** |
 
 Bold is the lens that ships with that sensor and the value used when no lens is stated. ✗ marks combinations the shipped pattern database cannot solve — see "Known sharp edges".
 
@@ -50,7 +50,7 @@ Bold is the lens that ships with that sensor and the value used when no lens is 
 
 The lens setting above has a gap in it, and it is one we put there. Deriving the search window from the lens is only right when we *know* the lens — and for an install that has never stored one, the "16 mm" the code fell back to was never knowledge. It was a guess wearing knowledge's confidence.
 
-That guess is wrong on real hardware. Some rev4 units shipped with a 12 mm lens and nothing in their configuration recording it, so on 2.6.2 they searched a window centred on 10.40° for frames that are actually 13.51° wide. **Those units stopped solving on update having changed nothing.** The configuration that broke them is the configuration we shipped them.
+That guess is wrong on real hardware. Some rev4 units shipped with a 12 mm lens and nothing in their configuration recording it, so on 2.6.2 they searched a window centred on 10.40° for frames that are actually 12.44° wide. **Those units stopped solving on update having changed nothing.** The configuration that broke them is the configuration we shipped them.
 
 The fix is to make the search window's width follow how much the PiFinder actually knows:
 
@@ -59,11 +59,11 @@ The fix is to make the search window's width follow how much the PiFinder actual
 
 | Sensor | Lenses it shipped with | Window when the lens is unstated |
 |---|---|---|
-| imx462 / imx290 | 12 mm (13.51°), 16 mm (10.40°) | `12.19 ± 3.35` = [8.84, 15.53] |
-| imx296 | 12 mm (17.78°), 16 mm (13.71°) | `16.05 ± 4.39` = [11.65, 20.44] |
+| imx462 / imx290 | 12 mm (12.44°), 16 mm (10.40°) | `11.57 ± 2.73` = [8.84, 14.30] |
+| imx296 | 12 mm (16.38°), 16 mm (13.71°) | `15.25 ± 3.59` = [11.65, 18.84] |
 | HQ (imx477) | 25 mm (10.33°) | [8.78, 11.88] — **unchanged** |
 
-The imx462's window lands within a whisker of the fixed `[8.0, 16.0]` that 2.6.1 used, which is the behaviour these units are known to work under. The HQ only ever shipped one lens, so nothing about it widens at all.
+The imx462's window sits comfortably inside the fixed `[8.0, 16.0]` that 2.6.1 used, which is the behaviour these units are known to work under. The HQ only ever shipped one lens, so nothing about it widens at all.
 
 **Then the PiFinder identifies the lens for itself.** A successful solve reports the field of view it measured, and the sensor is already known, so what is left is the lens. After **three consecutive solves agreeing to within 5%**, the device writes that lens into the Lens setting and narrows its window onto it. From then on the menu shows the real lens and the solver has 2.6.2's full precision back.
 

--- a/release_notes/release-2.6.2-test-plan.md
+++ b/release_notes/release-2.6.2-test-plan.md
@@ -311,11 +311,11 @@ Everything above tests the *declaration*. This gate tests the thing the release 
 to enable. Needs a physically different lens.
 
 - [ ] **G3.1** Fit a 12 mm lens to an imx296 or imx462. Declare it in the menu. Confirm
-  it solves. **On 2.6.1 the imx296 + 12 mm combination could not solve at all** (17.8°,
+  it solves. **On 2.6.1 the imx296 + 12 mm combination could not solve at all** (16.4°,
   outside the old `[8.0, 16.0]` window) — this is the headline capability and it has to
   be demonstrated on real hardware, not re-projected frames.
 - [ ] **G3.2** With the 12 mm physically fitted, confirm the fitted FOV tetra3 reports
-  lands near the derived 17.78° (imx296) or 13.51° (imx462).
+  lands near the derived 16.38° (imx296) or 12.44° (imx462).
 - [ ] **G3.3** Declare the 12 mm while the 16 mm is fitted, and vice versa. Confirm both
   directions stop solving, and that recovering is simply a matter of correcting the menu.
 - [ ] **G3.4** Note the SQM value with the 12 mm fitted. Its zero-point offset is


### PR DESCRIPTION
Fixes #627.

The `12mm` lens entry carried its nominal 12.0 mm as effective focal length, flagged `effective_focal_length_measured=False`, with a comment noting the 16 mm had measured 2.5% short of its label so assuming this one exact was optimistic. It was optimistic by **8.7%, in the other direction**.

## The measurement

A rev4 imx462 on a 12 mm fitted **12.4366 ± 0.0025°** over six solves, which back-derives to **13.04 mm** on the 980 px @ 2.9 µm crop.

The same board, same night, same code then took a 16 mm and fitted 10.4011° — reproducing that lens's derived field to 0.02% and its 15.61 mm to 15.613 mm. That control is what makes this a measurement of the 12 mm rather than of the sensor profile, which it independently confirms.

| lens | registry EFL | fitted vs derived |
|---|---|---|
| 16mm | 15.61 mm (measured) | **−0.02%** |
| 12mm | 12.0 mm (nominal placeholder) | **−7.9%** |

## The symptom

Self-heal could never identify a 12 mm. A fitted 12.44° sat 7.9% from the derived 13.51°, outside `LENS_IDENTIFY_TOLERANCE` (5%), so `identify_lens_from_fitted_fov` returned `None` on every frame and affected units kept solving on the wide assumed gate forever — ADR 0029's "a fitted FOV matching no shipped lens writes nothing" branch, firing on a lens we ship rather than on third-party glass.

The `logger.info` that would have explained it is invisible on a stock unit: `logconf_default.json` sets the root logger to `ERROR`, so no Integrator line reaches `pifinder.log` at all.

## What moves with the constant

| | before | after |
|---|---|---|
| imx462 12 mm field | 13.51° | **12.44°** |
| imx296 12 mm field | 17.78° | **16.38°** |
| imx462 / imx290 assumed gate | [8.84, 15.53] | **[8.84, 14.30]** |
| imx296 assumed gate | [11.65, 20.44] | **[11.65, 18.84]** |
| hq | [8.78, 11.88] | unchanged — never shipped a 12 mm |

The gates **narrow**, because the 12 mm's true field is closer to the 16 mm's than the nominal implied. So the mis-solve rejection ADR 0029 argued for gets slightly stronger, not weaker, and the `[10.0, 30.0]` database floor still clears everything.

SQM on 12 mm units was reading a field 8.6% too wide, and its zero point with it.

## Also in here: the failed-solve log line was lying

`solver.py` hardcoded the pre-0027 constants in the one message a reader consults while diagnosing a no-solve problem:

```python
f"pattern match failed (FOV est: 12.0°, max err: 4.0°)"
```

Those stopped being true when the gate started coming from the optical train, so the line described a window the solver had not used in two releases. It cost ten minutes of misdiagnosis during this investigation, on what turned out to be a focus problem. It now reports the gate in force and whether the lens is stated or assumed.

## Verification

Hardware, both directions, on the board that surfaced the bug:

```
20:53:54  Lens self-heal: 3 solves fitted 10.41 deg, which is the 16mm (10.40 deg derived)
21:14:11  Optical train: assumed 16mm lens on imx462, fov 10.40 deg, FOV gate [8.84, 14.30]
21:47:14  Lens self-heal: 3 solves fitted 12.43 deg, which is the 12mm (12.44 deg derived)
21:47:16  Optical train: stated 12mm lens on imx462, fov 12.44 deg, FOV gate [10.57, 14.30]
```

Post-fix the 12 mm promotes in three solves at **−0.07%** error, against −7.9% before. Both halves of ADR 0029 are now demonstrated on real hardware: the assumed gate admits the frame, and the fitted FOV identifies the lens.

1283 unit + smoke tests pass. Seven assertions changed, each because the value it asserted legitimately moved; each carries a comment saying why rather than being silently re-baselined.

**Ruff has not run** — it isn't installed in the venv on this device. Style was matched by hand.

## Docs

ADR 0029 gains an **amendment** rather than a rewrite: the decision is untouched and only the arithmetic moved, and the regression it exists to fix was real either way (a rev4 assuming the 16 mm gated `[8.84, 11.96]` against frames that are 12.44° wide — still outside, still every frame). The 2.6.2 release notes and test plan carry the corrected figures; the test plan's G3.2 previously told a tester to expect 13.51°.

## The one caveat

**13.04 mm rests on a single 12 mm sample.** The 16 mm earned its 15.61 by reproducing two independently calibrated field widths on two different sensors. A second 12 mm — ideally on an imx296, so the sensor half varies too — would put it on the same footing. This is recorded in the ADR amendment. Reviewers who would rather hold for that second sample should say so; the alternative is shipping a constant we know to be closer than the placeholder but have confirmed only once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
