### PR TITLE
docs(bom): warn against the similar but incompatible Adafruit 2472 BNO055 board

### DIFF
--- a/docs/source/BOM.rst
+++ b/docs/source/BOM.rst
@@ -47,7 +47,7 @@ These are the electronic bits needed to build the Display/Keypad unit that fits 
      - `https://www.waveshare.com/wiki/1.5inch_RGB_OLED_Module <https://www.waveshare.com/wiki/1.5inch_RGB_OLED_Module>`_
      - 
    * - 1
-     - Adafruit IMU Fusion Breakout - BNO055
+     - Adafruit IMU Fusion Breakout - BNO055 - **See Note**
      - https://www.adafruit.com/product/4646
      - Order product 4646 exactly. Adafruit sells another BNO055 board (product
        2472) that looks very similar, but its data pins are in a different

--- a/docs/source/BOM.rst
+++ b/docs/source/BOM.rst
@@ -49,7 +49,9 @@ These are the electronic bits needed to build the Display/Keypad unit that fits 
    * - 1
      - Adafruit IMU Fusion Breakout - BNO055
      - https://www.adafruit.com/product/4646
-     - 
+     - Order product 4646 exactly. Adafruit sells another BNO055 board (product
+       2472) that looks very similar, but its data pins are in a different
+       order and it does not work in the PiFinder
    * - 1
      - 2x20 40 Pin Stacking Female Header
      - https://www.amazon.com/dp/B0827THC7R


### PR DESCRIPTION
## Summary

The DIY BOM's IMU line links to the correct part, the Adafruit BNO055 STEMMA QT breakout ([product 4646](https://www.adafruit.com/product/4646)). Adafruit also sells the older BNO055 breakout ([product 2472](https://www.adafruit.com/product/2472)), which looks nearly identical but has its data pins in a different order, so it does not work on the PiFinder hat. This has caught a couple of builders out (see the wrong-IMU item under "Test the IMU" in the dev guide).

This adds a note to the IMU line item in `BOM.rst` telling builders to order the 4646 exactly and why the 2472 does not work.

## Verification

- `sphinx -b html -n -q` builds clean (zero warnings) with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LjVuC4YMM5FGMRaeLh8q1