### PR TITLE
feat(gps): show the last GPS event and its age on the STATUS screen

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -6,6 +6,7 @@ PiFinder is a multi-process Raspberry Pi finder/plate-solver. These contexts eac
 
 - [Catalog](./docs/ax/catalog/CONTEXT.md) — loads, filters, searches astronomical catalogs (M, NGC, IC, WDS, planets, comets) for the UI.
 - [Positioning](./docs/ax/positioning/CONTEXT.md) — acquires telescope pointing via plate-solving and IMU dead-reckoning; publishes the canonical "where am I looking?" answer.
+- [GPS](./docs/ax/gps/CONTEXT.md) — acquires the observer's position and the wall-clock time from a satellite receiver, behind three interchangeable backends (raw UBX, gpsd, replay/fake).
 - [SQM](./docs/ax/sqm/CONTEXT.md) — estimates sky brightness in mag/arcsec² from solved frames; also produces the noise-floor signal auto-exposure consumes.
 - [Equipment](./docs/ax/equipment/CONTEXT.md) — models the user's telescopes and eyepieces; supplies the active optics that drive magnification, true field of view, and object-image orientation.
 - [UI](./docs/ax/ui/CONTEXT.md) — the on-device menu system: menu tree, screen modules, the navigation stack and key dispatch, marking menus.
@@ -19,6 +20,9 @@ PiFinder is a multi-process Raspberry Pi finder/plate-solver. These contexts eac
 ## Relationships
 
 - **Positioning → Catalog**: Catalog reads RA/Dec/Alt/Az from `shared_state.solution()` to compute visibility and "near me" lists.
+- **GPS → system-wide**: the GPS process is the only subsystem process that does **not** hold `shared_state`; it publishes `("fix" | "time" | "satellites", payload)` onto `gps_queue` and the main loop writes them into shared state on its behalf, applying the **location source** precedence rules (a `WEB`/`MANUAL`/`CONFIG:`/`replay` location outranks the receiver) and discarding any fix whose **position error** is worse than the stored one. `gps_queue` flows only *into* main — there is no main → GPS channel.
+- **GPS → Positioning**: the stored location supplies the observer's lat/lon/altitude and the wall-clock time that turn a plate-solved RA/Dec into Alt/Az. Beware the word **solution**: in GPS it is the receiver's navigation solution, in Positioning it is a plate-solve result, and both hang off `shared_state`.
+- **GPS → UI**: `UIGPSStatus` renders lock and satellite state, and can publish a fix of its own back onto `gps_queue` (save/lock location). The STATUS screen's **comms row** reports link liveness from the parser's **event** stream, including markers for frames that could not be decoded (see [ADR 0032](./docs/adr/0032-ubx-parser-yields-undecodable-frames.md)).
 - **Positioning → SQM**: SQM is a side effect of every successful plate solve in the solver process; it reuses the tetra3 `matched_centroids` and the camera frame.
 - **SQM / Camera units boundary**: SQM photometry and its pedestal diagnostics use raw sensor ADU. The Camera background controller measures processed 8-bit images and uses its separate shared 10 ADU floor; raw SQM thresholds must not cross that boundary.
 - **Positioning → Camera**: `Matches` is published on every solve attempt (success or failure) as the feedback signal for solver-driven auto-exposure.

--- a/docs/adr/0032-ubx-parser-yields-undecodable-frames.md
+++ b/docs/adr/0032-ubx-parser-yields-undecodable-frames.md
@@ -14,6 +14,6 @@ Anything consuming the parser's output must tolerate a `class` that is not a rea
 
 The **comms row** on the STATUS screen is the only consumer that reads markers, and it is what makes the distinction visible: a churning `?CKSUM` says bytes are arriving corrupted, a churning `?0135` says the receiver is emitting something we have no parser for, and a frozen name with a rising age says the link is gone.
 
-A resync storm can yield markers far faster than real messages arrive, so the publisher caps how often it forwards events onto `gps_queue`; the cap is a rate limit on *reporting*, not on parsing.
+A resync storm can yield markers far faster than real messages arrive, so the publisher caps how often it forwards events onto `gps_queue`; the cap is a rate limit on *reporting*, not on parsing. Only the event's name is forwarded — the main process stamps arrival with its own monotonic clock, because that is the process the row renders in and `time.monotonic()` is not comparable across processes.
 
 > Numbering note: `0031` is claimed independently by two in-flight branches (the chart center-object readout and the secure-WiFi refresh). This ADR takes `0032` to avoid becoming a third; resolving the `0031` collision is out of scope here.

--- a/docs/adr/0032-ubx-parser-yields-undecodable-frames.md
+++ b/docs/adr/0032-ubx-parser-yields-undecodable-frames.md
@@ -1,0 +1,19 @@
+# The UBX parser yields markers for frames it cannot decode
+
+`UBXParser.parse_messages` used to yield only frames it successfully decoded: an unregistered class/id became `{"error": "Unknown message type"}` and was dropped by the `if "class" in parsed` guard, and a checksum failure was logged at WARNING and dropped. Nothing above the parser could tell "no bytes arriving" from "bytes arriving that we don't understand" — which made a receiver talking an unexpected dialect, or running at the wrong baud rate, look pixel-identical to an unplugged GPS. The parser now yields a **marker** for both cases (`{"class": "?XXYY"}` naming the two message bytes, `{"class": "?CKSUM"}` for a checksum mismatch), widening its output contract from *messages* to *events*.
+
+## Considered options
+
+- **A stats dict on the parser instance.** Keeps the yield contract untouched, but `process_messages` receives `parser.parse_messages` as a bare bound method and never sees the parser object, so exposing counters means changing the signature at both call sites (`gps_ubx`, `gps_fake`) plus the dispatch tests — more churn than the thing it was avoiding, in exchange for a second, parallel egress path for the same information.
+- **A separate counter argument threaded through `process_messages`.** Same churn, and it splits "what arrived" across two mechanisms that have to be kept in step.
+- **Leave it alone and infer from silence.** Rejected because silence is precisely the ambiguity being removed.
+
+## Consequences
+
+Anything consuming the parser's output must tolerate a `class` that is not a real message type. Today that is only `process_messages`, whose `elif` chain ignores unrecognised classes harmlessly, so no dispatch behaviour changes — but the guard is now "is this a class I handle", not "is this a message". The `?` prefix is reserved for markers and must not be used by any real message class.
+
+The **comms row** on the STATUS screen is the only consumer that reads markers, and it is what makes the distinction visible: a churning `?CKSUM` says bytes are arriving corrupted, a churning `?0135` says the receiver is emitting something we have no parser for, and a frozen name with a rising age says the link is gone.
+
+A resync storm can yield markers far faster than real messages arrive, so the publisher caps how often it forwards events onto `gps_queue`; the cap is a rate limit on *reporting*, not on parsing.
+
+> Numbering note: `0031` is claimed independently by two in-flight branches (the chart center-object readout and the secure-WiFi refresh). This ADR takes `0032` to avoid becoming a third; resolving the `0031` collision is out of scope here.

--- a/docs/ax/gps/CONTEXT.md
+++ b/docs/ax/gps/CONTEXT.md
@@ -72,6 +72,10 @@ _Avoid_: provider, origin, fix source.
 The single `UIStatus` row reporting GPS link liveness, showing the name of the most recent **event** and the seconds elapsed since it arrived. A churning name means events are flowing; a frozen name with a rising age means the link died; `?XXYY` or `?CKSUM` mean bytes are arriving that we cannot decode; `--` means nothing has ever been received. Its age is derived from a **monotonic** stamp, never wall clock, because the GPS is what *sets* the wall clock.
 _Avoid_: GPS status (that is the whole `UIGPSStatus` screen), message counter, heartbeat.
 
+**Comms stamp**:
+The monotonic reading recorded when a comms **event** is drained off **gps_queue** — taken by the *main* process, not the **GPS process**, so it can be subtracted from the reading the **comms row** takes when it renders. Only the event's name travels over the queue. The difference between the two is queue latency, well under one redraw.
+_Avoid_: arrival time / timestamp unqualified (both read as wall clock), send time.
+
 ## Flagged ambiguities
 
 - **"the GPS thread"** — there isn't one. It is a **GPS process**, and it is the only subsystem process that does not receive `shared_state`. Anyone reasoning about how to get data out of it from the "thread" framing will reach for shared memory that does not exist.
@@ -80,7 +84,7 @@ _Avoid_: GPS status (that is the whole `UIGPSStatus` screen), message counter, h
 - **A worse fix is silently discarded** — the main loop only applies an incoming fix when its **position error** is *smaller* than the stored one. A receiver that degrades (antenna knocked, satellites lost) leaves the old position and its lock state standing indefinitely, with no on-screen signal that the fix is stale. This is deliberate but surprising.
 - **`class` collides across contexts** — a GPS **message**'s `class` is a wire message type (`NAV-SOL`). In `gps_gpsd` it is gpsd's own tag (`TPV`). Neither is a Python class. Say "message class" or, better, name the message.
 - **"solution"** — in this context a solution is the receiver's *navigation* solution. In [Positioning](../positioning/CONTEXT.md) a solution is a *plate-solve* result, and both are reachable from `shared_state`. Never use the bare word across the boundary.
-- **Comms age must be monotonic** — a GPS-derived timestamp sets the system clock, so an age computed from wall clock jumps or inverts the moment a fix lands. `time.monotonic()` is system-wide on Linux and safe to compare across processes on the same host.
+- **Comms age must be monotonic, and from one process** — a GPS-derived timestamp sets the system clock, so an age computed from wall clock jumps or inverts the moment a fix lands. Monotonic solves that but introduces a second trap: `time.monotonic()`'s reference point is *undefined*, and on macOS it is process start, so subtracting one process's reading from another's yields the gap between their launches. On a dev machine that reads as a permanently several-second-old GPS link. Hence the **comms stamp** is taken by the main process on receipt: only the event name crosses the process boundary.
 
 ## Example dialogue
 

--- a/docs/ax/gps/CONTEXT.md
+++ b/docs/ax/gps/CONTEXT.md
@@ -1,0 +1,101 @@
+# GPS
+
+The GPS context acquires the observer's position and the wall-clock time from a satellite receiver, and publishes them as a **fix** and a **time** for the rest of the system. It runs as its own process behind one of three interchangeable **backends**, and — unlike every other subsystem process — it does not hold `shared_state`; everything it produces reaches the system through `gps_queue`.
+
+## Language
+
+### Processes and plumbing
+
+**GPS process**:
+The `multiprocessing.Process` named `"GPS"` spawned in `main.py`, running the selected backend's `gps_monitor`. It receives exactly three arguments — `gps_queue`, `console_queue`, `log_queue` — and notably **not** `shared_state`, which every other subsystem process does get. Any new fact the GPS process wants to publish therefore travels on `gps_queue`.
+_Avoid_: GPS thread (it is a process, and the distinction decides what transports are available), GPS service, GPS daemon (that is **gpsd**, a separate OS-level thing).
+
+**GPS backend**:
+One of three interchangeable modules providing `gps_monitor(gps_queue, console_queue, log_queue)`: `gps_ubx` (parses raw UBX binary read from gpsd's socket — the default), `gps_gpsd` (consumes gpsd's own decoded TPV/SKY dicts via `gpsdclient`), and `gps_fake` (replays a recorded `.ubx` capture, or synthesises a slowly-improving fix). Chosen at startup from the `gps_type` **config_option**, which defaults to `ublox`. `gps_ubx` and `gps_fake` share the whole UBX decode path; `gps_gpsd` shares none of it.
+_Avoid_: GPS driver, GPS mode, GPS source ("source" is the **location source**, a different thing).
+
+**gpsd**:
+The OS-level GPS daemon that owns the serial device. Both real backends talk to it — `gps_ubx` opens a raw socket to port 2947 and asks for binary passthrough, `gps_gpsd` uses its decoded JSON. Its serial baud rate is synced from the `gps_baud_rate` **config_option** at startup.
+_Avoid_: the GPS daemon, the GPS service (ambiguous with the **GPS process**).
+
+**gps_queue**:
+The many-producer, single-consumer queue drained by the main loop, carrying `(tag, payload)` tuples. Despite living in `command_queues["gps"]`, it is an **inbox to the main process**, not a command channel *to* the GPS process — `UIGPSStatus` also publishes onto it, and nothing the main process puts there is ever read by the GPS process. There is no main → GPS channel at all.
+_Avoid_: GPS command queue (it commands nothing), GPS channel.
+
+### On the wire
+
+**Frame**:
+One delimited, checksum-verified UBX packet located in the incoming byte stream: sync bytes, class, id, length, payload, checksum. A frame is a *transport* unit and exists only on the UBX path — `gps_gpsd` receives decoded dicts and has no frames at all.
+_Avoid_: packet, sentence (an NMEA word), UBX message (a frame may fail to become a **message**).
+
+**Message**:
+A decoded `dict` carrying a `class` key naming what it is: `NAV-SOL`, `NAV-SAT`, `NAV-DOP`, `NAV-TIMEGPS`, `NAV-PVT`, `NAV-SVINFO` on the UBX path, `TPV` and `SKY` on the gpsd path. Messages are what the dispatcher acts on. One **frame** yields at most one message.
+_Avoid_: reading, record, sample.
+
+**Marker**:
+A synthesised **event** standing in for a **frame** that could not become a **message** — either its class/id has no registered parser (`?XXYY`, naming the two bytes) or its checksum failed (`?CKSUM`). Markers exist so that "the receiver is transmitting something we cannot read" is observable, instead of being indistinguishable from silence. The dispatcher ignores them; only the **comms row** consumes them. See [ADR 0032](../../adr/0032-ubx-parser-yields-undecodable-frames.md).
+_Avoid_: error, unknown message (a marker is not a message), garbage.
+
+**Event**:
+The union of **message** and **marker** — everything the parser yields. The right word when talking about GPS link activity in general, because liveness is about events arriving, not about any of them being useful.
+_Avoid_: message (when markers are included too), traffic, activity.
+
+### The fix
+
+**Fix**:
+The position result published as `("fix", {...})`: latitude, longitude, altitude, **position error**, **lock**, **lock type**, and a **location source**. Emitted per qualifying NAV-SOL or NAV-PVT.
+_Avoid_: position (reserve for the coordinate pair itself), solution (that is the Positioning context's plate-solve result — a *completely* different thing that also lives in `shared_state`).
+
+**Lock**:
+A sticky boolean meaning "this connection has, at least once, produced a fix whose reported error was under 50 km" (`MAX_GPS_ERROR`). It latches on and is never cleared for the life of a **GPS process** connection. It says the receiver got far enough to be believed once, not that the current fix is good.
+_Avoid_: treating it as current-fix quality, "has signal", "locked on".
+
+**Lock type**:
+The receiver's own fix mode, `0`–`3`, carried through from the UBX `gpsFix` / gpsd `mode` field: no fix, dead-reckoning, 2D, 3D. Independent of **lock** — and it is `lock_type`, not `lock`, that `UIGPSStatus` tests to decide whether to say "GPS Locked".
+_Avoid_: fix quality, lock strength, conflating with **lock**.
+
+**Position error**:
+The receiver's reported horizontal position uncertainty in metres (`ecefpAcc` from NAV-SOL, `hAcc` from NAV-PVT), stored as `error_in_m`. It gates whether a new fix is allowed to replace the stored **location** at all.
+_Avoid_: accuracy (it is an error bound, and larger is worse), HDOP (a separate dimensionless quantity).
+
+**Sats seen** / **sats used**:
+Satellites the receiver is tracking, and the subset it used in the navigation solution. Published together as a `(seen, used)` tuple and always held so that `seen >= used`, since a satellite contributing to the solution is by definition being tracked. Several message classes carry only `used`, so the floor is what stops the display reading `0/9`.
+_Avoid_: satellites in view (that is a wider set including ones not tracked), satellite count (which one?), nSat/uSat in prose.
+
+**Location source**:
+A string on the stored location recording where it came from — `GPS`, `WEB`, `MANUAL`, `CONFIG:<name>`, `Saved: <name>`, `replay`. It encodes **precedence**: a fix from the GPS process will not overwrite a location whose source is `WEB`, `MANUAL`, `replay`, or a `CONFIG:` entry. A user or a telemetry replay outranks the receiver.
+_Avoid_: provider, origin, fix source.
+
+### Diagnostics
+
+**Comms row**:
+The single `UIStatus` row reporting GPS link liveness, showing the name of the most recent **event** and the seconds elapsed since it arrived. A churning name means events are flowing; a frozen name with a rising age means the link died; `?XXYY` or `?CKSUM` mean bytes are arriving that we cannot decode; `--` means nothing has ever been received. Its age is derived from a **monotonic** stamp, never wall clock, because the GPS is what *sets* the wall clock.
+_Avoid_: GPS status (that is the whole `UIGPSStatus` screen), message counter, heartbeat.
+
+## Flagged ambiguities
+
+- **"the GPS thread"** — there isn't one. It is a **GPS process**, and it is the only subsystem process that does not receive `shared_state`. Anyone reasoning about how to get data out of it from the "thread" framing will reach for shared memory that does not exist.
+- **"GPS messages never leave the GPS process"** — they already leave three ways: decoded results on `gps_queue`, a `"GPS: Locked"` note on `console_queue`, and *every* parsed message logged at DEBUG through the multiproc log queue (there is a ready-made `logconf_gps.json` for exactly this). What is missing is a *live, on-device, no-restart* view, not egress.
+- **`lock` vs `lock_type`** — different facts, and the UI mixes them. `lock` is a sticky "we believed a fix once this connection"; `lock_type` is the receiver's current 0–3 mode. `UIGPSStatus`'s headline reads `lock_type > 1` while its detail line reads `lock`, so the two can legitimately disagree on screen. Name which one you mean.
+- **A worse fix is silently discarded** — the main loop only applies an incoming fix when its **position error** is *smaller* than the stored one. A receiver that degrades (antenna knocked, satellites lost) leaves the old position and its lock state standing indefinitely, with no on-screen signal that the fix is stale. This is deliberate but surprising.
+- **`class` collides across contexts** — a GPS **message**'s `class` is a wire message type (`NAV-SOL`). In `gps_gpsd` it is gpsd's own tag (`TPV`). Neither is a Python class. Say "message class" or, better, name the message.
+- **"solution"** — in this context a solution is the receiver's *navigation* solution. In [Positioning](../positioning/CONTEXT.md) a solution is a *plate-solve* result, and both are reachable from `shared_state`. Never use the bare word across the boundary.
+- **Comms age must be monotonic** — a GPS-derived timestamp sets the system clock, so an age computed from wall clock jumps or inverts the moment a fix lands. `time.monotonic()` is system-wide on Linux and safe to compare across processes on the same host.
+
+## Example dialogue
+
+> **Dev:** I want to show whether we're getting GPS messages. Can I read the message list out of shared state?
+>
+> **Domain:** There isn't one, and the GPS process can't write to shared state anyway — it only gets three queues. Everything it publishes goes over `gps_queue` and the main loop puts it into shared state on its behalf.
+>
+> **Dev:** Fine, I'll send a command to the GPS process asking it to start reporting.
+>
+> **Domain:** You can't. `gps_queue` looks like a command queue because of where it's stored, but it only flows *into* main — the GPS process never reads it. There's no main-to-GPS channel at all. Publish unconditionally instead.
+>
+> **Dev:** So if the row is empty, the GPS is dead?
+>
+> **Domain:** Careful. Empty means no **event** has *ever* arrived. A dead link shows the last event's name frozen with a climbing age. And if you see `?0135` or `?CKSUM` churning, the receiver is very much alive — we just can't decode what it's saying, which is usually a baud rate or the wrong receiver.
+>
+> **Dev:** And if it says locked I can trust the position?
+>
+> **Domain:** Ask which "locked". `lock` latches the first time we believed a fix and never clears. `lock_type` is the receiver's current mode. And remember a worse fix never overwrites a better one, so a good position can outlive the conditions that produced it.

--- a/gps-comms-row-plan.md
+++ b/gps-comms-row-plan.md
@@ -1,0 +1,109 @@
+# GPS comms row — implementation plan
+
+**Goal:** answer "are we receiving GPS messages?" at a glance, on the device, with no restart and no second machine.
+
+**Shape:** one row on the STATUS screen naming the most recent GPS **event** and how long ago it arrived.
+
+```
+GPS MSG TIMEGPS  0.4s
+```
+
+## What the row tells you
+
+| On screen | Meaning |
+|---|---|
+| `SOL` / `DOP` / `TIMEGPS` churning, age near 0 | Healthy. The name changing frame to frame is itself the liveness signal — readable across a dark field without parsing digits. |
+| `?0135` churning | Receiver is transmitting, but in a dialect we have no parser for. Wrong receiver, or a u-blox variant emitting IDs we don't register. |
+| `?CKSUM` churning | Bytes arriving corrupted. Baud mismatch (`gps_baud_rate` is user-editable) or bad wiring. |
+| name frozen, age climbing | The link died. The name tells you what it was doing when it stopped. |
+| `--` | Nothing has *ever* been received this session. |
+
+All four failure modes discriminated in one 21-character row. Today every one of them looks identical from anywhere above the parser.
+
+## Decisions taken (and why)
+
+1. **Live instrument, not a log view.** Every parsed message is *already* logged at DEBUG and there is a ready-made `logconf_gps.json`, but reaching it means switching log config, restarting the app, reproducing the fault, then reading a text file from another device. Unusable in the field.
+2. **Capture at the frame layer, not just the message layer.** `_parse_ubx` silently drops any class/id it has no parser for, so "unintelligible" and "absent" are currently the same observation.
+3. **One readout covering both backends.** `gps_gpsd` has no frames at all — its message half works unchanged, its frame-level events simply never occur.
+4. **A menu item, not a key chord.** Originally scoped as SQUARE on the status screen; landed as its own discoverable, translatable entry. In the end the readout collapsed into a single status row, so no new screen is needed at all.
+5. **Age + last event name, not a rate.** u-blox emits in per-epoch **bursts**, so a one-second window alternates between roughly 5 and roughly 10 and never settles. Age needs no window, is immune to burstiness, and reports *when* a dead link died — which a rate cannot.
+6. **The parser yields markers for undecodable frames.** See [ADR 0032](docs/adr/0032-ubx-parser-yields-undecodable-frames.md).
+
+## Rejected
+
+- **A ring buffer of recent messages in `shared_state`.** The GPS process does not receive `shared_state` — it gets `(gps_queue, console_queue, gps_logqueue)` and nothing else, so this needs a new process argument. Worse, `UIStatus.update()` runs at the full 30 fps target with no throttle, so a whole-buffer copy back through the manager proxy would run 30×/second.
+- **A dedicated GPS debug screen.** Designed in full, then dropped: a single row answers the actual question, and the screen would have been a second thing to navigate to while cold.
+- **On-demand capture (press a key to start).** There is no main → GPS channel. `gps_queue` looks like one because it lives in `command_queues["gps"]`, but it flows only *into* main. Always-on also wins on merit: the age is already correct the instant you look, with no warm-up.
+- **A once-per-second aggregate.** Would freeze the event name for a whole second and quantise the age, destroying the churn signal the design rests on.
+
+## Implementation
+
+### `PiFinder/gps_ubx_parser.py`
+
+- `_parse_ubx`: for an unregistered `(class, id)`, return `{"class": f"?{msg_class:02X}{msg_id:02X}"}` instead of `{"error": "Unknown message type"}`, so the existing `if "class" in parsed` guard lets it through.
+- `parse_messages`: on checksum mismatch, `yield {"class": "?CKSUM"}` alongside the existing WARNING.
+
+Reserve the `?` prefix for markers. No real message class may start with it.
+
+### `PiFinder/gps_ubx.py` — `process_messages`
+
+Publish one comms event at the top of the `async for` loop, before the dispatch chain, so *every* event counts including ones we parse but don't act on:
+
+```python
+_publish_comms(gps_queue, msg_class, clock)
+```
+
+- Send the **raw** class (`NAV-TIMEGPS`); presentation belongs to the UI.
+- Payload `("comms", (class_name, clock()))`.
+- **Rate-cap forwarding to ~20/s.** A resync storm can yield markers far faster than real messages arrive, and the `.ubx` replay path runs with `wait=0`. 20 Hz is well past perceptible against a 30 fps redraw, and it bounds worst-case queue traffic. This caps *reporting*, not parsing.
+
+Steady-state cost is a handful of pipe writes per second against backpressure thresholds of 10 and 50, on a queue the main loop drains to empty 30×/second. The throttles only bite when the main loop is already stalled, where slowing GPS is the intended behaviour.
+
+### `PiFinder/gps_gpsd.py`
+
+Same publish in the `dict_stream` loop, using `time.monotonic()` and the same cap. Note the existing `filter=["TPV", "SKY"]` means this path can only ever report those two classes — the row is a weaker instrument on gpsd, and deliberately so rather than widening the filter as a side effect.
+
+### `PiFinder/gps_fake.py`
+
+The `.ubx` replay path reuses `process_messages` and gets this free. Add a publish to the synthetic branch too (class `FAKE`) so the row is live under `-fh` and the feature is developable without hardware.
+
+### `PiFinder/state.py`
+
+`gps_comms()` / `set_gps_comms()` and a `self.__gps_comms = None`, shaped exactly like the existing `sats` pair.
+
+### `PiFinder/main.py`
+
+One branch in the existing `gps_queue` drain:
+
+```python
+if gps_msg == "comms":
+    shared_state.set_gps_comms(gps_content)
+```
+
+### `PiFinder/ui/status.py`
+
+- Add `"GPS MSG"` to `status_dict`, positioned after `"GPS LCK"` to group the four GPS rows. The key is exactly 7 characters, which is the width `_render_row` pads to. Status keys are untranslated literals throughout, so no `_()` — consistent with every existing row.
+- Format in `update_status_dict` from `shared_state.gps_comms()`:
+  - `None` → `"--"`
+  - strip a leading `NAV-`: `TIMEGPS` and `POSECEF` (7) are the longest, versus `NAV-TIMEGPS` (11) which would not fit
+  - age from `time.monotonic() - stamp`, bucketed to stay ≤ 5 chars: `<100s` → `47.2s`, `<100m` → `12m`, else `2h`
+
+Base font is 21 chars on the 128 panel (`width=6`), key padded to 7, so the value column is **14**. Worst case `TIMEGPS 47.2s` is 13. The 176 panel gets 29, so it is only ever roomier. If a value ever does overflow, the row's existing horizontal scroller catches it rather than truncating.
+
+## Tests
+
+- **`test_gps_ubx_parser.py`** — an unregistered class/id yields `?XXYY`; a corrupted checksum yields `?CKSUM`. No existing test touches either branch (the one `"error"` assertion covers a short-payload SVINFO case), so nothing needs rewriting.
+- **`test_gps_ubx_dispatch.py`** — extend the existing `run_messages` helper to capture `("comms", …)` puts. Assert one publish per event; assert the rate cap suppresses a burst, driven by the `FakeClock` already wired into `process_messages`; assert markers publish without disturbing the `(seen, used)` counts.
+- **`test_status_scroll.py`** (or a sibling) — reuse the existing headless-display fixture for the formatter: `None` → `--`, `NAV-` stripping, age bucketing at each boundary, and **a width regression guard** asserting the rendered row fits `fonts.base.line_length` for every message class we can emit, on both panel resolutions.
+
+## Watch-outs
+
+- **The age stamp must be `time.monotonic()`, never wall clock.** GPS is what *sets* the system clock, so a wall-clock age jumps or inverts the moment a fix lands. `CLOCK_MONOTONIC` is system-wide on Linux and safe to compare across processes on one host. This is the single easiest thing to get wrong here and it fails in exactly the situation the feature exists to diagnose.
+- `?` is reserved for markers.
+- The gpsd path is limited to TPV/SKY by an existing filter.
+
+## Follow-ups (not in scope)
+
+- Surface `gps_comms` on the web status page / `/api/current-selection` — the web server already holds `shared_state`, so it is nearly free, and "read me your GPS MSG row" is a good support question.
+- User-guide line documenting how to read the row.
+- Resolve the `0031` ADR collision between the chart center-object and secure-WiFi branches.

--- a/gps-comms-row-plan.md
+++ b/gps-comms-row-plan.md
@@ -45,16 +45,22 @@ All four failure modes discriminated in one 21-character row. Today every one of
 
 Reserve the `?` prefix for markers. No real message class may start with it.
 
+### `PiFinder/gps_comms.py` — new
+
+`CommsPublisher(gps_queue, clock)`, shared by all three backends so the row means the same thing whichever is running. Holds the rate-cap state and does the `put`.
+
 ### `PiFinder/gps_ubx.py` — `process_messages`
 
 Publish one comms event at the top of the `async for` loop, before the dispatch chain, so *every* event counts including ones we parse but don't act on:
 
 ```python
-_publish_comms(gps_queue, msg_class, clock)
+now = clock()
+comms.publish(msg_class, now)
 ```
 
 - Send the **raw** class (`NAV-TIMEGPS`); presentation belongs to the UI.
-- Payload `("comms", (class_name, clock()))`.
+- Payload `("comms", class_name)` — the name only. See the stamping watch-out below.
+- One clock reading per event, shared with the NAV-SAT freshness window, so the two agree on when a message arrived.
 - **Rate-cap forwarding to ~20/s.** A resync storm can yield markers far faster than real messages arrive, and the `.ubx` replay path runs with `wait=0`. 20 Hz is well past perceptible against a 30 fps redraw, and it bounds worst-case queue traffic. This caps *reporting*, not parsing.
 
 Steady-state cost is a handful of pipe writes per second against backpressure thresholds of 10 and 50, on a queue the main loop drains to empty 30×/second. The throttles only bite when the main loop is already stalled, where slowing GPS is the intended behaviour.
@@ -73,11 +79,11 @@ The `.ubx` replay path reuses `process_messages` and gets this free. Add a publi
 
 ### `PiFinder/main.py`
 
-One branch in the existing `gps_queue` drain:
+One branch in the existing `gps_queue` drain, which is also where the event gets its stamp:
 
 ```python
 if gps_msg == "comms":
-    shared_state.set_gps_comms(gps_content)
+    shared_state.set_gps_comms((gps_content, time.monotonic()))
 ```
 
 ### `PiFinder/ui/status.py`
@@ -98,7 +104,9 @@ Base font is 21 chars on the 128 panel (`width=6`), key padded to 7, so the valu
 
 ## Watch-outs
 
-- **The age stamp must be `time.monotonic()`, never wall clock.** GPS is what *sets* the system clock, so a wall-clock age jumps or inverts the moment a fix lands. `CLOCK_MONOTONIC` is system-wide on Linux and safe to compare across processes on one host. This is the single easiest thing to get wrong here and it fails in exactly the situation the feature exists to diagnose.
+- **The age stamp must be `time.monotonic()`, never wall clock.** GPS is what *sets* the system clock, so a wall-clock age jumps or inverts the moment a fix lands. This is the single easiest thing to get wrong here and it fails in exactly the situation the feature exists to diagnose.
+- **...and both readings must come from the same process.** The first cut stamped in the GPS process and subtracted in main, on the theory that `CLOCK_MONOTONIC` is system-wide on Linux. It is — but `time.monotonic()`'s reference point is explicitly *undefined*, and on macOS it is process start, so the dev-machine row read a steady ~4s stale on a fake GPS publishing every 0.5s. Caught by running it, not by the tests. The stamp is now taken by main on receipt; only the name crosses the boundary.
+- **`gps_queue.qsize()` raises `NotImplementedError` on macOS**, so the `.ubx` replay backend cannot run there at all (pre-existing, in both `gps_fake.emit` and `process_messages`' backpressure check). Exercise the replay path by driving `process_messages` directly, or on a Pi.
 - `?` is reserved for markers.
 - The gpsd path is limited to TPV/SKY by an existing filter.
 

--- a/python/PiFinder/gps_comms.py
+++ b/python/PiFinder/gps_comms.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+# -*- coding:utf-8 -*-
+"""
+Publishing of GPS comms events - the liveness half of what the GPS process
+reports, as opposed to the fix and time it exists to produce.
+
+An *event* is anything the parser yields: a decoded message, or a marker
+standing in for a frame that arrived but could not be decoded. The STATUS
+screen's comms row shows the most recent event's name and how long ago it
+arrived, which is what separates "nothing is arriving" from "bytes are
+arriving that we cannot read". See docs/ax/gps/CONTEXT.md.
+
+The GPS process publishes names; the main process stamps them on arrival.
+
+All three GPS backends publish through this module so the row means the same
+thing whichever one is running.
+"""
+
+import time
+from typing import Optional
+
+# How often comms events are forwarded onto gps_queue, at most. A resync storm
+# can yield markers far faster than real messages arrive, and the .ubx replay
+# path runs with wait=0, so an uncapped publish would put the queue depth at
+# the mercy of how badly the link is behaving. 20 Hz is well past perceptible
+# against a 30 fps redraw. This caps *reporting*, not parsing.
+MAX_COMMS_RATE_HZ = 20
+
+
+class CommsPublisher:
+    """Forwards GPS event names onto gps_queue, rate-capped.
+
+    Only the name is published. The arrival time is stamped by the main
+    process when it drains the queue, with its own monotonic clock, because
+    that is the process the STATUS screen renders in - a stamp taken here
+    would have to survive a comparison against a *different* process's clock,
+    and ``time.monotonic()``'s reference point is explicitly undefined (on
+    macOS it is process start, so the age comes out inflated by however long
+    after main the GPS process happened to start).
+
+    The clock read here is only ever used for the rate cap, which measures an
+    interval between two readings in this one process - the use the standard
+    library does guarantee.
+    """
+
+    def __init__(self, gps_queue, clock=time.monotonic, max_rate_hz=MAX_COMMS_RATE_HZ):
+        self._gps_queue = gps_queue
+        self._clock = clock
+        self._min_interval = 1.0 / max_rate_hz
+        self._last_published = None
+
+    def publish(self, event_name: str, now: Optional[float] = None) -> bool:
+        """Publish `event_name` as having arrived at `now` (default: read the
+        clock). Returns False if the event was suppressed by the rate cap."""
+        if not event_name:
+            return False
+        if now is None:
+            now = self._clock()
+        if (
+            self._last_published is not None
+            and now - self._last_published < self._min_interval
+        ):
+            return False
+        self._last_published = now
+        self._gps_queue.put(("comms", event_name))
+        return True

--- a/python/PiFinder/gps_fake.py
+++ b/python/PiFinder/gps_fake.py
@@ -14,6 +14,7 @@ import logging
 from PiFinder import utils
 from PiFinder import timez
 from PiFinder.multiproclogging import MultiprocLogging
+from PiFinder.gps_comms import CommsPublisher
 from PiFinder.gps_ubx_parser import UBXParser
 from PiFinder.gps_ubx import process_messages
 
@@ -90,9 +91,13 @@ def gps_monitor(gps_queue, console_queue, log_queue, file_name="test.ubx"):
         lock = False
         lock_type = None
         i = -1
+        # Nothing is being received here, but the comms row should still be
+        # live under -fh so the feature is developable without hardware.
+        comms = CommsPublisher(gps_queue)
         while True:
             i += 1
             time.sleep(0.5)
+            comms.publish("FAKE")
             fix = (
                 "fix",
                 {

--- a/python/PiFinder/gps_gpsd.py
+++ b/python/PiFinder/gps_gpsd.py
@@ -5,6 +5,7 @@ This module is for GPS related functions
 """
 
 from PiFinder.multiproclogging import MultiprocLogging
+from PiFinder.gps_comms import CommsPublisher
 from gpsdclient import GPSDClient
 import logging
 
@@ -47,6 +48,7 @@ def gps_main(gps_queue, console_queue, log_queue):
     MultiprocLogging.configurer(log_queue)
     logger.info("Using GPSD GPS code")
     gps_locked = False
+    comms = CommsPublisher(gps_queue)
 
     while True:
         try:
@@ -54,6 +56,11 @@ def gps_main(gps_queue, console_queue, log_queue):
                 for result in client.dict_stream(
                     convert_datetime=True, filter=["TPV", "SKY"]
                 ):
+                    # gpsd hands us decoded dicts, so there are no frames here
+                    # and never any markers; the filter above also means the
+                    # comms row can only ever name TPV or SKY on this backend.
+                    comms.publish(result.get("class", ""))
+
                     if result["class"] == "TPV" and is_tpv_accurate(result):
                         logger.debug("last reading is %s", result)
                         if (

--- a/python/PiFinder/gps_ubx.py
+++ b/python/PiFinder/gps_ubx.py
@@ -7,6 +7,7 @@ This module is for GPS related functions
 import asyncio
 import time
 from PiFinder.multiproclogging import MultiprocLogging
+from PiFinder.gps_comms import CommsPublisher
 from PiFinder.gps_ubx_parser import UBXParser
 import logging
 
@@ -51,10 +52,19 @@ async def process_messages(
 ):
     gps_locked = False
     last_nav_sat = None  # monotonic stamp of the most recent NAV-SAT message
+    comms = CommsPublisher(gps_queue, clock=clock)
 
     async for msg in parser_iterator():
         msg_class = msg.get("class", "")
         logger.debug("GPS: %s: %s", msg_class, msg)
+
+        # One reading per event, shared by everything below, so the comms
+        # stamp and the NAV-SAT freshness window agree on when this arrived.
+        now = clock()
+
+        # Every event counts towards liveness, including markers and messages
+        # the dispatch chain below has no branch for.
+        comms.publish(msg_class, now)
 
         if msg_class == "NAV-DOP":
             error_info["error_2d"] = msg["hdop"]
@@ -64,7 +74,7 @@ async def process_messages(
             # Fallback satellite info, used while NAV-SAT is absent or stale
             nav_sat_fresh = (
                 last_nav_sat is not None
-                and clock() - last_nav_sat < NAV_SAT_PREFERENCE_TIMEOUT
+                and now - last_nav_sat < NAV_SAT_PREFERENCE_TIMEOUT
             )
             if not nav_sat_fresh and "nSat" in msg:
                 sats_seen = msg["nSat"]
@@ -76,7 +86,7 @@ async def process_messages(
 
         elif msg_class == "NAV-SAT":
             # Preferred satellite info source - not seen in the current pifinder gps versions
-            last_nav_sat = clock()
+            last_nav_sat = now
             sats_seen = msg["nSat"]
             sats_used = sum(
                 1 for sat in msg.get("satellites", []) if sat.get("used", False)

--- a/python/PiFinder/gps_ubx_parser.py
+++ b/python/PiFinder/gps_ubx_parser.py
@@ -19,6 +19,12 @@ logger = logging.getLogger("GPS.parser")
 # reported C/N0 is an unconfirmed acquisition candidate.
 QUALITY_CODE_LOCKED = 4
 
+# Prefix reserved for markers: synthesised events standing in for a frame that
+# arrived but could not become a message. No real message class may start with
+# it. See docs/adr/0032-ubx-parser-yields-undecodable-frames.md.
+MARKER_PREFIX = "?"
+CHECKSUM_MARKER = f"{MARKER_PREFIX}CKSUM"
+
 
 class UBXClass(IntEnum):
     NAV = 0x01
@@ -227,6 +233,10 @@ class UBXParser:
                         logger.warning(
                             f"Checksum mismatch: expected {ck_a:02x}{ck_b:02x}, got {msg_data[-2]:02x}{msg_data[-1]:02x}"
                         )
+                        # Bytes arrived but could not be decoded - yield a
+                        # marker so this stays distinguishable from silence.
+                        # See docs/adr/0032.
+                        yield {"class": CHECKSUM_MARKER}
                     self.buffer = self.buffer[total_length:]
             except (ConnectionResetError, BrokenPipeError):
                 logger.exception("Connection error")
@@ -254,7 +264,9 @@ class UBXParser:
         logger.debug(
             f"No parser found for message class=0x{msg_class:02x}, id=0x{msg_id:02x}"
         )
-        return {"error": "Unknown message type"}
+        # A frame we cannot decode is still evidence the receiver is talking,
+        # so name it rather than dropping it. See docs/adr/0032.
+        return {"class": f"{MARKER_PREFIX}{msg_class:02X}{msg_id:02X}"}
 
     def _ecef_to_lla(self, x: float, y: float, z: float):
         try:

--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -784,6 +784,13 @@ def main(
                         if gps_msg == "satellites":
                             # logger.debug("Main: GPS nr sats seen: %s", gps_content)
                             shared_state.set_sats(gps_content)
+                        if gps_msg == "comms":
+                            # The GPS process has no shared_state, so liveness
+                            # reaches the STATUS screen only by way of this
+                            # queue. Stamp arrival here rather than at the
+                            # sending end: the row renders in this process, so
+                            # this is the only clock it can safely subtract.
+                            shared_state.set_gps_comms((gps_content, time.monotonic()))
                 except queue.Empty:
                     pass
 

--- a/python/PiFinder/state.py
+++ b/python/PiFinder/state.py
@@ -288,6 +288,7 @@ class SharedStateObj:
         }
         self.__solution: PointingEstimate = PointingEstimate()
         self.__sats = None
+        self.__gps_comms = None
         self.__imu = None
         self.__battery = None
         self.__hardware = None
@@ -418,6 +419,18 @@ class SharedStateObj:
 
     def set_sats(self, v):
         self.__sats = v
+
+    def gps_comms(self):
+        """The most recent GPS event as ``(name, monotonic_stamp)``, or None
+        when nothing has been received this session. The name is a message
+        class (``NAV-SOL``) or a marker (``?CKSUM``). The stamp is the main
+        process's ``time.monotonic()`` reading when the event was drained off
+        ``gps_queue``, so only that process can meaningfully subtract it --
+        see docs/ax/gps/CONTEXT.md."""
+        return self.__gps_comms
+
+    def set_gps_comms(self, v):
+        self.__gps_comms = v
 
     def imu(self):
         return self.__imu

--- a/python/PiFinder/ui/status.py
+++ b/python/PiFinder/ui/status.py
@@ -16,6 +16,41 @@ from PiFinder.ui.layout import rows_below_titlebar
 sys_utils = utils.get_sys_utils()
 
 
+def _format_comms_age(seconds: float) -> str:
+    """Age of the last GPS event, bucketed to stay within 5 characters.
+
+    Seconds carry a decimal because that is the range where the number is
+    doing the work (is it live, or a second stale?); past that only the order
+    of magnitude matters.
+    """
+    seconds = max(0.0, seconds)
+    if seconds < 99.95:
+        return f"{seconds:.1f}s"
+    if seconds < 6000:
+        return f"{seconds / 60:.0f}m"
+    return f"{seconds / 3600:.0f}h"
+
+
+def _format_gps_comms(comms) -> str:
+    """Render the comms row value from shared_state.gps_comms().
+
+    A churning name with a near-zero age means events are flowing; a frozen
+    name with a climbing age means the link died doing that; a ``?`` name
+    means bytes arrived that we could not decode. See docs/ax/gps/CONTEXT.md.
+    """
+    if not comms:
+        return "--"
+    name, stamp = comms
+    # Monotonic, because the GPS is what sets the wall clock and a wall-clock
+    # age inverts the instant a fix lands. main.py takes the stamp with this
+    # same process's clock, which is the only way the subtraction is valid.
+    age = _format_comms_age(time.monotonic() - stamp)
+    # NAV-TIMEGPS would not fit the 14-character value column; TIMEGPS does.
+    if name.startswith("NAV-"):
+        name = name[4:]
+    return f"{name} {age}"
+
+
 class UIStatus(UIModule):
     """
     Displays various status information
@@ -44,6 +79,7 @@ class UIStatus(UIModule):
             "GPS": "--",
             "GPS ALT": "--",
             "GPS LCK": "--",
+            "GPS MSG": "--",
             "LCL TM": "--",
             "UTC TM": "--",
             "CPU TMP": "--",
@@ -144,6 +180,7 @@ class UIStatus(UIModule):
         self.status_dict["GPS ALT"] = f"{location.altitude:.1f}m"
         last_lock = location.last_gps_lock
         self.status_dict["GPS LCK"] = last_lock if last_lock else "--"
+        self.status_dict["GPS MSG"] = _format_gps_comms(self.shared_state.gps_comms())
 
         # use datetimes explictly converted to the timezone we want to print
         # datetime() can be in any timezone and time() will just ignore TZ

--- a/python/tests/test_gps_ubx_dispatch.py
+++ b/python/tests/test_gps_ubx_dispatch.py
@@ -9,7 +9,7 @@ import asyncio
 
 import pytest
 
-from PiFinder import gps_ubx
+from PiFinder import gps_comms, gps_ubx
 
 
 class FakeQueue:
@@ -36,8 +36,27 @@ class FakeClock:
         self.now += seconds
 
 
-def run_messages(messages, clock=None):
-    """Feed `messages` through process_messages, return published sat tuples."""
+class TickingClock:
+    """Monotonic stand-in that advances on every read.
+
+    The comms publisher is rate-capped, so a frozen clock suppresses every
+    event after the first; use this where the test is about what gets
+    published rather than about the cap itself.
+    """
+
+    def __init__(self, step=1.0):
+        self.now = 1000.0
+        self.step = step
+
+    def __call__(self):
+        value = self.now
+        self.now += self.step
+        return value
+
+
+def run_messages(messages, clock=None, tag="satellites"):
+    """Feed `messages` through process_messages, return the payloads it
+    published under `tag` ("satellites" counts, or "comms" events)."""
     gps_ubx.sats[0] = 0
     gps_ubx.sats[1] = 0
     gps_queue = FakeQueue()
@@ -56,7 +75,7 @@ def run_messages(messages, clock=None):
             clock=clock or FakeClock(),
         )
     )
-    return [content for name, content in gps_queue.items if name == "satellites"]
+    return [content for name, content in gps_queue.items if name == tag]
 
 
 def nav_sat(seen, used):
@@ -128,3 +147,76 @@ def test_nav_sol_used_count_raises_the_seen_floor():
     published = run_messages([{"class": "NAV-SOL", "satellites": 6}])
 
     assert published == [(6, 6)]
+
+
+# --- Comms events ------------------------------------------------------------
+# Liveness reporting: every event the parser yields is named on gps_queue, which
+# is what lets the STATUS comms row tell a dead link from an undecodable one.
+# Only the name travels - the main process stamps arrival with its own clock.
+
+
+@pytest.mark.unit
+def test_every_event_is_published_by_name():
+    published = run_messages(
+        [{"class": "NAV-DOP", "hdop": 1.0, "pdop": 2.0}, {"class": "NAV-EOE"}],
+        clock=TickingClock(),
+        tag="comms",
+    )
+
+    assert published == ["NAV-DOP", "NAV-EOE"]
+
+
+@pytest.mark.unit
+def test_events_the_dispatcher_ignores_still_count_as_liveness():
+    """NAV-POSECEF has no branch in the dispatch chain, but the link is
+    demonstrably alive when one arrives."""
+    published = run_messages(
+        [{"class": "NAV-POSECEF"}], clock=TickingClock(), tag="comms"
+    )
+
+    assert published == ["NAV-POSECEF"]
+
+
+@pytest.mark.unit
+def test_markers_are_published_like_any_other_event():
+    """A frame we cannot decode is exactly the case the row exists for, so it
+    must reach the queue even though the dispatch chain ignores it."""
+    published = run_messages(
+        [{"class": "?CKSUM"}, {"class": "?0122"}],
+        clock=TickingClock(),
+        tag="comms",
+    )
+
+    assert published == ["?CKSUM", "?0122"]
+
+
+@pytest.mark.unit
+def test_markers_do_not_disturb_the_satellite_counts():
+    published = run_messages(
+        [svinfo(11, 8), {"class": "?CKSUM"}, {"class": "?0122"}],
+        clock=TickingClock(),
+    )
+
+    assert published == [(11, 8)]
+
+
+@pytest.mark.unit
+def test_rate_cap_suppresses_a_burst():
+    """A resync storm yields markers far faster than real messages arrive; the
+    cap bounds queue traffic without slowing parsing."""
+    burst = [{"class": "?CKSUM"} for _ in range(50)]
+    published = run_messages(burst, clock=FakeClock(), tag="comms")
+
+    # FakeClock never advances, so everything after the first is inside the
+    # minimum interval.
+    assert published == ["?CKSUM"]
+
+
+@pytest.mark.unit
+def test_rate_cap_releases_once_the_interval_passes():
+    clock = TickingClock(step=2.0 / gps_comms.MAX_COMMS_RATE_HZ)
+    published = run_messages(
+        [{"class": "?CKSUM"} for _ in range(4)], clock=clock, tag="comms"
+    )
+
+    assert len(published) == 4

--- a/python/tests/test_gps_ubx_parser.py
+++ b/python/tests/test_gps_ubx_parser.py
@@ -1,3 +1,4 @@
+import asyncio
 import struct
 
 import pytest
@@ -114,3 +115,78 @@ def test_nav_sat_used_from_svused_bit(parser):
     sat17, sat13 = result["satellites"]
     assert (sat17["id"], sat17["used"], sat17["quality"]) == (17, True, 4)
     assert (sat13["id"], sat13["used"], sat13["elevation"]) == (13, False, -5)
+
+
+# --- Markers -----------------------------------------------------------------
+# A frame that arrives but cannot be decoded yields a marker rather than being
+# dropped, so "we can't read this" stays distinguishable from "nothing is
+# arriving". See docs/adr/0032-ubx-parser-yields-undecodable-frames.md.
+
+
+@pytest.fixture
+def registered_parser():
+    """A parser with its message_parsers table populated, unlike the bare
+    __new__ fixture above -- _parse_ubx dispatches through that table."""
+    return UBXParser(log_queue=None)
+
+
+class FakeReader:
+    """Hands out canned chunks, then EOF to end parse_messages' read loop."""
+
+    def __init__(self, *chunks):
+        self.chunks = list(chunks)
+
+    async def read(self, _n):
+        return self.chunks.pop(0) if self.chunks else b""
+
+
+def make_frame(msg_class, msg_id, payload=b"", corrupt=False):
+    body = bytes([msg_class, msg_id]) + len(payload).to_bytes(2, "little") + payload
+    ck_a = ck_b = 0
+    for b in body:
+        ck_a = (ck_a + b) & 0xFF
+        ck_b = (ck_b + ck_a) & 0xFF
+    if corrupt:
+        ck_b ^= 0xFF
+    return b"\xb5\x62" + body + bytes([ck_a, ck_b])
+
+
+def drain(parser):
+    async def collect():
+        return [msg async for msg in parser.parse_messages()]
+
+    return asyncio.run(collect())
+
+
+@pytest.mark.unit
+def test_unregistered_class_id_yields_a_named_marker(registered_parser):
+    # 0x01/0x35 is NAV-SAT, which is registered; 0x01/0x22 is not.
+    result = registered_parser._parse_ubx(make_frame(0x01, 0x22, b"\x00" * 8))
+
+    assert result == {"class": "?0122"}
+
+
+@pytest.mark.unit
+def test_marker_passes_the_class_guard(registered_parser):
+    """The marker must survive parse_messages' `if "class" in parsed` guard --
+    that guard is what used to drop undecodable frames."""
+    registered_parser.reader = FakeReader(make_frame(0x0A, 0x04, b"\x00" * 4))
+
+    assert [msg["class"] for msg in drain(registered_parser)] == ["?0A04"]
+
+
+@pytest.mark.unit
+def test_checksum_mismatch_yields_a_marker(registered_parser):
+    registered_parser.reader = FakeReader(
+        make_frame(0x01, 0x04, b"\x00" * 18, corrupt=True)
+    )
+
+    assert [msg["class"] for msg in drain(registered_parser)] == ["?CKSUM"]
+
+
+@pytest.mark.unit
+def test_decodable_frame_still_yields_its_message(registered_parser):
+    """Guard against the markers swallowing the normal path."""
+    registered_parser.reader = FakeReader(make_frame(0x01, 0x61, b"\x00" * 4))
+
+    assert [msg["class"] for msg in drain(registered_parser)] == ["NAV-EOE"]

--- a/python/tests/test_status_gps_comms.py
+++ b/python/tests/test_status_gps_comms.py
@@ -1,0 +1,138 @@
+"""
+Unit tests for the STATUS screen's GPS comms row: how a published GPS event
+becomes the row's value, and a width guard proving every event name we can
+emit still fits its column on every panel.
+
+The row is the whole user-facing point of the comms plumbing -- see
+docs/ax/gps/CONTEXT.md and docs/adr/0032.
+"""
+
+import time
+
+import pytest
+from PIL import Image, ImageDraw
+
+# Installs the _() gettext builtin the UI modules rely on; must precede ui imports.
+import PiFinder.i18n  # noqa: F401
+
+from PiFinder.displays import get_display
+from PiFinder.gps_ubx_parser import CHECKSUM_MARKER, MARKER_PREFIX, NAVMessageId
+from PiFinder.ui.status import UIStatus, _format_comms_age, _format_gps_comms
+from PiFinder.ui.ui_utils import SpaceCalculatorFixed
+
+pytestmark = pytest.mark.unit
+
+
+# Every event name that can reach the row. The NAV names are derived from the
+# parser's own table so a newly registered message class is width-checked
+# automatically rather than quietly overflowing.
+UBX_MESSAGE_NAMES = [f"NAV-{msg.name}" for msg in NAVMessageId]
+GPSD_MESSAGE_NAMES = ["TPV", "SKY"]
+MARKER_NAMES = [CHECKSUM_MARKER, f"{MARKER_PREFIX}FFFF"]
+FAKE_MESSAGE_NAMES = ["FAKE"]
+ALL_EVENT_NAMES = (
+    UBX_MESSAGE_NAMES + GPSD_MESSAGE_NAMES + MARKER_NAMES + FAKE_MESSAGE_NAMES
+)
+
+
+def make_status(display_hardware):
+    """A minimal UIStatus carrying only what _render_row touches, backed by a
+    real headless display so the fonts and column width are the real ones."""
+    display = get_display(display_hardware)
+    s = UIStatus.__new__(UIStatus)
+    s.display_class = display
+    s.colors = display.colors
+    s.fonts = display.fonts
+    s.draw = ImageDraw.Draw(Image.new("RGBA", display.resolution), mode="RGBA")
+    s.spacecalc = SpaceCalculatorFixed(display.fonts.base.line_length)
+    s.value_scrollers = {}
+    return s
+
+
+# --- The value ---------------------------------------------------------------
+
+
+def test_nothing_ever_received_reads_as_empty():
+    # Distinct from a frozen name with a climbing age, which means the link
+    # died rather than never having spoken.
+    assert _format_gps_comms(None) == "--"
+
+
+def test_nav_prefix_is_stripped():
+    # NAV-TIMEGPS (11) would not fit the value column; TIMEGPS (7) does.
+    assert _format_gps_comms(("NAV-TIMEGPS", time.monotonic())).startswith("TIMEGPS ")
+
+
+def test_marker_name_is_shown_verbatim():
+    assert _format_gps_comms((CHECKSUM_MARKER, time.monotonic())).startswith("?CKSUM ")
+
+
+def test_gpsd_class_is_shown_verbatim():
+    assert _format_gps_comms(("SKY", time.monotonic())).startswith("SKY ")
+
+
+def test_age_is_measured_against_the_monotonic_clock():
+    """The stamp is monotonic, so the age must be too -- the GPS is what sets
+    the wall clock, and a wall-clock age inverts the instant a fix lands."""
+    value = _format_gps_comms(("NAV-SOL", time.monotonic() - 12.0))
+
+    assert value.startswith("SOL 12.")
+
+
+# --- Age bucketing -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "age, expected",
+    [
+        (0.0, "0.0s"),
+        (0.44, "0.4s"),
+        (47.23, "47.2s"),
+        (99.9, "99.9s"),
+        (99.99, "2m"),  # rounds out of the seconds bucket rather than to 100.0s
+        (120.0, "2m"),
+        (5999.0, "100m"),
+        (6000.0, "2h"),
+        (99999.0, "28h"),
+    ],
+)
+def test_age_buckets(age, expected):
+    assert _format_comms_age(age) == expected
+
+
+def test_age_never_goes_negative():
+    # Monotonic clocks are per-host, so a stamp fractionally ahead of ours is
+    # not worth rendering as "-0.0s".
+    assert _format_comms_age(-0.3) == "0.0s"
+
+
+@pytest.mark.parametrize("age", [0.0, 47.2, 99.9, 5999.0, 999999.0])
+def test_age_stays_within_five_characters(age):
+    assert len(_format_comms_age(age)) <= 5
+
+
+# --- Width -------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("display_hardware", ["headless", "headless_176"])
+@pytest.mark.parametrize("name", ALL_EVENT_NAMES)
+def test_every_event_name_fits_its_column(display_hardware, name):
+    """Width regression guard: the row must render statically, never falling
+    back to the horizontal scroller, for any event we can publish."""
+    status = make_status(display_hardware)
+    # 999999s is the widest age bucket; pair it with the widest names.
+    value = _format_gps_comms((name, time.monotonic() - 999999.0))
+
+    line = status._render_row("GPS MSG", value)
+
+    assert len(line) <= status.spacecalc.width
+    assert "GPS MSG" not in status.value_scrollers  # fits without scrolling
+
+
+@pytest.mark.parametrize("display_hardware", ["headless", "headless_176"])
+def test_row_key_is_exactly_the_padded_key_width(display_hardware):
+    # _render_row pads keys to 7; a longer key would eat into the value column
+    # and silently push the widest names into the scroller.
+    assert len("GPS MSG") == 7
+    status = make_status(display_hardware)
+    assert status._render_row("GPS MSG", "SOL 0.4s").startswith("GPS MSG")


### PR DESCRIPTION
One row on the STATUS screen naming the most recent GPS **event** and how long ago it arrived:

```
GPS MSG TIMEGPS  0.4s
```

| On screen | Meaning |
|---|---|
| `SOL` / `DOP` / `TIMEGPS` churning, age near 0 | Healthy — the name changing is itself the liveness signal |
| `?0135` churning | Receiver transmitting a dialect we have no parser for |
| `?CKSUM` churning | Bytes arriving corrupted — baud mismatch or wiring |
| name frozen, age climbing | Link died, and the name says what it was doing when it stopped |
| `--` | Nothing ever received this session |

Four failure modes discriminated in 21 characters. Today all four look identical from anywhere above the parser.

Started as a `/grill-with-docs` session; the docs and plan landed first and the code is now on top of them.

## What the grilling changed

The ask started as "SQUARE on the status screen opens a readout of received GPS messages, and the messages don't leave the GPS thread." Three things didn't survive:

- It's a **process**, not a thread — and the only subsystem process that doesn't receive `shared_state` (verified against all nine others). That rules out the ring-buffer-in-shared-state design.
- Messages **already leave**, three ways: `gps_queue`, `console_queue`, and a DEBUG log line per parsed message with a ready-made `logconf_gps.json`. The gap is *live, on-device, no-restart*, not egress.
- There is **no main → GPS channel**. `gps_queue` lives in `command_queues["gps"]` but flows only *into* main, so on-demand capture was off the table and always-on won on merit anyway.

A full debug screen was designed and then dropped once it became clear a single row answers the actual question.

## The code

- **`gps_ubx_parser.py`** — an unregistered class/id yields `{"class": "?XXYY"}` and a checksum failure yields `{"class": "?CKSUM"}`, instead of both being dropped. `?` is reserved for markers.
- **`gps_comms.py`** (new) — `CommsPublisher`, shared by all three backends, rate-capped to 20 Hz. A resync storm can yield markers far faster than real messages arrive; the cap bounds queue traffic without slowing parsing.
- **`gps_ubx.py`** — publishes at the top of the dispatch loop, so every event counts including ones we parse but don't act on. Now reads the clock once per event, shared with the NAV-SAT freshness window.
- **`gps_gpsd.py`** / **`gps_fake.py`** — same publish. gpsd's existing `filter=["TPV", "SKY"]` means the row is a weaker instrument there, deliberately rather than by widening the filter as a side effect. The synthetic fake publishes `FAKE` so the row is live under `-fh`.
- **`state.py`** / **`main.py`** / **`ui/status.py`** — `gps_comms()` accessor, one branch in the queue drain, and the row.

## The trap, and how it moved

The age must be monotonic, never wall clock: GPS is what *sets* the system clock, so a wall-clock age jumps or inverts the instant a fix lands — failing in exactly the situation the feature exists to diagnose.

The first cut stamped in the GPS process and subtracted in main, on the theory that `CLOCK_MONOTONIC` is system-wide on Linux. It is — but `time.monotonic()`'s reference point is explicitly *undefined*, and **on macOS it is process start**. Running it caught what the tests didn't: the row read a steady ~4s stale against a fake GPS publishing every 0.5s, that being how long after main the GPS process happened to start. The stamp is now taken by main when it drains the queue; only the event name crosses the boundary. ADR 0032 and the GPS `CONTEXT.md` record this.

## Verification

- `nox -s lint / format / type_hints` clean; 1371 unit + smoke tests pass.
- New tests: marker yielding at both parser branches, publish-per-event, the rate cap engaging and releasing, markers not disturbing the `(seen, used)` counts, age bucketing at each boundary, and a width regression guard over every event name we can emit — NAV names derived from the parser's own table — on both panel resolutions.
- Ran headless and read the row off the screen: `GPS MSG   FAKE 0.3s`, churning against a 0.5s publish.
- Replayed a synthetic `.ubx` mixing decodable frames, an unregistered class/id and a corrupted frame through the real parser and publisher: 400 each of `NAV-TIMEGPS`, `NAV-DOP`, `NAV-EOE`, `?0122`, `?CKSUM`, in order.

Note for anyone testing on a Mac: the `.ubx` replay backend cannot run there at all — `gps_queue.qsize()` raises `NotImplementedError` on macOS, in both `gps_fake.emit` and `process_messages`' backpressure check. Pre-existing, untouched here.

## Follow-ups (not in scope)

- Surface `gps_comms` on the web status page / `/api/current-selection`. The web server holds `shared_state`, so it is nearly free — but it is a *different process*, so it needs its own arrival stamp rather than reusing main's.
- User-guide line documenting how to read the row.
- Resolve the `0031` ADR collision between the chart center-object and secure-WiFi branches. This ADR took `0032` to avoid becoming a third.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXthLa4U42Ai77iyntX1Ch
