### PR TITLE
fix(ui): align Update Now/Cancel with the selection caret on 176px displays

### DIFF
--- a/python/PiFinder/ui/software.py
+++ b/python/PiFinder/ui/software.py
@@ -370,13 +370,13 @@ class UISoftware(UIModule):
         # If we are here, go for update!
         self._go_for_update = True
         self.draw.text(
-            (10, 90),
+            (10, msg_top),
             _("Update Now"),
             font=self.fonts.large.font,
             fill=self.colors.get(255),
         )
         self.draw.text(
-            (10, 105),
+            (10, msg_bottom),
             _("Cancel"),
             font=self.fonts.large.font,
             fill=self.colors.get(255),


### PR DESCRIPTION
## Problem

On the 176×176 display, when the Software Upd screen offers an update, the "Update Now" / "Cancel" options render well above the selection caret. The labels also collide with the "Release Version" info block, while the caret (▶) sits alone near the bottom of the screen pointing at nothing.

## Cause

`UISoftware.update()` anchors its two-line status messages — and the selection caret — at `msg_top`/`msg_bottom`, computed up from the bottom of the screen (`resY - 2*pitch - 6`). Every message branch ("WiFi must be…", "Checking for…", "No Update needed") was converted to those anchors, but the update-offer branch still drew its labels at hardcoded `y=90`/`y=105` from the 128px layout. On 128px those coincide almost exactly with the anchors (92/107), which is why the bug only shows on 176.

## Fix

Draw "Update Now" and "Cancel" at `msg_top`/`msg_bottom`, same as the caret and every other branch. Two-line change.

## Verification

Reproduced and verified headlessly (`--display headless_176`, local `version.txt` temporarily lowered to 2.6.2 so the update offer renders):

- **Before (176):** labels at y=90/105 overlapping "Release Version 2.6.3"; caret alone at the bottom.
- **After (176):** labels bottom-anchored, caret points at "Update Now"; toggling with DOWN moves it to "Cancel" correctly.
- **After (128):** labels shift 2px down to meet the caret exactly — no visible regression.

`ruff check`/`format` clean; smoke and unit suites pass (1517 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWDMMi9s5gt39Ta5C9jRgD