### PR TITLE
fix(optics): no FOV gate for frames from an unknown optical train

### DIFF
--- a/docs/adr/0029-fov-gate-width-follows-lens-confidence.md
+++ b/docs/adr/0029-fov-gate-width-follows-lens-confidence.md
@@ -200,3 +200,106 @@ One caveat, recorded honestly: 13.04 mm rests on a **single 12 mm sample**. The
 16 mm earned its 15.61 by reproducing two independently calibrated field
 widths on two different sensors. A second 12 mm — ideally on an imx296, so the
 sensor half varies too — would put it on the same footing.
+
+## Amendment: a third rung — no gate when the optical train is unknown
+
+The ladder above has two rungs, and both assume the frames came through the
+optics the device is configured with. `--camera debug` breaks that assumption:
+it replays archived frames, and the train those frames were shot through is
+not the train this machine is configured for. So the ladder gains a third
+rung — **stated → ±15%, assumed → union over shipped lenses, unknown → no gate
+at all** — and the confidence the width follows becomes confidence in the
+pairing rather than only in the lens.
+
+### The failure
+
+ADR 0027 relabelled the debug camera's sensor from `imx296` to `hq`, because
+the frames in `test_images/` are 10.2° and only the hq's train covers that.
+That fixed the sensor half and left the lens half reading live from
+`camera_lens`, which `resolve_lens` honours whatever profile it is handed. The
+result is a train that has never physically existed:
+
+| train | derived FOV | gate | debug frames |
+|---|---|---|---|
+| hq + no stated lens | 10.33° | [8.78, 11.88] | solve (fitted 10.20°) |
+| hq + stated `25mm` | 10.33° | [8.78, 11.88] | solve |
+| hq + stated `16mm` | 17.12° | [14.55, 19.69] | **no solve** |
+| hq + stated `12mm` | 20.43° | [17.37, 23.49] | **no solve** |
+
+Any developer who has ever opened the Lens menu, and every device whose lens
+this ADR's own self-heal has written, loses `--camera debug` entirely. It is
+the same shape as the regression this document exists to fix, mirrored: there
+an assumption wore a statement's confidence; here a statement is made about
+hardware that is not in the loop.
+
+`tests/test_optics_solving.py` did not catch it because every case calls
+`build_optical_train("hq")` with no lens key — only ever the assumed path.
+
+### Why no hint, rather than the alternatives
+
+**Declaring a lens from the camera** (debug publishes hq + 25 mm, config
+loses) keeps the gate and its mis-solve rejection, and was the first
+instinct. Rejected because it needs a lens statement that must never reach
+`camera_lens` — a second, differently-scoped writer for a key whose whole
+meaning is "the user's claim" — and because it pins debug mode to the one
+frame set we happen to ship. Dropping your own unsolvable field into
+`test_images/` is the main thing debug mode is *for*, and under a declared
+lens those frames are gated out exactly as the shipped ones are today.
+
+**Emulating the configured train** (serve frames matching the user's sensor
+and lens, so `-fh` behaves like their rev4) is the right answer to a different
+question and needs a real archived frame per shipped combination. The frames
+we have are 10.2°, too narrow to re-project outward from; this stays open if
+anyone wants it, and it wants captures, not code.
+
+**A database-range gate** of `[10, 30]°` is no-hint with extra steps — the
+database floor is already doing that pruning — and leaves a constant to
+maintain for no protection gained.
+
+**Rejecting non-shipped pairings** in `resolve_lens` (an hq never shipped with
+a 12 mm, so that statement is not credible) would fix debug as a side effect
+and close the sensor-swap deadlock too. Rejected here as blast radius: it
+makes a user's explicit statement conditionally non-authoritative, which is a
+direct contradiction of 0027, and it deserves its own decision rather than
+riding along with a development-tool fix.
+
+The measured cost of no-hint is small and known. On the shipped frames all
+three widths return identical RA/Dec, `Matches` and `Prob` within ~1 ms of
+each other. What no-hint gives up is the upper bound that rejected confident
+mis-solves in this document's noise trials — a protection whose value is that
+a device under the stars never reports a wrong pointing. Nothing is under the
+stars in debug mode.
+
+### Consequences
+
+**The gate is omitted, not widened.** `fov_estimate` is not passed at all when
+the train is unknown, so there is no third window to keep consistent with the
+other two, and any frame from any train solves.
+
+**Self-heal is barred under an unknown train**, and this is a live bug the
+amendment fixes rather than a hazard it introduces. With no `camera_lens` in
+config — the ordinary state of a development machine — `--camera debug` solves
+at 10.20°, `identify_lens_from_fitted_fov` matches that to the hq's `25mm`
+within 1.3%, and after three frames the integrator writes `camera_lens: 25mm`
+into the developer's config. It is not wrong about the *frames*; it is a
+statement about a device made from a recording. The trap springs later: attach
+a real imx462 and the now-stated 25 mm derives 6.4°, nothing solves, and
+self-heal cannot undo it because it only ever writes into an absence. A fitted
+FOV measures the train the frames passed through, so under an unknown train it
+measures nothing about this device and must not be learned from.
+
+**Only the gate and self-heal follow the unknown train.** The **frustum** keeps
+deriving from the configured optics, deliberately: it answers "what would my
+camera image", which is a question about the device and stays meaningful while
+a recording plays. Propagating would also delete a frustum that is *correct*
+on a dev laptop (10.33° derived against 10.20° frames) to avoid one that is
+wrong only when a lens is stated. SQM is unaffected either way — only
+`camera_pi` publishes radiometer samples, so the radiometric path is inert
+under the debug camera.
+
+**A stated lens still means no solves on real hardware.** Nothing here softens
+0027. The unknown train is a property of where the frames came from, not a
+new escape hatch for a wrong statement — which is why the sensor-swap
+deadlock (switch imx296 → hq from the Camera Type menu with a stated 16 mm,
+derive 17.12°, and be unable to measure out of it) is untouched by this and
+remains a documentation path (#613).

--- a/docs/ax/camera/CONTEXT.md
+++ b/docs/ax/camera/CONTEXT.md
@@ -123,7 +123,9 @@ the one field of view it implies, and nothing overrides it, so a wrong
 statement still means no solves (that is [ADR
 0027](../../adr/0027-fov-gate-derived-from-optical-train.md)'s deliberate
 consequence, not a regression). Written by the user from the Lens menu, or
-once by the device itself from a fitted FOV it is confident about.
+once by the device itself from a fitted FOV it is confident about — but never
+from a fitted FOV measured under an **unknown optical train**, which measures
+a recording rather than this device.
 _Avoid_: configured lens (true of a self-healed value too, so it does not
 distinguish), selected lens, user lens.
 
@@ -133,7 +135,9 @@ stated. Not a claim about the hardware — an admission that nobody has said,
 which is the ordinary condition of an install predating the setting. Because
 there is nothing to trust, the FOV gate widens to cover *every* lens that
 sensor has shipped with rather than centring on the fallback. An assumed lens
-is a temporary state: the first confident solve turns it into a stated one.
+is a temporary state: the first confident solve turns it into a stated one —
+unless the train is **unknown**, in which case no solve ever ends the
+assumption, because none of them measured this device.
 _Avoid_: default lens (reads as a preference rather than an absence of
 information), unset lens (the field of view is never unset — some lens is
 always assumed).
@@ -165,6 +169,25 @@ and the pair is resolved wherever a derived value is needed.
 _Avoid_: optical configuration ("configuration" already names the physical
 build variants — see [Positioning](../positioning/CONTEXT.md) *screen
 direction*), camera setup, imaging train.
+
+**Unknown optical train**:
+The state of a camera whose frames did not come through this device's optics
+at all — today only the debug camera, which replays archived frames. The
+device's train still resolves to *something* (the debug camera declares the
+sensor its frames were shot on), but that train describes the machine, not
+the frames, so two things follow: nothing about the device may be **asserted**
+about the frames — the solver is handed no FOV gate rather than a derived one
+— and nothing about the device may be **inferred** from them, so a fitted FOV
+cannot promote an **assumed lens** to a **stated** one. This is the third rung
+of the confidence ladder the FOV gate's width follows: stated → ±15%, assumed
+→ the union over the sensor's shipped lenses, unknown → no gate at all (see
+[ADR 0029](../../adr/0029-fov-gate-width-follows-lens-confidence.md)).
+Deliberately *not* a blanket "everything derived goes dark": the **frustum**
+still answers what the configured camera would image, which is a question
+about the device and stays meaningful while a recording is being replayed.
+_Avoid_: debug FOV, no FOV (the frames have one — nobody here knows it),
+unknown lens (the lens resolves normally; it is the pairing that means
+nothing), fake camera.
 
 **Field of view**:
 The angular width of the **crop**, in degrees — the edge-to-edge extent, not

--- a/python/PiFinder/camera_debug.py
+++ b/python/PiFinder/camera_debug.py
@@ -33,11 +33,14 @@ class CameraDebug(CameraInterface):
     def __init__(self, exposure_time) -> None:
         logger.debug("init camera debug")
         # Format matches PI cameras for compatibility. The sensor named here
-        # is not cosmetic: it half-determines the solver's FOV gate, and the
-        # frames in test_images/ are ~10.2 deg, which only the hq profile's
-        # train covers. Declaring imx296 centres the gate on 13.71 deg and
-        # every debug frame is rejected before verification -- no solves at
-        # all under `--camera debug`. See docs/adr/0027.
+        # is the one the frames in test_images/ were actually shot on, which
+        # is what makes SQM's profile lookup and the Lens menu resolve to
+        # something plausible. It is *not* a claim that this machine has an hq
+        # attached, and it does not settle the field of view on its own: the
+        # other half of the train comes from config, and a config that states
+        # a lens (16mm -> 17.12 deg, 12mm -> 20.43 deg) gates these ~10.2 deg
+        # frames straight out. Hence optical_train_known below. See
+        # docs/adr/0027 and the third-rung amendment to docs/adr/0029.
         self.camType = "Debug hq"
         self.path = utils.pifinder_dir / "test_images"
         self.exposure_time = exposure_time
@@ -105,6 +108,18 @@ class CameraDebug(CameraInterface):
 
     def get_cam_type(self) -> str:
         return self.camType
+
+    def optical_train_known(self) -> bool:
+        """No. These frames are a recording, not a view through this device.
+
+        Whatever lens config states is a claim about glass that is not in the
+        loop, so pairing it with the sensor above produces a field of view
+        that describes nothing. Saying so is what keeps `--camera debug`
+        solving whatever the config happens to hold -- including frames a
+        developer drops into test_images/ from another train entirely, which
+        no derived gate could have anticipated.
+        """
+        return False
 
 
 def get_images(shared_state, camera_image, command_queue, console_queue, log_queue):

--- a/python/PiFinder/camera_interface.py
+++ b/python/PiFinder/camera_interface.py
@@ -287,6 +287,22 @@ class CameraInterface:
     def get_cam_type(self) -> str:
         return "foo"
 
+    def optical_train_known(self) -> bool:
+        """Whether these frames came through this device's own optics.
+
+        True for anything pointed at the sky, which is why it defaults that
+        way: a camera has to opt *out*, so a new hardware backend inherits the
+        FOV gate rather than silently losing it.
+
+        False is an **unknown optical train** (docs/ax/camera/CONTEXT.md): the
+        frames were captured through some other train, so the resolved one
+        describes this machine and not them. Two things follow, both handled
+        by the consumers rather than here -- the solver asserts no FOV gate,
+        and lens self-heal declines to infer a lens from a fitted FOV that
+        measured a recording. See docs/adr/0029.
+        """
+        return True
+
     def start_camera(self) -> None:
         pass
 
@@ -307,6 +323,18 @@ class CameraInterface:
                 camera_type = camera_type_str.split(" ")[1].lower()
                 shared_state.set_camera_type(camera_type)
                 logger.info(f"Camera type set to: {camera_type}")
+
+            # Published beside the sensor because it qualifies it: the sensor
+            # a playback camera declares is the one its *frames* were shot on,
+            # which is not the same claim a live camera makes.
+            train_known = self.optical_train_known()
+            shared_state.set_optical_train_known(train_known)
+            if not train_known:
+                logger.info(
+                    "Optical train is unknown: these frames did not come "
+                    "through this device's optics, so the solver gets no FOV "
+                    "gate and the lens cannot self-heal from them"
+                )
 
             # Check if auto-exposure was previously enabled in config
             config_exp = cfg.get_option("camera_exp")

--- a/python/PiFinder/integrator.py
+++ b/python/PiFinder/integrator.py
@@ -101,6 +101,14 @@ class LensSelfHeal:
       authoritative, so this only ever writes into an absence. That also means
       it writes at most once in the life of a device -- the write is what ends
       the condition it triggers on.
+    * **An unknown optical train never writes at all.** A fitted FOV measures
+      the train the frames passed through; under ``--camera debug`` that is
+      the train they were *recorded* on, so it says nothing about this
+      machine. Without this, a debug run on a config with no lens writes the
+      hq's ``25mm`` (the archived frames fit 10.20 deg, 1.3% off its derived
+      10.33) into that developer's config -- and a real imx462 attached
+      afterwards then derives 6.4 deg, solves nothing, and cannot heal,
+      because healing only writes into an absence that no longer exists.
     * **A fitted FOV matching no shipped lens writes nothing.** Third-party
       glass leaves the lens assumed and the gate wide, which is honest: we do
       not know its focal length, and a wrong write would be worse than none
@@ -115,8 +123,9 @@ class LensSelfHeal:
         self._shared_state = shared_state
         self._candidate: Optional[str] = None
         self._streak = 0
-        # Both latch to keep a per-frame condition from logging per frame.
+        # All three latch to keep a per-frame condition from logging per frame.
         self._logged_unidentified = False
+        self._logged_unknown_train = False
         self._disabled = False
 
     def observe(self, result: SuccessfulSolve) -> None:
@@ -132,6 +141,19 @@ class LensSelfHeal:
             self._disabled = True
 
     def _observe(self, result: SuccessfulSolve) -> None:
+        if not self._shared_state.optical_train_known():
+            # Checked before the lens, not after: this is not "nothing to
+            # heal" but "nothing here can heal anything", and the streak must
+            # not carry across into a later run on real optics.
+            if not self._logged_unknown_train:
+                self._logged_unknown_train = True
+                logger.info(
+                    "Optical train is unknown, so a fitted FOV measures the "
+                    "recording rather than this device; lens self-heal is off"
+                )
+            self._reset()
+            return
+
         lens_key = self._shared_state.camera_lens()
         if lens_is_stated(lens_key):
             # Nothing to heal -- and after a successful write this is the

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -979,26 +979,49 @@ def solver(
                     train = optical_train.resolve(
                         shared_state.camera_type(), shared_state.camera_lens()
                     )
+                    # Read live for the same reason the train is: the camera
+                    # process publishes this after the solver is already
+                    # looping, so latching it here would miss it.
+                    train_known = shared_state.optical_train_known()
                 except (BrokenPipeError, ConnectionResetError) as e:
                     logger.error(f"Lost connection to shared state manager: {e}")
                     continue
-                if train is not logged_train:
-                    logged_train = train
-                    logger.info(
-                        # Say which of the two it is: under an assumed lens
-                        # the gate is wider than the stated field of view
-                        # implies, and a reader diagnosing "why did it solve
-                        # / not solve" needs to know the lens is a fallback
-                        # rather than something the device was told.
-                        "Optical train: %s %s lens on %s, field of view "
-                        "%.2f deg, FOV gate [%.2f, %.2f]",
-                        "stated" if train.lens_stated else "assumed",
-                        train.lens.menu_label,
-                        shared_state.camera_type(),
-                        train.fov_degrees,
-                        *_fov_gate_bounds(train),
-                    )
-                    _warn_if_outside_solver_database(t3, train)
+                if (train, train_known) != logged_train:
+                    logged_train = (train, train_known)
+                    if not train_known:
+                        # The resolved train is still worth printing -- it is
+                        # what SQM and the frustum are using -- but saying it
+                        # without saying it describes the device rather than
+                        # the frames is how somebody concludes the gate is
+                        # wrong when there is no gate.
+                        logger.info(
+                            "Optical train: %s %s lens on %s (%.2f deg), but "
+                            "these frames did not come through it -- solving "
+                            "with no FOV gate",
+                            "stated" if train.lens_stated else "assumed",
+                            train.lens.menu_label,
+                            shared_state.camera_type(),
+                            train.fov_degrees,
+                        )
+                    else:
+                        logger.info(
+                            # Say which of the two it is: under an assumed
+                            # lens the gate is wider than the stated field of
+                            # view implies, and a reader diagnosing "why did
+                            # it solve / not solve" needs to know the lens is
+                            # a fallback rather than something the device was
+                            # told.
+                            "Optical train: %s %s lens on %s, field of view "
+                            "%.2f deg, FOV gate [%.2f, %.2f]",
+                            "stated" if train.lens_stated else "assumed",
+                            train.lens.menu_label,
+                            shared_state.camera_type(),
+                            train.fov_degrees,
+                            *_fov_gate_bounds(train),
+                        )
+                        # Only meaningful against a gate we are actually
+                        # going to hand over.
+                        _warn_if_outside_solver_database(t3, train)
 
                 # Every camera frame already carries a tiny radiometer sample
                 # reduced in the camera process. Collect all of them and publish
@@ -1076,12 +1099,22 @@ def solver(
                         # view before verification and rejects survivors after
                         # fitting, so this window has to describe the actual
                         # hardware or nothing solves. See docs/adr/0027.
-                        fov_estimate, fov_max_error = train.solver_fov_params()
+                        #
+                        # Under an **unknown optical train** there is nothing
+                        # to derive it from -- the frames came through some
+                        # other optics -- so no gate is passed at all rather
+                        # than a wrong one. Omitting costs the upper bound
+                        # that rejects confident mis-solves, which is a trade
+                        # only defensible because nothing is being pointed at
+                        # the sky. See the third-rung amendment to 0029.
+                        if train_known:
+                            (
+                                _solver_args["fov_estimate"],
+                                _solver_args["fov_max_error"],
+                            ) = train.solver_fov_params()
                         solution = t3.solve_from_centroids(
                             centroids,
                             (512, 512),
-                            fov_estimate=fov_estimate,
-                            fov_max_error=fov_max_error,
                             match_max_error=0.005,
                             return_matches=True,  # Required for SQM calculation
                             target_pixel=shared_state.target_pixel(),

--- a/python/PiFinder/state.py
+++ b/python/PiFinder/state.py
@@ -309,6 +309,11 @@ class SharedStateObj:
         # None means "not stated", which resolves to the sensor's shipped lens
         # -- that is what lets installs predating this setting keep working.
         self.__camera_lens = config.Config().get_option("camera_lens")
+        # Whether the frames arriving actually came through the optics the two
+        # halves above describe. True until a camera says otherwise, so the
+        # window before the camera process reports behaves like the hardware
+        # case rather than silently dropping the FOV gate on every boot.
+        self.__optical_train_known = True
         # Degrees the camera process rotates the solve/display image relative
         # to the stored raw frame (PIL CCW). None until the camera reports.
         self.__solve_image_rotation = None
@@ -395,6 +400,18 @@ class SharedStateObj:
         registered lens (see PiFinder.optics.LENSES) or None.
         """
         self.__camera_lens = v
+
+    def optical_train_known(self) -> bool:
+        """False when the frames did not come through this device's optics.
+
+        See ``CameraInterface.optical_train_known``. Read alongside
+        ``camera_type``/``camera_lens`` rather than instead of them: the train
+        still resolves, it just does not describe the frames.
+        """
+        return self.__optical_train_known
+
+    def set_optical_train_known(self, v: bool):
+        self.__optical_train_known = bool(v)
 
     def sats(self):
         return self.__sats

--- a/python/tests/test_camera_interface.py
+++ b/python/tests/test_camera_interface.py
@@ -120,3 +120,46 @@ class TestCaptureWithTimeout:
         assert cam.capture_calls == 2
         assert cam._capture_thread is not wedged_thread
         assert cam._capture_thread is None
+
+
+@pytest.mark.unit
+class TestOpticalTrainKnown:
+    """Which cameras are entitled to a derived FOV gate.
+
+    The default direction is the whole point: a camera has to opt *out*, so a
+    new hardware backend inherits the gate rather than silently losing it and
+    the mis-solve protection with it. See the third-rung amendment to
+    docs/adr/0029-fov-gate-width-follows-lens-confidence.md.
+    """
+
+    def test_a_camera_pointed_at_the_sky_defaults_to_known(self):
+        assert _ScriptedCamera().optical_train_known() is True
+
+    def test_the_debug_camera_declares_its_train_unknown(self):
+        """It replays a recording, so config's lens describes absent glass.
+
+        This is what keeps `--camera debug` solving on a config that states a
+        lens -- hq x 16mm gates [14.55, 19.69] and hq x 12mm [17.37, 23.49],
+        against frames that are 10.2 deg.
+        """
+        from PiFinder.camera_debug import CameraDebug
+
+        assert CameraDebug(exposure_time=400000).optical_train_known() is False
+
+    def test_the_debug_camera_still_declares_the_sensor_it_recorded_on(self):
+        # Unknown is about the *pairing*, not the sensor: SQM's profile lookup
+        # and the Lens menu still need a plausible half to resolve from.
+        from PiFinder.camera_debug import CameraDebug
+
+        assert CameraDebug(exposure_time=400000).get_cam_type() == "Debug hq"
+
+    def test_shared_state_assumes_known_before_any_camera_reports(self):
+        """The boot window every run passes through must keep its gate.
+
+        The camera process publishes this after the solver is already
+        looping, so a False default would drop the FOV gate on real hardware
+        for the first few frames of every boot.
+        """
+        from PiFinder.state import SharedStateObj
+
+        assert SharedStateObj().optical_train_known() is True

--- a/python/tests/test_lens_self_heal.py
+++ b/python/tests/test_lens_self_heal.py
@@ -42,9 +42,10 @@ class FakeConfig:
 
 
 class FakeSharedState:
-    def __init__(self, camera_type="imx462", camera_lens=None):
+    def __init__(self, camera_type="imx462", camera_lens=None, train_known=True):
         self._camera_type = camera_type
         self._camera_lens = camera_lens
+        self._train_known = train_known
         self.published = []
 
     def camera_type(self):
@@ -52,6 +53,12 @@ class FakeSharedState:
 
     def camera_lens(self):
         return self._camera_lens
+
+    def optical_train_known(self):
+        return self._train_known
+
+    def set_optical_train_known(self, value):
+        self._train_known = value
 
     def set_camera_lens(self, value):
         self._camera_lens = value
@@ -75,6 +82,11 @@ def _solve(fov):
 # solving on 2.6.2 while assuming the 16mm.
 TWELVE_MM_ON_IMX462 = build_optical_train("imx462", "12mm").fov_degrees
 SIXTEEN_MM_ON_IMX462 = build_optical_train("imx462", "16mm").fov_degrees
+
+# What tetra3 fits the archived frames in test_images/ at -- the frames the
+# debug camera replays. Measured, not derived; test_optics_solving.py asserts
+# the same figure against the real solver.
+DEBUG_FRAME_FITTED_FOV = 10.20
 
 
 def _feed(healer, fov, times):
@@ -247,6 +259,66 @@ class TestSelfHealHoldsOff:
 
         assert len(caplog.records) == 1
         assert "matches no lens" in caplog.records[0].getMessage()
+
+    def test_an_unknown_optical_train_never_promotes(self):
+        """The exact `--camera debug` case, which used to write.
+
+        The archived frames fit 10.20 deg, which is 1.3% off the hq's derived
+        10.33 -- comfortably inside LENS_IDENTIFY_TOLERANCE, so this is not a
+        measurement self-heal would reject on its merits. It has to be
+        declined on provenance: the fit measures the train the frames were
+        *recorded* on, and the developer's config is about a different
+        machine. Writing 25mm here is what leaves a real imx462 attached
+        afterwards deriving 6.4 deg and unable to heal its way back.
+        """
+        cfg = FakeConfig()
+        state = FakeSharedState(camera_type="hq", train_known=False)
+        healer = LensSelfHeal(cfg, state)
+
+        _feed(healer, DEBUG_FRAME_FITTED_FOV, LENS_IDENTIFY_CONSECUTIVE * 4)
+
+        assert "camera_lens" not in cfg.options
+        assert state.published == []
+        assert cfg.calls == []
+
+    def test_the_same_fit_would_have_been_promoted_on_real_optics(self):
+        # Pins the test above to provenance rather than to the number: change
+        # only train_known and the identical measurement writes.
+        cfg = FakeConfig()
+        state = FakeSharedState(camera_type="hq", train_known=True)
+        healer = LensSelfHeal(cfg, state)
+
+        _feed(healer, DEBUG_FRAME_FITTED_FOV, LENS_IDENTIFY_CONSECUTIVE)
+
+        assert cfg.options["camera_lens"] == "25mm"
+
+    def test_an_unknown_train_logs_once_not_once_per_frame(self, caplog):
+        cfg = FakeConfig()
+        state = FakeSharedState(camera_type="hq", train_known=False)
+        healer = LensSelfHeal(cfg, state)
+
+        with caplog.at_level("INFO", logger="IMU.Integrator"):
+            _feed(healer, DEBUG_FRAME_FITTED_FOV, 25)
+
+        assert len(caplog.records) == 1
+        assert "Optical train is unknown" in caplog.records[0].getMessage()
+
+    def test_a_run_does_not_survive_the_train_going_unknown(self):
+        """Agreement counted on real optics must not be spent on a recording.
+
+        Ordering matters here: the check sits ahead of the stated-lens branch
+        precisely so it resets the streak rather than falling through it.
+        """
+        cfg, state = FakeConfig(), FakeSharedState(camera_type="hq")
+        healer = LensSelfHeal(cfg, state)
+
+        _feed(healer, DEBUG_FRAME_FITTED_FOV, LENS_IDENTIFY_CONSECUTIVE - 1)
+        state.set_optical_train_known(False)
+        _feed(healer, DEBUG_FRAME_FITTED_FOV, 1)
+        state.set_optical_train_known(True)
+        _feed(healer, DEBUG_FRAME_FITTED_FOV, 1)
+
+        assert "camera_lens" not in cfg.options
 
 
 @pytest.mark.unit

--- a/python/tests/test_optics.py
+++ b/python/tests/test_optics.py
@@ -617,7 +617,15 @@ class TestDebugCameraProfile:
         """The frames in test_images/ measure ~10.2 degrees when solved.
 
         That is inside hq + 25mm's window and outside imx296 + 16mm's, which
-        is the entire reason the debug camera's declared sensor changed.
+        is why the debug camera's declared sensor changed under ADR 0027.
+
+        It is no longer what makes `--camera debug` solve, though, and reading
+        it that way is how the regression got missed: this fits only because
+        no lens is stated. State one and the same sensor derives 17.12 or
+        20.43 degrees. The gate is now omitted entirely under an **unknown
+        optical train** -- see TestOpticalTrainKnown in
+        test_camera_interface.py and the no-gate cases in
+        test_optics_solving.py.
         """
         measured_debug_frame_fov = 10.2
 

--- a/python/tests/test_optics_solving.py
+++ b/python/tests/test_optics_solving.py
@@ -14,7 +14,7 @@ import pytest
 from PIL import Image
 
 from PiFinder import utils
-from PiFinder.optics import build_optical_train
+from PiFinder.optics import LENSES, build_optical_train
 
 pytestmark = pytest.mark.integration
 
@@ -113,3 +113,83 @@ def test_a_mis_stated_train_rejects_a_perfectly_good_frame(
     """
     solution = _solve(solver, debug_centroids[frame], build_optical_train("imx296"))
     assert solution.get("RA") is None
+
+
+# Every lens a config can name. The debug camera's sensor is fixed at hq, so
+# these are exactly the trains `--camera debug` can find itself resolving --
+# and only one of them is the one the frames were shot through.
+STATEABLE_LENSES = tuple(LENSES)
+
+
+def _solve_without_a_gate(solver, centroids):
+    """What the solver does under an **unknown optical train**.
+
+    Mirrors `solver.py`'s branch rather than re-deriving anything: when the
+    frames did not come through this device's optics there is nothing to
+    derive a gate from, so `fov_estimate`/`fov_max_error` are not passed.
+    """
+    return solver.solve_from_centroids(
+        centroids,
+        (512, 512),
+        match_max_error=0.005,
+    )
+
+
+@pytest.mark.parametrize("frame", DEBUG_FRAMES)
+@pytest.mark.parametrize("lens_key", STATEABLE_LENSES)
+def test_a_stated_lens_gates_out_the_debug_frames(
+    solver, debug_centroids, frame, lens_key
+):
+    """The regression itself, asserted rather than described.
+
+    ADR 0027 fixed the debug camera's *sensor* and left its lens reading live
+    from config, so stating one pairs hq with glass that is not in the loop:
+    16mm implies 17.12 deg and 12mm 20.43, against 10.2 deg frames. Only the
+    25mm -- the lens these frames were actually shot through -- still solves,
+    which is precisely why nobody noticed until a config stated something.
+    """
+    train = build_optical_train("hq", lens_key)
+    solution = _solve(solver, debug_centroids[frame], train)
+
+    if lens_key == "25mm":
+        assert solution.get("RA") is not None
+    else:
+        assert solution.get("RA") is None, (
+            f"{lens_key} on hq derives {train.fov_degrees:.2f} deg; "
+            f"if this now solves the gate is no longer doing its job"
+        )
+
+
+@pytest.mark.parametrize("frame", DEBUG_FRAMES)
+@pytest.mark.parametrize("lens_key", STATEABLE_LENSES)
+def test_no_gate_solves_the_debug_frames_whatever_config_states(
+    solver, debug_centroids, frame, lens_key
+):
+    """The fix: `--camera debug` works on any config, including yours.
+
+    The lens is parametrised but unused by the solve on purpose -- that is
+    the property under test. Under an unknown optical train the config's lens
+    cannot reach the solver at all, so every one of these has to pass.
+    """
+    solution = _solve_without_a_gate(solver, debug_centroids[frame])
+
+    assert solution.get("RA") is not None, f"failed to solve with {lens_key} stated"
+    assert solution["FOV"] == pytest.approx(MEASURED_DEBUG_FRAME_FOV, abs=0.1)
+
+
+@pytest.mark.parametrize("frame", DEBUG_FRAMES)
+def test_dropping_in_frames_from_another_train_still_solves(
+    solver, debug_centroids, frame
+):
+    """Why no gate, rather than the camera declaring the frames' own FOV.
+
+    A developer replacing test_images/ with frames off their own device is
+    the main use of debug mode. Any declared gate -- including one centred on
+    10.2 deg -- would reject those, which is the bug we are fixing wearing a
+    different hat. Asserted here with the imx296/12mm gate (16.38 deg) as the
+    stand-in for "a train nobody anticipated": it rejects these frames, and
+    no-gate does not.
+    """
+    foreign = build_optical_train("imx296", "12mm")
+    assert _solve(solver, debug_centroids[frame], foreign).get("RA") is None
+    assert _solve_without_a_gate(solver, debug_centroids[frame]).get("RA") is not None


### PR DESCRIPTION
Grilling session output for "debug mode stopped solving after the 2.6.2/3 lens system". Two commits: the decision (CONTEXT.md + ADR 0029 amendment), then the code.

## The bug

`--camera debug` derives its FOV gate from `hq × whatever lens the config states`. ADR 0027 fixed the *sensor* half (relabelled the debug camera `imx296` → `hq`, PR #609) and left the *lens* half reading live from `camera_lens`, which `resolve_lens` honours whatever profile it is handed. Measured against the real solver and the shipped `default_database.npz`:

| train | derived FOV | gate | debug_01 / debug_02 |
|---|---|---|---|
| hq + no stated lens | 10.33° | [8.78, 11.88] | solves (fits 10.20°) |
| hq + stated `25mm` | 10.33° | [8.78, 11.88] | solves |
| hq + stated `16mm` | 17.12° | [14.55, 19.69] | **no solve** |
| hq + stated `12mm` | 20.43° | [17.37, 23.49] | **no solve** |

So anyone who has opened the Lens menu — and every device whose lens 0029's self-heal has written — loses debug mode. `tests/test_optics_solving.py` missed it because every case called `build_optical_train("hq")` with no lens key, exercising only the assumed path.

**Second bug, live since 0029, fixed here too.** With no `camera_lens` in config, debug mode solves at 10.20°, `identify_lens_from_fitted_fov` matches that to the hq's `25mm` within 1.3%, and the integrator states it. It is in Rich's own log firing on 2026-08-17:

```
Lens self-heal: 3 solves fitted 10.20 deg, which is the 25mm (10.33 deg derived).
Stating it in config; the FOV gate narrows from the assumed range to this lens...
```

Attach a real imx462 afterwards and the now-*stated* 25 mm derives 6.4°, nothing solves, and self-heal can't undo it — it only ever writes into an absence.

## The decision

A new term, **unknown optical train**: a camera whose frames did not come through this device's optics. It extends 0029's ladder rather than special-casing the debug camera —

**stated → ±15% · assumed → union over shipped lenses · unknown → no gate at all**

— and one rule covers both bugs: nothing about the device may be *asserted* about the frames (no FOV hint), and nothing about the device may be *inferred* from them (no self-heal write).

Rejected, with reasons in the ADR: declaring a lens from the camera (needs a second writer for `camera_lens`, and gates out frames you drop in yourself — the main use of debug mode); emulating the configured train (right answer to a different question, wants captures we don't have); a database-range gate (no-hint with extra steps); rejecting non-shipped pairings in `resolve_lens` (fixes this *and* the sensor-swap deadlock, but makes a user's statement conditionally non-authoritative — a direct contradiction of 0027, and it deserves its own decision).

Cost of no-hint, measured: all three widths return identical RA/Dec, `Matches` and `Prob` on the shipped frames, within ~1 ms. What it gives up is the upper bound that rejected confident mis-solves in 0029's noise trials — a protection that matters to a device under the stars, and nothing is under the stars in debug mode.

## What changed

- `CameraInterface.optical_train_known()` defaults **True**, so a camera has to opt *out* — a new hardware backend inherits the gate rather than silently losing it. `CameraDebug` returns False.
- Published beside `camera_type` in `get_image_loop`; `SharedStateObj` defaults it True so the boot window before the camera reports keeps its gate on real hardware.
- `solver.py` omits `fov_estimate`/`fov_max_error` entirely, and says so in the one-shot train log line. `_warn_if_outside_solver_database` is skipped — it's only meaningful against a gate we're actually handing over.
- `LensSelfHeal._observe` returns early, ahead of the stated-lens branch so a streak counted on real optics can't be spent on a recording.

Scope stops there. The **frustum** keeps deriving from the configured optics — it answers "what would my camera image", a question about the device, and propagating would delete a frustum that is *correct* on a dev laptop (10.33° vs 10.20° frames). SQM is unaffected: only `camera_pi` publishes radiometer samples.

## Verification

**End to end, not just unit tests.** Launched headless with `camera_lens: "16mm"` stated — the exact config that produced zero solves:

```
"camera_solve": { "RA": 296.37, "Dec": -1.70, "Roll": 312.18 },
"constellation": "Aql", "FOV": 10.2016, "Matches": 21, "solve_source": "CAM"
```

with `Optical train is unknown ... lens self-heal is off` in the log and the config left unwritten. (A stated 16mm gates [14.55, 19.69], so a solve is only possible via the no-gate branch.)

- 1313 passed, `-m "unit or smoke"`; 20 passed in `test_optics_solving.py`
- ruff check + format clean; mypy clean on all five touched modules
- Two `-m integration` failures (`test_radec_entry`, `test_all_ui_modules_covered`) reproduce on untouched `origin/main` — the second only when `test_battery_titlebar_icon.py`'s `_BareModule` helper is loaded in the same session. Pre-existing, unrelated.

New tests: every lens a config can name, asserting both that the derived gate rejects these frames and that no-gate solves them; the self-heal bar plus a control showing the identical fit *would* have promoted on real optics; the opt-out default in both directions.

## Not in scope

The **sensor-swap deadlock** — switch imx296 → hq from the Camera Type menu with a stated 16 mm → 17.12°, no solves, no way to measure out. Real hardware, real statement, different failure class. Rich says it's filed; the closest issue I found is #613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUbR3ryYDL7RizsNhPxGkX
